### PR TITLE
Add java_opts to cbioportalImporter.py

### DIFF
--- a/src/main/resources/scripts/importer/cbioportalImporter.py
+++ b/src/main/resources/scripts/importer/cbioportalImporter.py
@@ -444,10 +444,9 @@ def check_dir(study_directory):
 def add_parser_args(parser):
     parser.add_argument('-s', '--study_directory', type=str, required=False,
                         help='Path to Study Directory')
-    parser.add_argument('-jvo', '--java_opts', type=str, required=False,
+    parser.add_argument('-jvo', '--java_opts', type=str, default=os.environ.get('JAVA_OPTS'),
                         help='Path to specify JAVA_OPTS for the importer. \
-                        (default: locates the jar path relative to the import script \
-                        and passes it as the JAVA_OPTS)')
+                        (default: gets the JAVA_OPTS from the environment)')
     parser.add_argument('-jar', '--jar_path', type=str, required=False,
                         help='Path to scripts JAR file')
     parser.add_argument('-meta', '--meta_filename', type=str, required=False,

--- a/src/main/resources/scripts/importer/cbioportalImporter.py
+++ b/src/main/resources/scripts/importer/cbioportalImporter.py
@@ -449,8 +449,7 @@ def add_parser_args(parser):
                         (default: locates the jar path relative to the import script \
                         and passes it as the JAVA_OPTS)')
     parser.add_argument('-jar', '--jar_path', type=str, required=False,
-                        help='DEPRECATED ARGUMENT. Please, use -jvo/--java_opts instead. If you \
-                             want to pass a jar path, use "-cp <jar_path>" as parameter for --java_opts.')
+                        help='Path to scripts JAR file')
     parser.add_argument('-meta', '--meta_filename', type=str, required=False,
                         help='Path to meta file')
     parser.add_argument('-data', '--data_filename', type=str, required=False,
@@ -524,6 +523,10 @@ def main(args):
     error_handler.setLevel(logging.ERROR)
     module_logger.addHandler(error_handler)
     LOGGER = module_logger
+
+    # move jar_path to java_opts if it exists
+    if args.jar_path:
+        args.java_opts = f"-cp {args.jar_path} {args.java_opts}"
 
     # java_opts is optional. If class (jar) path is not set (-cp), try to find the jar path relative to this script
     locate_jar_path = True

--- a/src/main/resources/scripts/importer/metaImport.py
+++ b/src/main/resources/scripts/importer/metaImport.py
@@ -80,8 +80,8 @@ def interface():
                         (default: locates the jar path relative to the import script \
                         and passes it as the JAVA_OPTS)')
     parser.add_argument('-jar', '--jar_path', type=str, required=False,
-                        help='DEPRECATED ARGUMENT. Please, use -jvo/--java_opts instead. If you \
-                             want to pass a jar path, use "-cp <jar_path>" as parameter for --java_opts.')
+                        help='Path to scripts JAR file (default: locate it '
+                             'relative to the import script)')
     parser.add_argument('-html', '--html_table', type=str,
                         help='path to html report')
     parser.add_argument('-v', '--verbose', action='store_true',

--- a/src/main/resources/scripts/importer/metaImport.py
+++ b/src/main/resources/scripts/importer/metaImport.py
@@ -75,10 +75,9 @@ def interface():
                                        action='store_true',
                                        help='Skip tests requiring information '
                                             'from the cBioPortal installation')
-    parser.add_argument('-jvo', '--java_opts', type=str, required=False,
+    parser.add_argument('-jvo', '--java_opts', type=str, default=os.environ.get('JAVA_OPTS'),
                         help='Path to specify JAVA_OPTS for the importer. \
-                        (default: locates the jar path relative to the import script \
-                        and passes it as the JAVA_OPTS)')
+                        (default: gets the JAVA_OPTS from the environment)')
     parser.add_argument('-jar', '--jar_path', type=str, required=False,
                         help='Path to scripts JAR file (default: locate it '
                              'relative to the import script)')

--- a/src/main/resources/scripts/importer/metaImport.py
+++ b/src/main/resources/scripts/importer/metaImport.py
@@ -74,11 +74,14 @@ def interface():
     portal_mode_group.add_argument('-n', '--no_portal_checks', default=False,
                                        action='store_true',
                                        help='Skip tests requiring information '
-                                            'from the cBioPortal installation')                                                               
+                                            'from the cBioPortal installation')
+    parser.add_argument('-jvo', '--java_opts', type=str, required=False,
+                        help='Path to specify JAVA_OPTS for the importer. \
+                        (default: locates the jar path relative to the import script \
+                        and passes it as the JAVA_OPTS)')
     parser.add_argument('-jar', '--jar_path', type=str, required=False,
-                        help=(
-                            'Path to scripts JAR file (default: locate it '
-                            'relative to the import script)'))
+                        help='DEPRECATED ARGUMENT. Please, use -jvo/--java_opts instead. If you \
+                             want to pass a jar path, use "-cp <jar_path>" as parameter for --java_opts.')
     parser.add_argument('-html', '--html_table', type=str,
                         help='path to html report')
     parser.add_argument('-v', '--verbose', action='store_true',


### PR DESCRIPTION
Currently we can only pass the `jar_path` to `cbioportalImporter.py`. This adds `java_opts` as a new option to `cbioportalImporter.py` to allow passing any `JAVA_OPTS` parameter. This allows us pass max memory usage etc. The `jar_path` option is retained in a backward-compatible manner