### PR TITLE
fix SyntaxWarning: invalid escape sequence '\s'

### DIFF
--- a/scripts/migrate_db.py
+++ b/scripts/migrate_db.py
@@ -267,7 +267,7 @@ def check_and_remove_type_of_cancer_id_foreign_key(cursor):
 
 
 def strip_trailing_comment_from_line(line):
-    line_parts = re.split("--\s", line)
+    line_parts = re.split(r"--\s", line)
     return line_parts[0]
 
 


### PR DESCRIPTION
This is a simple change to `migrate_db.py` to fix the warning about the unescaped "\s" in the regular expression. The fix is to make it a raw string to unambiguously preserve the backslash.
