### PR TITLE
migrate to spring db naming scheme

### DIFF
--- a/src/main/java/org/mskcc/cbio/portal/dao/JdbcDataSource.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/JdbcDataSource.java
@@ -13,16 +13,14 @@ public class JdbcDataSource extends BasicDataSource {
     public JdbcDataSource () {
         DatabaseProperties dbProperties = DatabaseProperties.getInstance();
 
-        String host = dbProperties.getDbHost();
-        String userName = dbProperties.getDbUser();
-        String password = dbProperties.getDbPassword();
-        String mysqlDriverClassName = dbProperties.getDbDriverClassName();
-        String database = dbProperties.getDbName();
+        String userName = dbProperties.getSpringDbUser();
+        String password = dbProperties.getSpringDbPassword();
+        String mysqlDriverClassName = dbProperties.getSpringDbDriverClassName();
         String enablePooling = (!StringUtils.isBlank(dbProperties.getDbEnablePooling())) ? dbProperties.getDbEnablePooling(): "false";
-        String connectionURL = dbProperties.getConnectionURL();
+        String connectionURL = dbProperties.getSpringConnectionURL();
         
         Assert.isTrue(
-            !defined(host) && !defined(database) && !defined(dbProperties.getConnectionURL()) &&!defined(dbProperties.getDbDriverClassName()) && !defined(dbProperties.getDbUseSSL()),
+            !defined(dbProperties.getDbHost()) && !defined(dbProperties.getDbUser()) && !defined(dbProperties.getDbPassword()) && !defined(dbProperties.getDbName()) && !defined(dbProperties.getConnectionURL()) && !defined(dbProperties.getDbDriverClassName()) && !defined(dbProperties.getDbUseSSL()),
             "\n----------------------------------------------------------------------------------------------------------------" +
                 "-- Connection error:\n" +
                 "-- You try to connect to the database using the deprecated 'db.host', 'db.portal_db_name' and 'db.use_ssl' or 'db.connection_string' and. 'db.driver' properties.\n" +
@@ -51,7 +49,6 @@ public class JdbcDataSource extends BasicDataSource {
         this.setMinEvictableIdleTimeMillis(30000);
         this.setTestOnBorrow(true);
         this.setValidationQuery("SELECT 1");
-        this.setJmxName("org.cbioportal:DataSource=" + database);
     }
     
     private String errorMessage(String displayName, String propertyName) {

--- a/src/main/java/org/mskcc/cbio/portal/dao/JdbcDataSource.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/JdbcDataSource.java
@@ -31,8 +31,8 @@ public class JdbcDataSource extends BasicDataSource {
                 "----------------------------------------------------------------------------------------------------------------\n"
         );
         
-        Assert.hasText(userName, errorMessage("username", "db.user"));
-        Assert.hasText(password, errorMessage("password", "db.password"));
+        Assert.hasText(userName, errorMessage("username", "spring.datasource.username"));
+        Assert.hasText(password, errorMessage("password", "spring.datasource.password"));
         Assert.hasText(mysqlDriverClassName, errorMessage("driver class name", "spring.datasource.driver-class-name"));
 
         this.setUrl(connectionURL);

--- a/src/main/java/org/mskcc/cbio/portal/dao/JdbcDataSource.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/JdbcDataSource.java
@@ -22,18 +22,18 @@ public class JdbcDataSource extends BasicDataSource {
         String connectionURL = dbProperties.getConnectionURL();
         
         Assert.isTrue(
-            !defined(host) && !defined(database) && !defined(dbProperties.getDbUseSSL()),
+            !defined(host) && !defined(database) && !defined(dbProperties.getConnectionURL()) &&!defined(dbProperties.getDbDriverClassName()) && !defined(dbProperties.getDbUseSSL()),
             "\n----------------------------------------------------------------------------------------------------------------" +
                 "-- Connection error:\n" +
-                "-- You try to connect to the database using the deprecated 'db.host', 'db.portal_db_name' and 'db.use_ssl' properties.\n" +
-                "-- Please remove these properties and use the 'db.connection_string' property instead. See https://docs.cbioportal.org/deployment/customization/portal.properties-reference/\n" +
+                "-- You try to connect to the database using the deprecated 'db.host', 'db.portal_db_name' and 'db.use_ssl' or 'db.connection_string' and. 'db.driver' properties.\n" +
+                "-- Please remove these properties and use the 'spring.datasource.url' property instead. See https://docs.cbioportal.org/deployment/customization/application.properties-reference/\n" +
                 "-- for assistance on building a valid connection string.\n" +
                 "----------------------------------------------------------------------------------------------------------------\n"
         );
         
         Assert.hasText(userName, errorMessage("username", "db.user"));
         Assert.hasText(password, errorMessage("password", "db.password"));
-        Assert.hasText(mysqlDriverClassName, errorMessage("driver class name", "db.driver"));
+        Assert.hasText(mysqlDriverClassName, errorMessage("driver class name", "spring.datasource.driver-class-name"));
 
         this.setUrl(connectionURL);
 
@@ -55,7 +55,7 @@ public class JdbcDataSource extends BasicDataSource {
     }
     
     private String errorMessage(String displayName, String propertyName) {
-        return String.format("No %s provided for database connection. Please set '%s' in portal.properties.", displayName, propertyName);
+        return String.format("No %s provided for database connection. Please set '%s' in application.properties.", displayName, propertyName);
     }
     
     private boolean defined(String property) {

--- a/src/main/java/org/mskcc/cbio/portal/servlet/QueryBuilder.java
+++ b/src/main/java/org/mskcc/cbio/portal/servlet/QueryBuilder.java
@@ -219,7 +219,7 @@ public class QueryBuilder extends HttpServlet {
 //                String extraMessage = "";
 //                //extra message for the cases where property is missing (will happen often in transition period to this new versioning model):
 //                if (dbPortalExpectedSchemaVersion.equals("0")) {
-//                    extraMessage = "The db.version property also not found in your portal.properties file. This new property needs to be added by the administrator.";
+//                    extraMessage = "The db.version property also not found in your application.properties file. This new property needs to be added by the administrator.";
 //                }
 //                String finalMessage = "Current DB schema version: " + dbActualSchemaVersion + "<br/>" +
 //                    "DB schema version expected by Portal: " + dbPortalExpectedSchemaVersion + "<br/>" + extraMessage;

--- a/src/main/java/org/mskcc/cbio/portal/util/DatabaseProperties.java
+++ b/src/main/java/org/mskcc/cbio/portal/util/DatabaseProperties.java
@@ -35,7 +35,7 @@ package org.mskcc.cbio.portal.util;
 import org.mskcc.cbio.portal.util.GlobalProperties;
 
 /**
- * Stores db props (name, id, pw, host) from portal.properties
+ * Stores db props (name, id, pw, host) from application.properties
  * and makes them accessible.
  */
 public class DatabaseProperties {
@@ -48,6 +48,8 @@ public class DatabaseProperties {
     private String dbUseSSL;
     private String dbEnablePooling;
     private String connectionURL;
+    private String springConnectionURL;
+    private String springDbDriverClassName;
 
     // No production keys stored in filesystem or code: digest the key; put it in properties; load it into dbms on startup
     private static DatabaseProperties dbProperties;
@@ -55,7 +57,7 @@ public class DatabaseProperties {
     public static DatabaseProperties getInstance() {
         if (dbProperties == null) {
             dbProperties = new DatabaseProperties();
-            //  Get DB Properties from portal.properties.
+            //  Get DB Properties from application.properties.
             dbProperties.setDbHost(GlobalProperties.getProperty("db.host"));
             dbProperties.setDbName(GlobalProperties.getProperty("db.portal_db_name"));
             dbProperties.setDbUser(GlobalProperties.getProperty("db.user"));
@@ -65,6 +67,9 @@ public class DatabaseProperties {
             dbProperties.setDbUseSSL(GlobalProperties.getProperty("db.use_ssl"));
             dbProperties.setDbEnablePooling(GlobalProperties.getProperty("db.enable_pooling"));
             dbProperties.setConnectionURL(GlobalProperties.getProperty("db.connection_string"));
+            dbProperties.setConnectionURL(GlobalProperties.getProperty("spring.datasource.url"));
+            dbProperties.setConnectionURL(GlobalProperties.getProperty("spring.datasource.driver-class-name"));
+
         }
         return dbProperties;
     }
@@ -142,6 +147,22 @@ public class DatabaseProperties {
 
     public void setConnectionURL(String connectionURL) {
         this.connectionURL = connectionURL;
+    }
+
+    public String getSpringConnectionURL() {
+        return springConnectionURL;
+    }
+
+    public void setSpringConnectionURL(String springConnectionURL) {
+        this.springConnectionURL = springConnectionURL;
+    }
+
+    public String getSpringDbDriverClassName() {
+        return springDbDriverClassName;
+    }
+
+    public void setSpringDbDriverClassName(String springDbDriverClassName) {
+        this.springDbDriverClassName = springDbDriverClassName;
     }
     
 }

--- a/src/main/java/org/mskcc/cbio/portal/util/DatabaseProperties.java
+++ b/src/main/java/org/mskcc/cbio/portal/util/DatabaseProperties.java
@@ -69,10 +69,10 @@ public class DatabaseProperties {
             dbProperties.setDbUseSSL(GlobalProperties.getProperty("db.use_ssl"));
             dbProperties.setDbEnablePooling(GlobalProperties.getProperty("db.enable_pooling"));
             dbProperties.setConnectionURL(GlobalProperties.getProperty("db.connection_string"));
-            dbProperties.setConnectionURL(GlobalProperties.getProperty("spring.datasource.username"));
-            dbProperties.setConnectionURL(GlobalProperties.getProperty("spring.datasource.password"));
-            dbProperties.setConnectionURL(GlobalProperties.getProperty("spring.datasource.url"));
-            dbProperties.setConnectionURL(GlobalProperties.getProperty("spring.datasource.driver-class-name"));
+            dbProperties.setSpringDbUser(GlobalProperties.getProperty("spring.datasource.username"));
+            dbProperties.setSpringDbPassword(GlobalProperties.getProperty("spring.datasource.password"));
+            dbProperties.setSpringConnectionURL(GlobalProperties.getProperty("spring.datasource.url"));
+            dbProperties.setSpringDbDriverClassName(GlobalProperties.getProperty("spring.datasource.driver-class-name"));
 
         }
         return dbProperties;

--- a/src/main/java/org/mskcc/cbio/portal/util/DatabaseProperties.java
+++ b/src/main/java/org/mskcc/cbio/portal/util/DatabaseProperties.java
@@ -48,6 +48,8 @@ public class DatabaseProperties {
     private String dbUseSSL;
     private String dbEnablePooling;
     private String connectionURL;
+    private String springDbUser;
+    private String springDbPassword;
     private String springConnectionURL;
     private String springDbDriverClassName;
 
@@ -67,6 +69,8 @@ public class DatabaseProperties {
             dbProperties.setDbUseSSL(GlobalProperties.getProperty("db.use_ssl"));
             dbProperties.setDbEnablePooling(GlobalProperties.getProperty("db.enable_pooling"));
             dbProperties.setConnectionURL(GlobalProperties.getProperty("db.connection_string"));
+            dbProperties.setConnectionURL(GlobalProperties.getProperty("spring.datasource.username"));
+            dbProperties.setConnectionURL(GlobalProperties.getProperty("spring.datasource.password"));
             dbProperties.setConnectionURL(GlobalProperties.getProperty("spring.datasource.url"));
             dbProperties.setConnectionURL(GlobalProperties.getProperty("spring.datasource.driver-class-name"));
 
@@ -155,6 +159,22 @@ public class DatabaseProperties {
 
     public void setSpringConnectionURL(String springConnectionURL) {
         this.springConnectionURL = springConnectionURL;
+    }
+
+    public String getSpringDbUser() {
+        return springDbUser;
+    }
+
+    public void setSpringDbUser(String springDbUser) {
+        this.springDbUser = springDbUser;
+    }
+
+    public String getSpringDbPassword() {
+        return springDbPassword;
+    }
+
+    public void setSpringDbPassword(String springDbPassword) {
+        this.springDbPassword = springDbPassword;
     }
 
     public String getSpringDbDriverClassName() {

--- a/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
+++ b/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
@@ -392,7 +392,7 @@ public class GlobalProperties {
      * Minimal portal property resolver that takes system property overrides.
      *
      * Provides properties from runtime or the baked-in
-     * portal.properties config file, but takes overrides from <code>-D</code>
+     * application.properties config file, but takes overrides from <code>-D</code>
      * system properties.
      */
     private static class ConfigPropertyResolver {
@@ -400,7 +400,7 @@ public class GlobalProperties {
         /**
          * Finds the config file for properties not overridden by system props.
          *
-         * Either the runtime or buildtime portal.properties file.
+         * Either the runtime or buildtime application.properties file.
          */
         public ConfigPropertyResolver() {
             configFileProperties = initializeProperties(PORTAL_PROPERTIES_FILE_NAME);

--- a/src/main/resources/applicationContext-persistenceConnections.xml
+++ b/src/main/resources/applicationContext-persistenceConnections.xml
@@ -16,8 +16,8 @@
             <property name="ignoreResourceNotFound" value="true" />
             <property name="locations">
                 <list>
-                    <value>classpath:/portal.properties</value>
-                    <value>file:///#{systemEnvironment['PORTAL_HOME']}/portal.properties</value>
+                    <value>classpath:/application.properties</value>
+                    <value>file:///#{systemEnvironment['PORTAL_HOME']}/application.properties</value>
                 </list>
             </property>
         </bean>

--- a/src/main/resources/scripts/compareDirectAndBulkDBMSload.pl
+++ b/src/main/resources/scripts/compareDirectAndBulkDBMSload.pl
@@ -24,7 +24,7 @@ use Getopt::Long;
 
 # on laptop: ./compareDirectAndBulkDBMSload.pl --outputDir "/Users/goldbera/Documents/Projects/TCGA Portal/Fast DBMS load/data/" --MySQLdbParams h=localhost,u=root,p=anOKpwd --database cgds
 # on toro: nohup ./compareDirectAndBulkDBMSload.pl --outputDir "/home/goldberg/data" --MySQLdbParams h=localhost,u=cbio,p=cbio --database cgds_arthur &> stdout.txt&
-# on toro: uses ./build/WEB-INF/classes/org/mskcc/cbio/portal/util/portal.properties
+# on toro: uses ./build/WEB-INF/classes/org/mskcc/cbio/portal/util/application.properties
 
 
 # CONSTANTS

--- a/src/main/resources/scripts/hot-deploy.sh
+++ b/src/main/resources/scripts/hot-deploy.sh
@@ -15,5 +15,5 @@ HOST=$1
 USER=$2
 REV=$3
 
-# Note, this script was intended to be run via cron.  Please ensure that the path to portal.properties.*
-$PORTAL_HOME/portal/scripts/hotDeploy.py --credentials $PORTAL_HOME/src/main/resources/properties.txt --portal-properties $PORTAL_HOME/src/main/resources/portal.properties.GDAC --rev $REV --host $HOST --user $USER
+# Note, this script was intended to be run via cron.  Please ensure that the path to application.properties.*
+$PORTAL_HOME/portal/scripts/hotDeploy.py --credentials $PORTAL_HOME/src/main/resources/properties.txt --portal-properties $PORTAL_HOME/src/main/resources/application.properties.GDAC --rev $REV --host $HOST --user $USER

--- a/src/main/resources/scripts/hotDeploy.py
+++ b/src/main/resources/scripts/hotDeploy.py
@@ -3,7 +3,7 @@
 # ------------------------------------------------------------------------------
 # Script which hot deploys cbio portal fixes.  Script assumes
 # properties file argument lives within $PORTAL_HOME/portal.  This
-# script will clobber any existing portal.properties file within $PORTAL_HOME/portal.
+# script will clobber any existing application.properties file within $PORTAL_HOME/portal.
 
 # ------------------------------------------------------------------------------
 # imports
@@ -29,7 +29,7 @@ PORTAL_PROJECT = PORTAL_HOME + os.sep + "portal"
 
 WAR_FILE_DEST = "/srv/www/sander-tomcat/tomcat6/webapps/"
 
-# fields in credentials - should match portal portal.properties
+# fields in credentials - should match portal application.properties
 CGDS_DATABASE_USER = 'db.user'
 CGDS_DATABASE_PW = 'db.password'
 BITLY_USER = 'bitly.user'
@@ -104,12 +104,12 @@ def deploy_war(host, user):
 
 def build_war(portal_credentials, portal_properties):
 
-	# setup portal.properties
-	portal_properties = PORTAL_PROJECT + os.sep + "portal.properties"
+	# setup application.properties
+	portal_properties = PORTAL_PROJECT + os.sep + "application.properties"
 	if os.path.exists(portal_properties):
 		print >> OUTPUT_FILE, "Clobbering %s" % portal_properties
 
-	# we are going to create a new portal.properties file using
+	# we are going to create a new application.properties file using
 	# portal_properties as the template and get credentials from portal_credentials
 	portal_properties_file = open(portal_properties, 'w')
 	portal_properties_file = open(portal_properties, 'r')

--- a/src/main/resources/scripts/hotDeploy.py
+++ b/src/main/resources/scripts/hotDeploy.py
@@ -30,8 +30,8 @@ PORTAL_PROJECT = PORTAL_HOME + os.sep + "portal"
 WAR_FILE_DEST = "/srv/www/sander-tomcat/tomcat6/webapps/"
 
 # fields in credentials - should match portal application.properties
-CGDS_DATABASE_USER = 'db.user'
-CGDS_DATABASE_PW = 'db.password'
+CGDS_DATABASE_USER = 'spring.datasource.username'
+CGDS_DATABASE_PW = 'spring.datasource.password'
 BITLY_USER = 'bitly.user'
 BITLY_KEY = 'bitly.api_key'
 CGDS_USERS_SPREADSHEET = 'users.spreadsheet'

--- a/src/main/resources/scripts/import-portal-users.sh
+++ b/src/main/resources/scripts/import-portal-users.sh
@@ -5,8 +5,8 @@ PYTHONHOME=
 PYTHONPATH=
 PORTAL_HOME=
 
-# Note, this script was intended to be run via cron.  Please ensure that the path to portal.properties.*
+# Note, this script was intended to be run via cron.  Please ensure that the path to application.properties.*
 # points to an unchanging location and version of the file.  The path below is only meant for illustrative purposes.
-$PORTAL_HOME/portal/scripts/importUsers.py --properties-file $PORTAL_HOME/portal/portal.properties.GDAC --send-email-confirm true 2>&1 > /dev/null
-$PORTAL_HOME/portal/scripts/importUsers.py --properties-file $PORTAL_HOME/portal/portal.properties.PRIVATE --send-email-confirm true 2>&1 > /dev/null
-$PORTAL_HOME/portal/scripts/importUsers.py --properties-file $PORTAL_HOME/portal/portal.properties.SU2C --send-email-confirm true 2>&1 > /dev/null
+$PORTAL_HOME/portal/scripts/importUsers.py --properties-file $PORTAL_HOME/portal/application.properties.GDAC --send-email-confirm true 2>&1 > /dev/null
+$PORTAL_HOME/portal/scripts/importUsers.py --properties-file $PORTAL_HOME/portal/application.properties.PRIVATE --send-email-confirm true 2>&1 > /dev/null
+$PORTAL_HOME/portal/scripts/importUsers.py --properties-file $PORTAL_HOME/portal/application.properties.SU2C --send-email-confirm true 2>&1 > /dev/null

--- a/src/main/resources/scripts/importUsers.py
+++ b/src/main/resources/scripts/importUsers.py
@@ -52,9 +52,9 @@ ERROR_FILE = sys.stderr
 OUTPUT_FILE = sys.stdout
 
 # fields in application.properties
-CGDS_DATABASE_HOST = 'db.host'
+CGDS_DATABASE_HOST = 'spring.datasource.password'
 CGDS_DATABASE_NAME = 'db.portal_db_name'
-CGDS_DATABASE_USER = 'db.user'
+CGDS_DATABASE_USER = 'spring.datasource.user'
 CGDS_DATABASE_PW = 'db.password'
 GOOGLE_ID = 'google.id'
 GOOGLE_PW = 'google.pw'

--- a/src/main/resources/scripts/importUsers.py
+++ b/src/main/resources/scripts/importUsers.py
@@ -2,7 +2,7 @@
 
 # ------------------------------------------------------------------------------
 # Script which adds new users fram google spreadsheet into the the cgds
-# user table.  The following properties must be specified in portal.properties:
+# user table.  The following properties must be specified in application.properties:
 #
 # db.name
 # db.user
@@ -51,7 +51,7 @@ from email import Encoders
 ERROR_FILE = sys.stderr
 OUTPUT_FILE = sys.stdout
 
-# fields in portal.properties
+# fields in application.properties
 CGDS_DATABASE_HOST = 'db.host'
 CGDS_DATABASE_NAME = 'db.portal_db_name'
 CGDS_DATABASE_USER = 'db.user'
@@ -345,7 +345,7 @@ def get_db_connection(portal_properties):
 
 
 # ------------------------------------------------------------------------------
-# parse portal.properties
+# parse application.properties
 
 def get_portal_properties(portal_properties_filename):
 

--- a/src/main/resources/scripts/importer/cbioportal_common.py
+++ b/src/main/resources/scripts/importer/cbioportal_common.py
@@ -45,7 +45,8 @@ PORTAL_PROPERTY_DATABASE_HOST = 'db.host'
 PORTAL_PROPERTY_DATABASE_NAME = 'db.portal_db_name'
 PORTAL_PROPERTY_DATABASE_URL = 'db.connection_string'
 PORTAL_PROPERTY_DATABASE_USESSL = 'db.use_ssl'
-REQUIRED_DATABASE_PROPERTIES = [PORTAL_PROPERTY_DATABASE_USER, PORTAL_PROPERTY_DATABASE_PW, PORTAL_PROPERTY_DATABASE_URL]
+PORTAL_PROPERTY_SPRING_DATABASE_URL = 'spring.datasource.url'
+REQUIRED_DATABASE_PROPERTIES = [PORTAL_PROPERTY_DATABASE_USER, PORTAL_PROPERTY_DATABASE_PW, PORTAL_PROPERTY_SPRING_DATABASE_URL]
 
 # provides a key for data types to metafile specification dict.
 class MetaFileTypes(object):
@@ -1013,7 +1014,7 @@ def run_java(*args):
 
 
 def properties_error_message(display_name: str, property_name: str) -> str:
-    return f"No {display_name} provided for database connection. Please set '{property_name}' in portal.properties."
+    return f"No {display_name} provided for database connection. Please set '{property_name}' in application.properties."
 
 
 class PortalProperties(object):
@@ -1041,12 +1042,13 @@ def get_database_properties(properties_filename: str) -> Optional[PortalProperti
 
     if properties.get(PORTAL_PROPERTY_DATABASE_HOST) is not None \
         or properties.get(PORTAL_PROPERTY_DATABASE_NAME) is not None \
-        or properties.get(PORTAL_PROPERTY_DATABASE_USESSL) is not None:
+        or properties.get(PORTAL_PROPERTY_DATABASE_USESSL) is not None \ 
+        or properties.get(PORTAL_PROPERTY_DATABASE_URL) is not None:
         print("""
             ----------------------------------------------------------------------------------------------------------------
             -- Connection error:
-            -- You try to connect to the database using the deprecated 'db.host', 'db.portal_db_name' and 'db.use_ssl' properties.
-            -- Please remove these properties and use the 'db.connection_string' property instead. See https://docs.cbioportal.org/deployment/customization/portal.properties-reference/
+            -- You try to connect to the database using the deprecated 'db.host', 'db.portal_db_name' and 'db.use_ssl' or 'db.connection_string' properties.
+            -- Please remove these properties and use the 'db.spring.datasource.url' property instead. See https://docs.cbioportal.org/deployment/customization/application.properties-reference/
             -- for assistance on building a valid connection string.
             ------------------------------------------------------------f---------------------------------------------------
         """, file=ERROR_FILE)
@@ -1054,7 +1056,7 @@ def get_database_properties(properties_filename: str) -> Optional[PortalProperti
 
     return PortalProperties(properties[PORTAL_PROPERTY_DATABASE_USER],
                             properties[PORTAL_PROPERTY_DATABASE_PW],
-                            properties[PORTAL_PROPERTY_DATABASE_URL])
+                            properties[PORTAL_PROPERTY_SPRING_DATABASE_URL])
 
 
 def parse_properties_file(properties_filename: str) -> Dict[str, str]:

--- a/src/main/resources/scripts/importer/cbioportal_common.py
+++ b/src/main/resources/scripts/importer/cbioportal_common.py
@@ -45,8 +45,10 @@ PORTAL_PROPERTY_DATABASE_HOST = 'db.host'
 PORTAL_PROPERTY_DATABASE_NAME = 'db.portal_db_name'
 PORTAL_PROPERTY_DATABASE_URL = 'db.connection_string'
 PORTAL_PROPERTY_DATABASE_USESSL = 'db.use_ssl'
+PORTAL_PROPERTY_SPRING_DATABASE_USER = 'spring.datasource.username'
+PORTAL_PROPERTY_SPRING_DATABASE_PW = 'spring.datasource.password'
 PORTAL_PROPERTY_SPRING_DATABASE_URL = 'spring.datasource.url'
-REQUIRED_DATABASE_PROPERTIES = [PORTAL_PROPERTY_DATABASE_USER, PORTAL_PROPERTY_DATABASE_PW, PORTAL_PROPERTY_SPRING_DATABASE_URL]
+REQUIRED_DATABASE_PROPERTIES = [PORTAL_PROPERTY_SPRING_DATABASE_USER, PORTAL_PROPERTY_SPRING_DATABASE_PW, PORTAL_PROPERTY_SPRING_DATABASE_URL]
 
 # provides a key for data types to metafile specification dict.
 class MetaFileTypes(object):
@@ -1054,8 +1056,8 @@ def get_database_properties(properties_filename: str) -> Optional[PortalProperti
         """, file=ERROR_FILE)
         return None
 
-    return PortalProperties(properties[PORTAL_PROPERTY_DATABASE_USER],
-                            properties[PORTAL_PROPERTY_DATABASE_PW],
+    return PortalProperties(properties[PORTAL_PROPERTY_SPRING_DATABASE_USER],
+                            properties[PORTAL_PROPERTY_SPRING_DATABASE_PW],
                             properties[PORTAL_PROPERTY_SPRING_DATABASE_URL])
 
 

--- a/src/main/resources/scripts/importer/cbioportal_common.py
+++ b/src/main/resources/scripts/importer/cbioportal_common.py
@@ -1042,7 +1042,7 @@ def get_database_properties(properties_filename: str) -> Optional[PortalProperti
 
     if properties.get(PORTAL_PROPERTY_DATABASE_HOST) is not None \
         or properties.get(PORTAL_PROPERTY_DATABASE_NAME) is not None \
-        or properties.get(PORTAL_PROPERTY_DATABASE_USESSL) is not None \ 
+        or properties.get(PORTAL_PROPERTY_DATABASE_USESSL) is not None \
         or properties.get(PORTAL_PROPERTY_DATABASE_URL) is not None:
         print("""
             ----------------------------------------------------------------------------------------------------------------

--- a/src/main/resources/scripts/importer/updateOncokbAnnotations.py
+++ b/src/main/resources/scripts/importer/updateOncokbAnnotations.py
@@ -269,7 +269,7 @@ def interface():
                         required=True,
                         help='Study Identifier')
     parser.add_argument('-p', '--portal_properties', type=str, required=True,
-                        help='portal.properties of cBioPortal')
+                        help='application.properties of cBioPortal')
     parser = parser.parse_args()
     return parser
 

--- a/src/main/resources/scripts/importer/validateData.py
+++ b/src/main/resources/scripts/importer/validateData.py
@@ -2133,7 +2133,7 @@ class MutationsExtendedValidator(CustomDriverAnnotationValidator, CustomNamespac
 
     def checkNCBIbuild(self, value):
         """
-        Checks whether the value found in MAF NCBI_Build column matches the genome specified in portal.properties at 
+        Checks whether the value found in MAF NCBI_Build column matches the genome specified in application.properties at 
         field ncbi.build. Expecting GRCh37, GRCh38, GRCm38 or without the GRCx prefix
         """    
     

--- a/src/main/resources/scripts/importer/validateStudies.py
+++ b/src/main/resources/scripts/importer/validateStudies.py
@@ -169,7 +169,7 @@ def interface(args=None):
                                    help='Skip tests requiring information '
                                         'from the cBioPortal installation')
     parser.add_argument('-P', '--portal_properties', type=str,
-                        help='portal.properties file path (default: assumed hg19)',
+                        help='application.properties file path (default: assumed hg19)',
                         required=False)
 
     parser.add_argument('-m', '--strict_maf_checks', required=False,

--- a/src/main/resources/scripts/migrate_db.py
+++ b/src/main/resources/scripts/migrate_db.py
@@ -371,7 +371,7 @@ def main():
     parser = argparse.ArgumentParser(description='cBioPortal DB migration script')
     parser.add_argument('-y', '--suppress_confirmation', default=False, action='store_true')
     parser.add_argument('-p', '--properties-file', type=str, required=False,
-                        help='Path to portal.properties file (default: locate it '
+                        help='Path to application.properties file (default: locate it '
                              'relative to the script)')
     parser.add_argument('-s', '--sql', type=str, required=False,
                         help='Path to official migration.sql script. (default: locate it '
@@ -389,7 +389,7 @@ def main():
         script_dir = Path(__file__).resolve().parent
         # go up from cbioportal/core/src/main/scripts/ to cbioportal/
         src_root = script_dir.parent.parent.parent.parent
-        properties_filename = src_root / 'portal.properties'
+        properties_filename = src_root / 'application.properties'
                 
     sql_filename = parser.sql
     if sql_filename is None:

--- a/src/test/resources/applicationContext-dao.xml
+++ b/src/test/resources/applicationContext-dao.xml
@@ -26,7 +26,7 @@
 	    <property name="ignoreResourceNotFound" value="true" />
 	    <property name="locations">
 		     <list>
-			     <value>file:///#{systemEnvironment['PORTAL_HOME']}/src/main/resources/portal.properties</value>
+			     <value>file:///#{systemEnvironment['PORTAL_HOME']}/src/main/resources/application.properties</value>
                  <value>file:///#{systemEnvironment['PORTAL_HOME']}/src/main/resources/maven.properties</value>
 		     </list>
 	    </property>


### PR DESCRIPTION
As 6.0.0 migrated to spring db I propose to also change this in the core library. Then the db settings in the application.properties only need to be defined once.

Goes together with: https://github.com/cBioPortal/cbioportal/pull/10537