### PR TITLE
Removing the filtering of amino acid changes with '+' as not relevant anymore

### DIFF
--- a/scripts/importer/validateData.py
+++ b/scripts/importer/validateData.py
@@ -2223,9 +2223,9 @@ class MutationsExtendedValidator(CustomDriverAnnotationValidator, CustomNamespac
                 return False
             # lines in this format are single mutations, so the haplotype
             # syntax supported by HGVS strings is not applicable
-            if ';' in value or '+' in value:
+            if ';' in value:
                 # return with an error message
-                self.extra = ("Unexpected ';' or '+' in amino acid change, "
+                self.extra = ("Unexpected ';' in amino acid change, "
                               "multi-variant allele notation is not supported")
                 self.extra_exists = True
                 return False


### PR DESCRIPTION
This change was not taken along when the externalized core was created. See https://github.com/cBioPortal/cbioportal/commit/76fd01b773fbd976a085914943f54fb89877c4df for the previous time this was implemented