### PR TITLE
filter out signature files from bc dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,6 +222,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.5.1</version>
 				<executions>
 					<execution>
 						<id>assembly</id>
@@ -230,6 +231,16 @@
 							<goal>shade</goal>
 						</goals>
 						<configuration>
+							<filters>
+								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>META-INF/*.SF</exclude>
+										<exclude>META-INF/*.DSA</exclude>
+										<exclude>META-INF/*.RSA</exclude>
+									</excludes>
+								</filter>
+							</filters>
 							<transformers>
 								<transformer
 										implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">


### PR DESCRIPTION
- if these are not filtered, the built jar of cbioportal-core appears to be a signed jar with invalid/incomplete signatures
- signatures are included in this dependency: org.bouncycastle:bcpkix-jdk15on