### PR TITLE
Speed up CnaEvent lookup during import

### DIFF
--- a/src/main/java/org/mskcc/cbio/portal/scripts/ImportCnaDiscreteLongData.java
+++ b/src/main/java/org/mskcc/cbio/portal/scripts/ImportCnaDiscreteLongData.java
@@ -45,7 +45,7 @@ public class ImportCnaDiscreteLongData {
     private String genePanel;
     private final DaoGeneOptimized daoGene;
     private CnaUtil cnaUtil;
-    private Set<CnaEvent.Event> existingCnaEvents = new HashSet<>();
+    private Map<CnaEvent.Event, CnaEvent.Event> existingCnaEvents = new HashMap<>();
     private int samplesSkipped = 0;
     private Set<String> namespaces;
 
@@ -84,7 +84,9 @@ public class ImportCnaDiscreteLongData {
             && geneticProfile.showProfileInAnalysisTab();
 
         if (isDiscretizedCnaProfile) {
-            existingCnaEvents.addAll(DaoCnaEvent.getAllCnaEvents());
+            for (CnaEvent.Event event : DaoCnaEvent.getAllCnaEvents()) {
+                existingCnaEvents.put(event, event);
+            }
             MySQLbulkLoader.bulkLoadOn();
         }
 

--- a/src/main/java/org/mskcc/cbio/portal/scripts/ImportTabDelimData.java
+++ b/src/main/java/org/mskcc/cbio/portal/scripts/ImportTabDelimData.java
@@ -265,9 +265,11 @@ public class ImportTabDelimData {
             DaoGeneticAlteration daoGeneticAlteration = DaoGeneticAlteration.getInstance();
 
             //cache for data found in  cna_event' table:
-            Set<CnaEvent.Event> existingCnaEvents = new HashSet<>();
+            Map<CnaEvent.Event, CnaEvent.Event> existingCnaEvents = new HashMap<>();
             if (isDiscretizedCnaProfile) {
-                existingCnaEvents.addAll(DaoCnaEvent.getAllCnaEvents());
+                for (CnaEvent.Event event : DaoCnaEvent.getAllCnaEvents()) {
+                    existingCnaEvents.put(event, event);
+                }
                 MySQLbulkLoader.bulkLoadOn();
             }
 
@@ -502,7 +504,7 @@ public class ImportTabDelimData {
                               boolean isRppaProfile, boolean isDiscretizedCnaProfile,
                               DaoGeneOptimized daoGene,
                               List<Integer> filteredSampleIndices, List<Integer> orderedSampleList,
-                              Set<CnaEvent.Event> existingCnaEvents
+                              Map<CnaEvent.Event, CnaEvent.Event> existingCnaEvents
     ) throws DaoException {
 
         //TODO: refactor this entire function - split functionality into smaller units / subroutines


### PR DESCRIPTION
- store existing events from the database in a HashMap instead of HashSet
- retrieval from HashMap uses CnaEvent.Event equals() and hashMap() semantics
- retrieval is neccessary in order to obtain the associated event_id from the db record
- this avoids a linear search through the set of all CnaEvent.Events in the database