### PR TITLE
remove ssl_mode parameter if not enabled

### DIFF
--- a/src/main/resources/scripts/importer/cbioportal_common.py
+++ b/src/main/resources/scripts/importer/cbioportal_common.py
@@ -1096,7 +1096,6 @@ def get_db_cursor(portal_properties: PortalProperties):
             connection_kwargs['ssl_mode'] = 'REQUIRED'
             connection_kwargs['ssl'] = {"ssl_mode": True}
         else:
-            connection_kwargs['ssl_mode'] = 'DISABLED'  
             if url_elements.query.get("get-server-public-key") == "true":
                 connection_kwargs['ssl'] = {
                     'MYSQL_OPT_GET_SERVER_PUBLIC_KEY': True


### PR DESCRIPTION
Currently the pararmeter `connection_kwargs['ssl_mode'] = 'DISABLED'` is set, even if ssl_mode is completely off. This is on one side not necessary and on the other side do many distributions nowadays ship with mariadb instead of mysql (and use mysql just as alias for mariadb). The latter one does not support the `ssl_mode`.

Therefore I propose to remove that parameter if it is disabled.