### PR TITLE
update cbioportal to v6.0.0 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<groupId>org.mskcc.cbio</groupId>
 	<artifactId>core</artifactId>
-	<version>1.0.4</version>
+	<version>1.0.5</version>
 
 	<name>Portal Core</name>
 	<description>Core libraries shared among other modules</description>
@@ -20,7 +20,7 @@
 
 		<!-- THIS SHOULD BE KEPT IN SYNC TO VERSION IN CGDS.SQL -->
 		<db.version>2.13.1</db.version>
-		<cbioportal.version>demo-rfc72-squash-9966fd5d1c-1</cbioportal.version>
+		<cbioportal.version>v6.0.0</cbioportal.version>
 		<maf.version>1.0.0</maf.version>
 
 


### PR DESCRIPTION
v6.0.0 release of cbioportal appears to not modify any of the depended upon code from the timeframe of the (now deleted) branch demo-rfc72-squash. Comparisons were made to branches rfc72-squash (Fri Dec 15 17:54:41 2023 -0500) and demo-rfc72 (Mon Dec 18 14:47:11 2023 -0500) referring to Inter-Repository-Dependencies.md (pending PR to cbioportal) and no alterations were seen.

An addition to the cbioportal packaged libraries was noticed:
v6.0.0 added spring-security-jwt 1.1.1.RELEASE
but this is unrelated to the UserDetails or PostFilter definitions in cbioportal-core which depend on other spring-security libraries.