### PR TITLE
Optimize CnaEvent lookup and storage in CnaUtil

### DIFF
--- a/src/main/java/org/mskcc/cbio/portal/util/CnaUtil.java
+++ b/src/main/java/org/mskcc/cbio/portal/util/CnaUtil.java
@@ -53,16 +53,14 @@ public class CnaUtil {
             if (!CNA.AMP.equals(cnaEvent.getAlteration()) && !CNA.HOMDEL.equals(cnaEvent.getAlteration())) {
                 continue;
             }
-            Optional<CnaEvent.Event> existingCnaEvent = existingCnaEvents
-                .stream()
-                .filter(e -> e.equals(cnaEvent.getEvent()))
-                .findFirst();
-            if (existingCnaEvent.isPresent()) {
-                cnaEvent.setEventId(existingCnaEvent.get().getEventId());
+            
+            CnaEvent.Event event = cnaEvent.getEvent()
+            if (existingCnaEvents.contains(event)) {
+                cnaEvent.setEventId(event.getEventId());
                 DaoCnaEvent.addCaseCnaEvent(cnaEvent, false);
             } else {
                 DaoCnaEvent.addCaseCnaEvent(cnaEvent, true);
-                existingCnaEvents.add(cnaEvent.getEvent());
+                existingCnaEvents.add(event);
             }
         }
     }


### PR DESCRIPTION
This commit improves the performance of the storeCnaEvents method by replacing the stream-based lookup with a HashSet contains check. This change reduces the computational complexity from O(n) to O(1) for the lookup operation, resulting in a significant performance gain when processing large collections of CnaEvent objects.


Note: This PR is carried over from https://github.com/cBioPortal/cbioportal/pull/10478 

Requesting review and merge from @JREastonMarks . Thank you!