### PR TITLE
Initialise transactionTemplate if needed

### DIFF
--- a/src/main/java/org/mskcc/cbio/portal/dao/JdbcUtil.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/JdbcUtil.java
@@ -82,6 +82,9 @@ public class JdbcUtil {
     }
 
     public static TransactionTemplate getTransactionTemplate() {
+        if (transactionTemplate == null) {
+            getDataSource();
+        }
         return transactionTemplate;
     }
 


### PR DESCRIPTION
`JdbcUtil.getTransactionTemplate()` returned `null` causing null pointer exception for all commands that used transaction programatically:
- `RemoveSamples`
- `RemovePatients`
- `ImportCnaDiscreteLongData`
- `ImportTabDelimData`