### PR TITLE
update mysql-connector-java to 8.0.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		<maf.version>1.0.0</maf.version>
 
 
-		<mysql_driver.version>5.1.48</mysql_driver.version>
+		<mysql_driver.version>8.0.28</mysql_driver.version>
 		<mysql_commons_lang3.version>3.13.0</mysql_commons_lang3.version>
 
 		<commons_dbcp2.version>2.10.0</commons_dbcp2.version>

--- a/src/main/java/org/mskcc/cbio/portal/dao/JdbcDataSource.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/JdbcDataSource.java
@@ -38,7 +38,7 @@ public class JdbcDataSource extends BasicDataSource {
         }
     }
 
-    public JdbcDataSource () {
+    public JdbcDataSource() {
         DatabaseProperties dbProperties = DatabaseProperties.getInstance();
         logUsedDeprecatedProperties(dbProperties);
         // extract required property values
@@ -65,6 +65,9 @@ public class JdbcDataSource extends BasicDataSource {
         this.setDriverClassName(mysqlDriverClassName);
         // Disable this to avoid caching statements
         this.setPoolPreparedStatements(Boolean.valueOf(enablePooling));
+        // this property setting is needed to enable MySQLbulkLoader to load data from a local file
+        // this is set here in case this class is initialized via JdbcUtil (not expected), but is also set in applicationContext resource files.
+        this.addConnectionProperty("allowLoadLocalInfile", "true");
         // these values are from the production cbioportal application context for a jndi data source
         this.setMaxTotal(500);
         this.setMaxIdle(30);

--- a/src/main/java/org/mskcc/cbio/portal/dao/MySQLbulkLoader.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/MySQLbulkLoader.java
@@ -84,10 +84,8 @@ public class MySQLbulkLoader {
             con = JdbcUtil.getDbConnection(MySQLbulkLoader.class);
             stmt = con.prepareStatement("SELECT @@foreign_key_checks;");
             ResultSet result = stmt.executeQuery();
-            
-            result.first();
+            result.next();
             checks = result.getInt(1);
-
             stmt = con.prepareStatement("SET foreign_key_checks = ?;");
             stmt.setLong(1, 0);
             stmt.execute();

--- a/src/main/resources/applicationContext-persistenceConnections.xml
+++ b/src/main/resources/applicationContext-persistenceConnections.xml
@@ -74,6 +74,17 @@
             <property name="mapperLocations" value="classpath*:org/cbioportal/persistence/mybatis/**/*.xml" />
             <property name="databaseIdProvider" ref="databaseIdProvider"/>
         </bean>
+        <!-- configure the data source to allow LOAD DATA LOCAL INFILE ... -->
+        <bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+            <property name="targetObject" ref="businessDataSource"/>
+            <property name="targetMethod" value="addConnectionProperty"/>
+            <property name="arguments">
+                <list>
+                    <value>allowLoadLocalInfile</value>
+                    <value>true</value>
+                </list>
+            </property>
+        </bean>
     </beans>
 
     <beans profile="dbcp">
@@ -98,4 +109,5 @@
             </property>
         </bean>
     </beans>
+
 </beans>

--- a/src/test/resources/applicationContext-dao.xml
+++ b/src/test/resources/applicationContext-dao.xml
@@ -88,6 +88,18 @@
         <property name="databaseIdProvider" ref="databaseIdProvider"/>
     </bean>
     
+    <!-- configure the data source to allow LOAD DATA LOCAL INFILE ... -->
+    <b:bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+        <b:property name="targetObject" ref="businessDataSource"/>
+        <b:property name="targetMethod" value="addConnectionProperty"/>
+        <b:property name="arguments">
+            <b:list>
+                <b:value>allowLoadLocalInfile</b:value>
+                <b:value>true</b:value>
+            </b:list>
+        </b:property>
+    </b:bean>
+
     <!-- scan for mappers and let them be autowired -->
     <bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
         <property name="basePackage" value="org.mskcc.cbio.portal.persistence,org.cbioportal.persistence.mybatis" />


### PR DESCRIPTION
The cbioportal codebase currently uses mysql-connector-java version 8.0.28, and cbioportal is brought into cbioportal-core as a dependency. This PR updates the mysql-connector-java version in cbioportal-core to match the one cbioportal.

Two connected changes were needed:
- the updated mysql-connector-java is more strict, disallowing any call of ResultSet.first() if the (default) ResultSet type is FORWARD_ONLY. Such a call was changed to ResultSet.next() to move the cursor onto the first record.
- the updated mysql-connector-java is more reluctant to allow bulk upload of data from local files (LOAD DATA LOCAL INFILE ...), so an additional property (allowLoadLocalInfile) needed to be set in the defined DataSource when opening connections to the database.