### PR TITLE
Minor fix to validate floats in clinical files

### DIFF
--- a/scripts/importer/validateData.py
+++ b/scripts/importer/validateData.py
@@ -2726,7 +2726,7 @@ class ClinicalValidator(Validator):
                 pass
             elif data_type == 'NUMBER':
                 if not self.checkFloat(value):
-                    if (value[0] in ('>','<')) and value[1:].isdigit():
+                    if (value[0] in ('>','<')) and self.checkFloat(value[1:]):
                         pass
                     else:
                         self.logger.error(


### PR DESCRIPTION
The current check `if (value[0] in ('>','<')) and value[1:].isdigit():` throws an error if the values are floats. This PR fixes that. 