### PR TITLE
A java command to check constraints violoations in CH database

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,3 +176,22 @@ The script will search for `core-*.jar` in the root of the project:
 ```bash
 python scripts/importer/metaImport.py -s tests/test_data/study_es_0 -p tests/test_data/api_json_unit_tests -o
 ```
+
+#### Check ClickHouse constraint violations
+
+Use `org.mskcc.cbio.portal.scripts.CheckClickHouseConstraints` to report ClickHouse foreign-key and unique-key violations. The command reads database connection settings from `application.properties`.
+
+Run it directly with the built jar:
+```bash
+PORTAL_HOME=$(pwd) java -cp core-*.jar org.mskcc.cbio.portal.scripts.CheckClickHouseConstraints
+```
+
+Run it from the Docker image:
+```bash
+docker run --rm -it --network <docker-network> \
+  -v $(pwd)/application.properties:/application.properties:ro \
+  cbioportal-core \
+  bash -lc 'java -cp /core-*.jar org.mskcc.cbio.portal.scripts.CheckClickHouseConstraints'
+```
+
+Omit `--network <docker-network>` if the target database is reachable without joining a Docker network. The command exits with a non-zero status when violations are found.

--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ python scripts/importer/metaImport.py -s tests/test_data/study_es_0 -p tests/tes
 
 Use `org.mskcc.cbio.portal.scripts.CheckClickHouseConstraints` to report ClickHouse foreign-key and unique-key violations. The command reads database connection settings from `application.properties`.
 
+This checker is a standalone validation step. It is not run automatically as part of the normal `importer/metaImport.py` study import flow. Run it explicitly when you want to verify that the ClickHouse copy of the data is internally consistent after an import or ClickHouse refresh.
+
 Run it directly with the built jar:
 ```bash
 PORTAL_HOME=$(pwd) java -cp core-*.jar org.mskcc.cbio.portal.scripts.CheckClickHouseConstraints
@@ -195,3 +197,5 @@ docker run --rm -it --network <docker-network> \
 ```
 
 Omit `--network <docker-network>` if the target database is reachable without joining a Docker network. The command exits with a non-zero status when violations are found.
+
+If the checker fails, use the reported table/column pairs and sample values to determine whether the issue is caused by bad source data. If so, the typical recovery step is to fix the data and rerun the normal import process.

--- a/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseConstraintChecker.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseConstraintChecker.java
@@ -1,0 +1,629 @@
+package org.mskcc.cbio.portal.dao;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Generates and executes ClickHouse SQL that reports constraint violations
+ * (foreign keys and unique keys) for the cBioPortal ClickHouse schema.
+ * <p>
+ * Foreign-key output columns per violation row:
+ * referer_table, referer_columns, referer_values, referred_table, referred_columns
+ * <p>
+ * Unique-key output columns per violation row:
+ * table_name, key_columns, key_values, duplicate_count
+ * <p>
+ * Notes:
+ * - ClickHouse does not enforce FKs, so orphans are detected via LEFT JOIN + isNull().
+ * - Unique keys are detected via GROUP BY + HAVING count() > 1.
+ * - Table/column names are normalized to lower-case in the generated SQL.
+ * - Rows are checked only when all FK/unique-key columns are non-NULL.
+ * - "NULL" in referer/key values means the column value was NULL.
+ * <p>
+ * The constraint lists are hard-coded for the ClickHouse schema (see clickhouse_cgds.sql).
+ * Update {@link #schemaForeignKeys()} and {@link #schemaUniqueKeys()} when the schema changes.
+ */
+public class ClickHouseConstraintChecker {
+
+    public static final String REFERER_TABLE = "referer_table";
+    public static final String REFERER_COLUMNS = "referer_columns";
+    public static final String REFERER_VALUES = "referer_values";
+    public static final String REFERRED_TABLE = "referred_table";
+    public static final String REFERRED_COLUMNS = "referred_columns";
+
+    public static final String UNIQUE_TABLE = "table_name";
+    public static final String UNIQUE_COLUMNS = "key_columns";
+    public static final String UNIQUE_VALUES = "key_values";
+    public static final String UNIQUE_DUPLICATE_COUNT = "duplicate_count";
+
+    private static final String VALUE_SEPARATOR = "|";
+
+    private static final List<ForeignKey> SCHEMA_FOREIGN_KEYS = schemaForeignKeys();
+    private static final List<UniqueKey> SCHEMA_UNIQUE_KEYS = schemaUniqueKeys();
+    private static final String FOREIGN_KEY_MASTER_QUERY = generateMasterUnionQuery(
+            SCHEMA_FOREIGN_KEYS,
+            fk -> fk.childTable,
+            fk -> generateForeignKeyViolationSelect(fk, "c", "p")
+    );
+    private static final String UNIQUE_KEY_MASTER_QUERY = generateMasterUnionQuery(
+            SCHEMA_UNIQUE_KEYS,
+            uk -> uk.table,
+            uk -> generateUniqueKeyViolationSelect(uk, "t")
+    );
+
+    private ClickHouseConstraintChecker() {
+    }
+
+    public record ForeignKeyViolation(
+            String refererTable,
+            String refererColumns,
+            String refererValues,
+            String referredTable,
+            String referredColumns
+    ) {
+    }
+
+    public record UniqueKeyViolation(
+            String table,
+            String columns,
+            String keyValues,
+            long duplicateCount
+    ) {
+    }
+
+    public static List<ForeignKeyViolation> findForeignKeyViolations() throws DaoException {
+        return runQuery(FOREIGN_KEY_MASTER_QUERY, rs -> new ForeignKeyViolation(
+                rs.getString(REFERER_TABLE),
+                rs.getString(REFERER_COLUMNS),
+                rs.getString(REFERER_VALUES),
+                rs.getString(REFERRED_TABLE),
+                rs.getString(REFERRED_COLUMNS)
+        ));
+    }
+
+    public static List<UniqueKeyViolation> findUniqueKeyViolations() throws DaoException {
+        return runQuery(UNIQUE_KEY_MASTER_QUERY, rs -> new UniqueKeyViolation(
+                rs.getString(UNIQUE_TABLE),
+                rs.getString(UNIQUE_COLUMNS),
+                rs.getString(UNIQUE_VALUES),
+                rs.getLong(UNIQUE_DUPLICATE_COUNT)
+        ));
+    }
+
+    private interface ResultSetMapper<T> {
+        T map(ResultSet rs) throws SQLException;
+    }
+
+    private static <T> List<T> runQuery(String sql, ResultSetMapper<T> mapper) throws DaoException {
+        if (sql.isBlank()) {
+            return List.of();
+        }
+        List<T> results = new ArrayList<>();
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        ResultSet rs = null;
+        try {
+            con = JdbcUtil.getDbConnection(ClickHouseConstraintChecker.class);
+            pstmt = con.prepareStatement(sql);
+            rs = pstmt.executeQuery();
+            while (rs.next()) {
+                results.add(mapper.map(rs));
+            }
+            return results;
+        } catch (SQLException e) {
+            throw new DaoException(e);
+        } finally {
+            JdbcUtil.closeAll(ClickHouseConstraintChecker.class, con, pstmt, rs);
+        }
+    }
+
+    /**
+     * Represents one foreign-key relationship (supports composite keys).
+     */
+    private static final class ForeignKey {
+        private final String childTable;       // referer_table
+        private final List<String> childCols;   // referer_columns (possibly composite)
+        private final String parentTable;      // referred_table
+        private final List<String> parentCols; // referred_columns (same arity as childCols)
+
+        private ForeignKey(String childTable, List<String> childCols, String parentTable, List<String> parentCols) {
+            if (childCols.isEmpty() || parentCols.isEmpty()) {
+                throw new IllegalArgumentException("FK column list cannot be empty: " + childTable + " -> " + parentTable);
+            }
+            if (childCols.size() != parentCols.size()) {
+                throw new IllegalArgumentException("FK arity mismatch: childCols=" + childCols + " parentCols=" + parentCols);
+            }
+            this.childTable = childTable.toLowerCase(Locale.ROOT);
+            this.childCols = childCols.stream().map(s -> s.toLowerCase(Locale.ROOT)).toList();
+            this.parentTable = parentTable.toLowerCase(Locale.ROOT);
+            this.parentCols = parentCols.stream().map(s -> s.toLowerCase(Locale.ROOT)).toList();
+        }
+
+        private String childColsCsv() {
+            return String.join(",", childCols);
+        }
+
+        private String parentColsCsv() {
+            return String.join(",", parentCols);
+        }
+    }
+
+    /**
+     * Represents one unique-key constraint (supports composite keys).
+     */
+    private static final class UniqueKey {
+        private final String table;
+        private final List<String> columns;
+
+        private UniqueKey(String table, List<String> columns) {
+            if (columns.isEmpty()) {
+                throw new IllegalArgumentException("Unique key column list cannot be empty: " + table);
+            }
+            this.table = table.toLowerCase(Locale.ROOT);
+            this.columns = columns.stream().map(s -> s.toLowerCase(Locale.ROOT)).toList();
+        }
+
+        private String columnsCsv() {
+            return String.join(",", columns);
+        }
+    }
+
+    /**
+     * Foreign key list for the ClickHouse schema (lower-case names).
+     * Keep this in sync with clickhouse_cgds.sql.
+     */
+    private static List<ForeignKey> schemaForeignKeys() {
+        List<ForeignKey> fks = new ArrayList<>();
+
+        // cancer_study
+        fks.add(new ForeignKey("cancer_study", List.of("type_of_cancer_id"), "type_of_cancer", List.of("type_of_cancer_id")));
+        fks.add(new ForeignKey("cancer_study", List.of("reference_genome_id"), "reference_genome", List.of("reference_genome_id")));
+
+        // cancer_study_tags
+        fks.add(new ForeignKey("cancer_study_tags", List.of("cancer_study_id"), "cancer_study", List.of("cancer_study_id")));
+
+        // patient
+        fks.add(new ForeignKey("patient", List.of("cancer_study_id"), "cancer_study", List.of("cancer_study_id")));
+
+        // sample
+        fks.add(new ForeignKey("sample", List.of("patient_id"), "patient", List.of("internal_id")));
+
+        // sample_list
+        fks.add(new ForeignKey("sample_list", List.of("cancer_study_id"), "cancer_study", List.of("cancer_study_id")));
+
+        // sample_list_list (only sample_id has an FK in the ClickHouse DDL)
+        fks.add(new ForeignKey("sample_list_list", List.of("sample_id"), "sample", List.of("internal_id")));
+
+        // gene
+        fks.add(new ForeignKey("gene", List.of("genetic_entity_id"), "genetic_entity", List.of("id")));
+
+        // gene_alias
+        fks.add(new ForeignKey("gene_alias", List.of("entrez_gene_id"), "gene", List.of("entrez_gene_id")));
+
+        // geneset
+        fks.add(new ForeignKey("geneset", List.of("genetic_entity_id"), "genetic_entity", List.of("id")));
+
+        // geneset_gene
+        fks.add(new ForeignKey("geneset_gene", List.of("entrez_gene_id"), "gene", List.of("entrez_gene_id")));
+        fks.add(new ForeignKey("geneset_gene", List.of("geneset_id"), "geneset", List.of("id")));
+
+        // geneset_hierarchy_leaf
+        fks.add(new ForeignKey("geneset_hierarchy_leaf", List.of("node_id"), "geneset_hierarchy_node", List.of("node_id")));
+        fks.add(new ForeignKey("geneset_hierarchy_leaf", List.of("geneset_id"), "geneset", List.of("id")));
+
+        // generic_entity_properties
+        fks.add(new ForeignKey("generic_entity_properties", List.of("genetic_entity_id"), "genetic_entity", List.of("id")));
+
+        // genetic_profile
+        fks.add(new ForeignKey("genetic_profile", List.of("cancer_study_id"), "cancer_study", List.of("cancer_study_id")));
+
+        // genetic_profile_link
+        fks.add(new ForeignKey("genetic_profile_link", List.of("referring_genetic_profile_id"), "genetic_profile", List.of("genetic_profile_id")));
+        fks.add(new ForeignKey("genetic_profile_link", List.of("referred_genetic_profile_id"), "genetic_profile", List.of("genetic_profile_id")));
+
+        // genetic_alteration
+        fks.add(new ForeignKey("genetic_alteration", List.of("genetic_profile_id"), "genetic_profile", List.of("genetic_profile_id")));
+        fks.add(new ForeignKey("genetic_alteration", List.of("genetic_entity_id"), "genetic_entity", List.of("id")));
+
+        // genetic_profile_samples
+        fks.add(new ForeignKey("genetic_profile_samples", List.of("genetic_profile_id"), "genetic_profile", List.of("genetic_profile_id")));
+
+        // gene_panel_list
+        fks.add(new ForeignKey("gene_panel_list", List.of("internal_id"), "gene_panel", List.of("internal_id")));
+        fks.add(new ForeignKey("gene_panel_list", List.of("gene_id"), "gene", List.of("entrez_gene_id")));
+
+        // sample_profile
+        fks.add(new ForeignKey("sample_profile", List.of("genetic_profile_id"), "genetic_profile", List.of("genetic_profile_id")));
+        fks.add(new ForeignKey("sample_profile", List.of("sample_id"), "sample", List.of("internal_id")));
+        fks.add(new ForeignKey("sample_profile", List.of("panel_id"), "gene_panel", List.of("internal_id")));
+
+        // structural_variant
+        fks.add(new ForeignKey("structural_variant", List.of("sample_id"), "sample", List.of("internal_id")));
+        fks.add(new ForeignKey("structural_variant", List.of("site1_entrez_gene_id"), "gene", List.of("entrez_gene_id")));
+        fks.add(new ForeignKey("structural_variant", List.of("site2_entrez_gene_id"), "gene", List.of("entrez_gene_id")));
+        fks.add(new ForeignKey("structural_variant", List.of("genetic_profile_id"), "genetic_profile", List.of("genetic_profile_id")));
+
+        // alteration_driver_annotation
+        fks.add(new ForeignKey("alteration_driver_annotation", List.of("genetic_profile_id"), "genetic_profile", List.of("genetic_profile_id")));
+        fks.add(new ForeignKey("alteration_driver_annotation", List.of("sample_id"), "sample", List.of("internal_id")));
+
+        // mutation_event
+        fks.add(new ForeignKey("mutation_event", List.of("entrez_gene_id"), "gene", List.of("entrez_gene_id")));
+
+        // mutation
+        fks.add(new ForeignKey("mutation", List.of("mutation_event_id"), "mutation_event", List.of("mutation_event_id")));
+        fks.add(new ForeignKey("mutation", List.of("entrez_gene_id"), "gene", List.of("entrez_gene_id")));
+        fks.add(new ForeignKey("mutation", List.of("genetic_profile_id"), "genetic_profile", List.of("genetic_profile_id")));
+        fks.add(new ForeignKey("mutation", List.of("sample_id"), "sample", List.of("internal_id")));
+
+        // mutation_count_by_keyword
+        fks.add(new ForeignKey("mutation_count_by_keyword", List.of("genetic_profile_id"), "genetic_profile", List.of("genetic_profile_id")));
+        fks.add(new ForeignKey("mutation_count_by_keyword", List.of("entrez_gene_id"), "gene", List.of("entrez_gene_id")));
+
+        // clinical_patient / clinical_sample
+        fks.add(new ForeignKey("clinical_patient", List.of("internal_id"), "patient", List.of("internal_id")));
+        fks.add(new ForeignKey("clinical_sample", List.of("internal_id"), "sample", List.of("internal_id")));
+
+        // clinical_attribute_meta
+        fks.add(new ForeignKey("clinical_attribute_meta", List.of("cancer_study_id"), "cancer_study", List.of("cancer_study_id")));
+
+        // mut_sig
+        fks.add(new ForeignKey("mut_sig", List.of("cancer_study_id"), "cancer_study", List.of("cancer_study_id")));
+        fks.add(new ForeignKey("mut_sig", List.of("entrez_gene_id"), "gene", List.of("entrez_gene_id")));
+
+        // gistic / gistic_to_gene
+        fks.add(new ForeignKey("gistic", List.of("cancer_study_id"), "cancer_study", List.of("cancer_study_id")));
+        fks.add(new ForeignKey("gistic_to_gene", List.of("entrez_gene_id"), "gene", List.of("entrez_gene_id")));
+        fks.add(new ForeignKey("gistic_to_gene", List.of("gistic_roi_id"), "gistic", List.of("gistic_roi_id")));
+
+        // cna_event / sample_cna_event
+        fks.add(new ForeignKey("cna_event", List.of("entrez_gene_id"), "gene", List.of("entrez_gene_id")));
+        fks.add(new ForeignKey("sample_cna_event", List.of("cna_event_id"), "cna_event", List.of("cna_event_id")));
+        fks.add(new ForeignKey("sample_cna_event", List.of("genetic_profile_id"), "genetic_profile", List.of("genetic_profile_id")));
+        fks.add(new ForeignKey("sample_cna_event", List.of("sample_id"), "sample", List.of("internal_id")));
+
+        // copy_number_seg / copy_number_seg_file
+        fks.add(new ForeignKey("copy_number_seg", List.of("cancer_study_id"), "cancer_study", List.of("cancer_study_id")));
+        fks.add(new ForeignKey("copy_number_seg", List.of("sample_id"), "sample", List.of("internal_id")));
+        fks.add(new ForeignKey("copy_number_seg_file", List.of("cancer_study_id"), "cancer_study", List.of("cancer_study_id")));
+
+        // clinical_event / clinical_event_data
+        fks.add(new ForeignKey("clinical_event", List.of("patient_id"), "patient", List.of("internal_id")));
+        fks.add(new ForeignKey("clinical_event_data", List.of("clinical_event_id"), "clinical_event", List.of("clinical_event_id")));
+
+        // reference_genome_gene
+        fks.add(new ForeignKey("reference_genome_gene", List.of("reference_genome_id"), "reference_genome", List.of("reference_genome_id")));
+        fks.add(new ForeignKey("reference_genome_gene", List.of("entrez_gene_id"), "gene", List.of("entrez_gene_id")));
+
+        // data_access_tokens
+        fks.add(new ForeignKey("data_access_tokens", List.of("username"), "users", List.of("email")));
+
+        // allele_specific_copy_number
+        fks.add(new ForeignKey("allele_specific_copy_number", List.of("mutation_event_id"), "mutation_event", List.of("mutation_event_id")));
+        fks.add(new ForeignKey("allele_specific_copy_number", List.of("genetic_profile_id"), "genetic_profile", List.of("genetic_profile_id")));
+        fks.add(new ForeignKey("allele_specific_copy_number", List.of("sample_id"), "sample", List.of("internal_id")));
+
+        // resource_definition
+        fks.add(new ForeignKey("resource_definition", List.of("cancer_study_id"), "cancer_study", List.of("cancer_study_id")));
+
+        // resource_sample / resource_patient / resource_study
+        fks.add(new ForeignKey("resource_sample", List.of("internal_id"), "sample", List.of("internal_id")));
+        fks.add(new ForeignKey("resource_patient", List.of("internal_id"), "patient", List.of("internal_id")));
+        fks.add(new ForeignKey("resource_study", List.of("internal_id"), "cancer_study", List.of("cancer_study_id")));
+
+        return List.copyOf(fks);
+    }
+
+    /**
+     * Unique key list for the ClickHouse schema (lower-case names).
+     * Keep this in sync with clickhouse_cgds.sql.
+     */
+    private static List<UniqueKey> schemaUniqueKeys() {
+        List<UniqueKey> uniqueKeys = new ArrayList<>();
+
+        // type_of_cancer
+        uniqueKeys.add(new UniqueKey("type_of_cancer", List.of("type_of_cancer_id")));
+
+        // reference_genome
+        uniqueKeys.add(new UniqueKey("reference_genome", List.of("reference_genome_id")));
+        uniqueKeys.add(new UniqueKey("reference_genome", List.of("build_name")));
+
+        // cancer_study
+        uniqueKeys.add(new UniqueKey("cancer_study", List.of("cancer_study_id")));
+        uniqueKeys.add(new UniqueKey("cancer_study", List.of("cancer_study_identifier")));
+
+        // cancer_study_tags
+        uniqueKeys.add(new UniqueKey("cancer_study_tags", List.of("cancer_study_id")));
+
+        // users
+        uniqueKeys.add(new UniqueKey("users", List.of("email")));
+
+        // patient
+        uniqueKeys.add(new UniqueKey("patient", List.of("internal_id")));
+
+        // sample
+        uniqueKeys.add(new UniqueKey("sample", List.of("internal_id")));
+
+        // sample_list
+        uniqueKeys.add(new UniqueKey("sample_list", List.of("list_id")));
+        uniqueKeys.add(new UniqueKey("sample_list", List.of("stable_id")));
+
+        // sample_list_list
+        uniqueKeys.add(new UniqueKey("sample_list_list", List.of("list_id", "sample_id")));
+
+        // genetic_entity
+        uniqueKeys.add(new UniqueKey("genetic_entity", List.of("id")));
+
+        // gene
+        uniqueKeys.add(new UniqueKey("gene", List.of("entrez_gene_id")));
+        uniqueKeys.add(new UniqueKey("gene", List.of("genetic_entity_id")));
+
+        // gene_alias
+        uniqueKeys.add(new UniqueKey("gene_alias", List.of("entrez_gene_id", "gene_alias")));
+
+        // geneset
+        uniqueKeys.add(new UniqueKey("geneset", List.of("id")));
+        uniqueKeys.add(new UniqueKey("geneset", List.of("name")));
+        uniqueKeys.add(new UniqueKey("geneset", List.of("external_id")));
+        uniqueKeys.add(new UniqueKey("geneset", List.of("genetic_entity_id")));
+
+        // geneset_gene
+        uniqueKeys.add(new UniqueKey("geneset_gene", List.of("geneset_id", "entrez_gene_id")));
+
+        // geneset_hierarchy_node
+        uniqueKeys.add(new UniqueKey("geneset_hierarchy_node", List.of("node_id")));
+        uniqueKeys.add(new UniqueKey("geneset_hierarchy_node", List.of("node_name", "parent_id")));
+
+        // geneset_hierarchy_leaf
+        uniqueKeys.add(new UniqueKey("geneset_hierarchy_leaf", List.of("node_id", "geneset_id")));
+
+        // generic_entity_properties
+        uniqueKeys.add(new UniqueKey("generic_entity_properties", List.of("id")));
+        uniqueKeys.add(new UniqueKey("generic_entity_properties", List.of("genetic_entity_id", "name")));
+
+        // genetic_profile
+        uniqueKeys.add(new UniqueKey("genetic_profile", List.of("genetic_profile_id")));
+        uniqueKeys.add(new UniqueKey("genetic_profile", List.of("stable_id")));
+
+        // genetic_profile_link
+        uniqueKeys.add(new UniqueKey("genetic_profile_link", List.of("referring_genetic_profile_id", "referred_genetic_profile_id")));
+
+        // genetic_alteration
+        uniqueKeys.add(new UniqueKey("genetic_alteration", List.of("genetic_profile_id", "genetic_entity_id")));
+
+        // gene_panel
+        uniqueKeys.add(new UniqueKey("gene_panel", List.of("internal_id")));
+        uniqueKeys.add(new UniqueKey("gene_panel", List.of("stable_id")));
+
+        // gene_panel_list
+        uniqueKeys.add(new UniqueKey("gene_panel_list", List.of("internal_id", "gene_id")));
+
+        // genetic_profile_samples
+        uniqueKeys.add(new UniqueKey("genetic_profile_samples", List.of("genetic_profile_id")));
+
+        // sample_profile
+        uniqueKeys.add(new UniqueKey("sample_profile", List.of("sample_id", "genetic_profile_id")));
+
+        // structural_variant
+        uniqueKeys.add(new UniqueKey("structural_variant", List.of("internal_id")));
+
+        // alteration_driver_annotation
+        uniqueKeys.add(new UniqueKey("alteration_driver_annotation", List.of("alteration_event_id", "genetic_profile_id", "sample_id")));
+
+        // mutation_event
+        uniqueKeys.add(new UniqueKey("mutation_event", List.of("mutation_event_id")));
+
+        // mutation
+        uniqueKeys.add(new UniqueKey("mutation", List.of("mutation_event_id", "genetic_profile_id", "sample_id")));
+
+        // clinical_patient / clinical_sample
+        uniqueKeys.add(new UniqueKey("clinical_patient", List.of("internal_id", "attr_id")));
+        uniqueKeys.add(new UniqueKey("clinical_sample", List.of("internal_id", "attr_id")));
+
+        // clinical_attribute_meta
+        uniqueKeys.add(new UniqueKey("clinical_attribute_meta", List.of("attr_id", "cancer_study_id")));
+
+        // mut_sig
+        uniqueKeys.add(new UniqueKey("mut_sig", List.of("cancer_study_id", "entrez_gene_id")));
+
+        // gistic / gistic_to_gene
+        uniqueKeys.add(new UniqueKey("gistic", List.of("gistic_roi_id")));
+        uniqueKeys.add(new UniqueKey("gistic_to_gene", List.of("gistic_roi_id", "entrez_gene_id")));
+
+        // cna_event
+        uniqueKeys.add(new UniqueKey("cna_event", List.of("cna_event_id")));
+        uniqueKeys.add(new UniqueKey("cna_event", List.of("entrez_gene_id", "alteration")));
+
+        // sample_cna_event
+        uniqueKeys.add(new UniqueKey("sample_cna_event", List.of("cna_event_id", "sample_id", "genetic_profile_id")));
+
+        // copy_number_seg / copy_number_seg_file
+        uniqueKeys.add(new UniqueKey("copy_number_seg", List.of("seg_id")));
+        uniqueKeys.add(new UniqueKey("copy_number_seg_file", List.of("seg_file_id")));
+
+        // clinical_event
+        uniqueKeys.add(new UniqueKey("clinical_event", List.of("clinical_event_id")));
+
+        // reference_genome_gene
+        uniqueKeys.add(new UniqueKey("reference_genome_gene", List.of("entrez_gene_id", "reference_genome_id")));
+
+        // data_access_tokens
+        uniqueKeys.add(new UniqueKey("data_access_tokens", List.of("token")));
+
+        // resource_definition
+        uniqueKeys.add(new UniqueKey("resource_definition", List.of("resource_id", "cancer_study_id")));
+
+        // resource_sample / resource_patient / resource_study
+        uniqueKeys.add(new UniqueKey("resource_sample", List.of("internal_id", "resource_id", "url")));
+        uniqueKeys.add(new UniqueKey("resource_patient", List.of("internal_id", "resource_id", "url")));
+        uniqueKeys.add(new UniqueKey("resource_study", List.of("internal_id", "resource_id", "url")));
+
+        // allele_specific_copy_number
+        uniqueKeys.add(new UniqueKey("allele_specific_copy_number", List.of("mutation_event_id", "genetic_profile_id", "sample_id")));
+
+        return List.copyOf(uniqueKeys);
+    }
+
+    /**
+     * Builds a ClickHouse SELECT that returns one row per orphaned FK value.
+     */
+    private static String generateForeignKeyViolationSelect(ForeignKey fk, String childAlias, String parentAlias) {
+        String joinPredicate = buildJoinPredicate(fk, childAlias, parentAlias);
+        String childHasAllValues = buildAllNotNullPredicate(fk.childCols, childAlias);
+        String parentMissing = buildAllNullPredicate(fk.parentCols, parentAlias);
+        String valuesExpr = buildKeyValuesExpression(fk.childCols, childAlias);
+
+        return ""
+                + "SELECT\n"
+                + "  '" + fk.childTable + "' AS " + REFERER_TABLE + ",\n"
+                + "  '" + fk.childColsCsv() + "' AS " + REFERER_COLUMNS + ",\n"
+                + "  " + valuesExpr + " AS " + REFERER_VALUES + ",\n"
+                + "  '" + fk.parentTable + "' AS " + REFERRED_TABLE + ",\n"
+                + "  '" + fk.parentColsCsv() + "' AS " + REFERRED_COLUMNS + "\n"
+                + "FROM " + fk.childTable + " " + childAlias + "\n"
+                + "LEFT JOIN " + fk.parentTable + " " + parentAlias + "\n"
+                + "  ON " + joinPredicate + "\n"
+                + "WHERE " + childHasAllValues + "\n"
+                + "  AND " + parentMissing;
+    }
+
+    /**
+     * Builds a ClickHouse SELECT that returns one row per duplicated unique-key value.
+     */
+    private static String generateUniqueKeyViolationSelect(UniqueKey uniqueKey, String tableAlias) {
+        String allNotNull = buildAllNotNullPredicate(uniqueKey.columns, tableAlias);
+        String valuesExpr = buildKeyValuesExpression(uniqueKey.columns, tableAlias);
+        String groupBy = buildColumnReferenceList(uniqueKey.columns, tableAlias);
+
+        return ""
+                + "SELECT\n"
+                + "  '" + uniqueKey.table + "' AS " + UNIQUE_TABLE + ",\n"
+                + "  '" + uniqueKey.columnsCsv() + "' AS " + UNIQUE_COLUMNS + ",\n"
+                + "  " + valuesExpr + " AS " + UNIQUE_VALUES + ",\n"
+                + "  count() AS " + UNIQUE_DUPLICATE_COUNT + "\n"
+                + "FROM " + uniqueKey.table + " " + tableAlias + "\n"
+                + "WHERE " + allNotNull + "\n"
+                + "GROUP BY " + groupBy + "\n"
+                + "HAVING count() > 1";
+    }
+
+    /**
+     * Generates one master UNION ALL query for a list of constraints.
+     */
+    private static <T> String generateMasterUnionQuery(
+            List<T> constraints,
+            Function<T, String> tableExtractor,
+            Function<T, String> selectBuilder
+    ) {
+        if (constraints.isEmpty()) {
+            return "";
+        }
+        Map<String, List<T>> byTable = constraints.stream()
+                .collect(Collectors.groupingBy(tableExtractor, LinkedHashMap::new, Collectors.toList()));
+
+        List<String> blocks = new ArrayList<>();
+        for (Map.Entry<String, List<T>> e : byTable.entrySet()) {
+            String table = e.getKey();
+            List<T> entries = e.getValue();
+
+            List<String> selects = new ArrayList<>();
+            for (T entry : entries) {
+                selects.add(selectBuilder.apply(entry));
+            }
+            String union = String.join("\nUNION ALL\n", selects);
+            blocks.add("-- ===============================\n"
+                    + "-- table: " + table + "\n"
+                    + "-- ===============================\n"
+                    + union + ";\n");
+        }
+
+        List<String> blockSelects = blocks.stream()
+                .map(s -> s.replaceAll(";\\s*$", ""))
+                .toList();
+        return String.join("\nUNION ALL\n", blockSelects) + ";\n";
+    }
+
+// -------------------------
+// Helpers
+// -------------------------
+
+    private static String buildJoinPredicate(ForeignKey fk, String childAlias, String parentAlias) {
+        return zip(fk.childCols, fk.parentCols).stream()
+                .map(pair -> childAlias + "." + quote(pair.left) + " = " + parentAlias + "." + quote(pair.right))
+                .collect(Collectors.joining(" AND "));
+    }
+
+    private static String buildAllNotNullPredicate(List<String> columns, String tableAlias) {
+        return columns.stream()
+                .map(col -> "NOT isNull(" + tableAlias + "." + quote(col) + ")")
+                .collect(Collectors.joining(" AND ", "(", ")"));
+    }
+
+    private static String buildAllNullPredicate(List<String> columns, String tableAlias) {
+        return columns.stream()
+                .map(col -> "isNull(" + tableAlias + "." + quote(col) + ")")
+                .collect(Collectors.joining(" AND ", "(", ")"));
+    }
+
+    /**
+     * Builds the key-values expression, joining values with '|' and rendering NULL as "NULL".
+     */
+    private static String buildKeyValuesExpression(List<String> columns, String tableAlias) {
+        List<String> values = columns.stream()
+                .map(col -> "ifNull(toString(" + tableAlias + "." + quote(col) + "), 'NULL')")
+                .toList();
+        return buildDelimitedConcat(values, VALUE_SEPARATOR);
+    }
+
+    private static String buildDelimitedConcat(List<String> args, String separatorLiteral) {
+        if (args.isEmpty()) {
+            throw new IllegalArgumentException("Cannot build concatenation for empty argument list.");
+        }
+        if (args.size() == 1) {
+            return args.get(0);
+        }
+        StringBuilder sb = new StringBuilder("concat(");
+        for (int i = 0; i < args.size(); i++) {
+            if (i > 0) {
+                sb.append(", '").append(separatorLiteral).append("', ");
+            }
+            sb.append(args.get(i));
+        }
+        sb.append(")");
+        return sb.toString();
+    }
+
+    private static String buildColumnReferenceList(List<String> columns, String tableAlias) {
+        return columns.stream()
+                .map(col -> tableAlias + "." + quote(col))
+                .collect(Collectors.joining(", "));
+    }
+
+    private static String quote(String identifier) {
+        // ClickHouse supports backticks for identifiers; safe for reserved words.
+        return "`" + identifier.replace("`", "``") + "`";
+    }
+
+    private record Pair(String left, String right) {
+    }
+
+    private static List<Pair> zip(List<String> a, List<String> b) {
+        if (a.size() != b.size()) {
+            throw new IllegalArgumentException("Mismatched list sizes: " + a.size() + " vs " + b.size());
+        }
+        List<Pair> out = new ArrayList<>();
+        for (int i = 0; i < a.size(); i++) {
+            out.add(new Pair(a.get(i), b.get(i)));
+        }
+        return out;
+    }
+}

--- a/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseReferentialIntegrityChecker.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseReferentialIntegrityChecker.java
@@ -1,0 +1,40 @@
+package org.mskcc.cbio.portal.dao;
+
+import java.util.List;
+
+/**
+ * @deprecated Use {@link ClickHouseConstraintChecker} for ClickHouse constraint checks.
+ */
+@Deprecated
+public class ClickHouseReferentialIntegrityChecker {
+
+    public static final String REFERER_TABLE = ClickHouseConstraintChecker.REFERER_TABLE;
+    public static final String REFERER_COLUMNS = ClickHouseConstraintChecker.REFERER_COLUMNS;
+    public static final String REFERER_VALUES = ClickHouseConstraintChecker.REFERER_VALUES;
+    public static final String REFERRED_TABLE = ClickHouseConstraintChecker.REFERRED_TABLE;
+    public static final String REFERRED_COLUMNS = ClickHouseConstraintChecker.REFERRED_COLUMNS;
+
+    private ClickHouseReferentialIntegrityChecker() {
+    }
+
+    public record ReferenceViolation(
+            String refererTable,
+            String refererColumns,
+            String refererValues,
+            String referredTable,
+            String referredColumns
+    ) {
+    }
+
+    public static List<ReferenceViolation> findReferenceViolations() throws DaoException {
+        return ClickHouseConstraintChecker.findForeignKeyViolations().stream()
+                .map(v -> new ReferenceViolation(
+                        v.refererTable(),
+                        v.refererColumns(),
+                        v.refererValues(),
+                        v.referredTable(),
+                        v.referredColumns()
+                ))
+                .toList();
+    }
+}

--- a/src/main/java/org/mskcc/cbio/portal/scripts/CheckClickHouseConstraints.java
+++ b/src/main/java/org/mskcc/cbio/portal/scripts/CheckClickHouseConstraints.java
@@ -1,0 +1,179 @@
+package org.mskcc.cbio.portal.scripts;
+
+import org.mskcc.cbio.portal.dao.ClickHouseConstraintChecker;
+import org.mskcc.cbio.portal.dao.ClickHouseConstraintChecker.ForeignKeyViolation;
+import org.mskcc.cbio.portal.dao.ClickHouseConstraintChecker.UniqueKeyViolation;
+import org.mskcc.cbio.portal.dao.DaoException;
+import org.mskcc.cbio.portal.util.ConsoleUtil;
+import org.mskcc.cbio.portal.util.ProgressMonitor;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Checks ClickHouse foreign-key and unique-key constraints for the portal schema.
+ */
+public class CheckClickHouseConstraints extends ConsoleRunnable {
+
+    private static final int SAMPLE_VALUE_LIMIT = 5;
+
+    private record ForeignKeyGroupKey(
+            String refererTable,
+            String refererColumns,
+            String referredTable,
+            String referredColumns
+    ) {
+    }
+
+    private static final class ForeignKeyGroup {
+        private int totalCount;
+        private final List<String> sampleValues = new ArrayList<>();
+
+        private void add(String refererValue) {
+            totalCount++;
+            if (sampleValues.size() < SAMPLE_VALUE_LIMIT && !sampleValues.contains(refererValue)) {
+                sampleValues.add(refererValue);
+            }
+        }
+    }
+
+    private record UniqueKeyGroupKey(
+            String table,
+            String columns
+    ) {
+    }
+
+    private static final class UniqueKeyGroup {
+        private int totalKeyValues;
+        private long totalRowCount;
+        private final List<String> sampleValues = new ArrayList<>();
+
+        private void add(UniqueKeyViolation violation) {
+            totalKeyValues++;
+            totalRowCount += violation.duplicateCount();
+            String sample = formatUniqueSample(violation);
+            if (sampleValues.size() < SAMPLE_VALUE_LIMIT && !sampleValues.contains(sample)) {
+                sampleValues.add(sample);
+            }
+        }
+    }
+
+    @Override
+    public void run() {
+        ProgressMonitor.setCurrentMessage("Checking ClickHouse constraints...");
+        try {
+            List<ForeignKeyViolation> foreignKeyViolations = ClickHouseConstraintChecker.findForeignKeyViolations();
+            List<UniqueKeyViolation> uniqueKeyViolations = ClickHouseConstraintChecker.findUniqueKeyViolations();
+
+            if (foreignKeyViolations.isEmpty() && uniqueKeyViolations.isEmpty()) {
+                ProgressMonitor.setCurrentMessage("No ClickHouse constraint violations found.");
+            } else {
+                Map<ForeignKeyGroupKey, ForeignKeyGroup> fkGroups = groupForeignKeyViolations(foreignKeyViolations);
+                Map<UniqueKeyGroupKey, UniqueKeyGroup> uniqueGroups = groupUniqueKeyViolations(uniqueKeyViolations);
+                ProgressMonitor.setCurrentMessage(String.format(
+                        Locale.ROOT,
+                        "ClickHouse constraint violations found: %d foreign-key rows across %d relationships; %d unique-key groups across %d constraints.",
+                        foreignKeyViolations.size(),
+                        fkGroups.size(),
+                        uniqueKeyViolations.size(),
+                        uniqueGroups.size()
+                ));
+
+                for (var entry : fkGroups.entrySet()) {
+                    ProgressMonitor.logWarning(formatForeignKeyGroup(entry.getKey(), entry.getValue()));
+                }
+                for (var entry : uniqueGroups.entrySet()) {
+                    ProgressMonitor.logWarning(formatUniqueKeyGroup(entry.getKey(), entry.getValue()));
+                }
+                ConsoleUtil.showWarnings();
+                System.exit(1);
+            }
+        } catch (DaoException e) {
+            throw new RuntimeException("Failed to check ClickHouse constraints.", e);
+        }
+        ProgressMonitor.setCurrentMessage("Done.");
+    }
+
+    private static Map<ForeignKeyGroupKey, ForeignKeyGroup> groupForeignKeyViolations(List<ForeignKeyViolation> violations) {
+        Map<ForeignKeyGroupKey, ForeignKeyGroup> grouped = new LinkedHashMap<>();
+        for (ForeignKeyViolation violation : violations) {
+            ForeignKeyGroupKey key = new ForeignKeyGroupKey(
+                    violation.refererTable(),
+                    violation.refererColumns(),
+                    violation.referredTable(),
+                    violation.referredColumns()
+            );
+            grouped.computeIfAbsent(key, unused -> new ForeignKeyGroup()).add(violation.refererValues());
+        }
+        return grouped;
+    }
+
+    private static Map<UniqueKeyGroupKey, UniqueKeyGroup> groupUniqueKeyViolations(List<UniqueKeyViolation> violations) {
+        Map<UniqueKeyGroupKey, UniqueKeyGroup> grouped = new LinkedHashMap<>();
+        for (UniqueKeyViolation violation : violations) {
+            UniqueKeyGroupKey key = new UniqueKeyGroupKey(
+                    violation.table(),
+                    violation.columns()
+            );
+            grouped.computeIfAbsent(key, unused -> new UniqueKeyGroup()).add(violation);
+        }
+        return grouped;
+    }
+
+    private static String formatForeignKeyGroup(ForeignKeyGroupKey key, ForeignKeyGroup group) {
+        String sampleText = group.sampleValues.isEmpty()
+                ? "No sample values captured."
+                : String.join(", ", group.sampleValues);
+        int remainingCount = Math.max(0, group.totalCount - group.sampleValues.size());
+        String remainingText = remainingCount > 0
+                ? " (+" + remainingCount + " more)"
+                : "";
+        return String.format(
+                Locale.ROOT,
+                "Table %s (columns: %s) has %d values that do not exist in table %s (columns: %s). Examples: %s%s.",
+                key.refererTable(),
+                key.refererColumns(),
+                group.totalCount,
+                key.referredTable(),
+                key.referredColumns(),
+                sampleText,
+                remainingText
+        );
+    }
+
+    private static String formatUniqueSample(UniqueKeyViolation violation) {
+        return violation.keyValues() + " (count=" + violation.duplicateCount() + ")";
+    }
+
+    private static String formatUniqueKeyGroup(UniqueKeyGroupKey key, UniqueKeyGroup group) {
+        String sampleText = group.sampleValues.isEmpty()
+                ? "No sample values captured."
+                : String.join(", ", group.sampleValues);
+        int remainingCount = Math.max(0, group.totalKeyValues - group.sampleValues.size());
+        String remainingText = remainingCount > 0
+                ? " (+" + remainingCount + " more)"
+                : "";
+        return String.format(
+                Locale.ROOT,
+                "Table %s (columns: %s) has %d duplicated keys across %d rows. Examples: %s%s.",
+                key.table(),
+                key.columns(),
+                group.totalKeyValues,
+                group.totalRowCount,
+                sampleText,
+                remainingText
+        );
+    }
+
+    public CheckClickHouseConstraints(String[] args) {
+        super(args);
+    }
+
+    public static void main(String[] args) {
+        ConsoleRunnable runner = new CheckClickHouseConstraints(args);
+        runner.runInConsole();
+    }
+}

--- a/src/test/java/org/mskcc/cbio/portal/integrationTest/dao/TestClickHouseConstraintChecker.java
+++ b/src/test/java/org/mskcc/cbio/portal/integrationTest/dao/TestClickHouseConstraintChecker.java
@@ -1,0 +1,277 @@
+package org.mskcc.cbio.portal.integrationTest.dao;
+
+import org.junit.Test;
+import org.mskcc.cbio.portal.dao.ClickHouseConstraintChecker;
+import org.mskcc.cbio.portal.dao.ClickHouseConstraintChecker.ForeignKeyViolation;
+import org.mskcc.cbio.portal.dao.ClickHouseConstraintChecker.UniqueKeyViolation;
+import org.mskcc.cbio.portal.dao.JdbcUtil;
+import org.mskcc.cbio.portal.integrationTest.IntegrationTestBase;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertTrue;
+
+public class TestClickHouseConstraintChecker extends IntegrationTestBase {
+
+    private static final String FK_VIOLATIONS_SQL = "clickhouse_fk_violations.sql";
+    private static final String UNIQUE_VIOLATIONS_SQL = "clickhouse_unique_violations.sql";
+
+    @Test
+    public void testForeignKeyViolations() throws Exception {
+        applySqlResource(FK_VIOLATIONS_SQL, List.of());
+
+        List<ForeignKeyViolation> violations = ClickHouseConstraintChecker.findForeignKeyViolations();
+        Set<String> actual = new LinkedHashSet<>();
+        for (ForeignKeyViolation violation : violations) {
+            actual.add(fkKey(
+                    violation.refererTable(),
+                    violation.refererColumns(),
+                    violation.referredTable(),
+                    violation.referredColumns()));
+        }
+
+        Set<String> expected = expectedForeignKeyConstraints();
+        Set<String> missing = new LinkedHashSet<>(expected);
+        missing.removeAll(actual);
+        assertTrue("Missing foreign-key violations: " + missing, missing.isEmpty());
+    }
+
+    @Test
+    public void testUniqueKeyViolations() throws Exception {
+        // ReplacingMergeTree tables can collapse duplicate keys during merges.
+        setMergesEnabled(false);
+        try {
+            applySqlResource(UNIQUE_VIOLATIONS_SQL, List.of("SET optimize_on_insert = 0"));
+
+            List<UniqueKeyViolation> violations = ClickHouseConstraintChecker.findUniqueKeyViolations();
+            Set<String> actual = new LinkedHashSet<>();
+            for (UniqueKeyViolation violation : violations) {
+                actual.add(ukKey(violation.table(), violation.columns()));
+            }
+
+            Set<String> expected = expectedUniqueKeyConstraints();
+            Set<String> missing = new LinkedHashSet<>(expected);
+            missing.removeAll(actual);
+            assertTrue("Missing unique-key violations: " + missing, missing.isEmpty());
+        } finally {
+            setMergesEnabled(true);
+        }
+    }
+
+    private static void applySqlResource(String resourceName) throws Exception {
+        applySqlResource(resourceName, List.of());
+    }
+
+    private static void applySqlResource(String resourceName, List<String> preludeStatements) throws Exception {
+        String sql = readResource(resourceName);
+        List<String> statements = splitStatements(sql);
+        if (statements.isEmpty()) {
+            throw new IllegalStateException("No SQL statements found in " + resourceName);
+        }
+        try (Connection connection = JdbcUtil.getDbConnection(TestClickHouseConstraintChecker.class);
+             Statement statement = connection.createStatement()) {
+            for (String prelude : preludeStatements) {
+                statement.execute(prelude);
+            }
+            for (String sqlStatement : statements) {
+                statement.execute(sqlStatement);
+            }
+        }
+    }
+
+    private static void setMergesEnabled(boolean enabled) throws Exception {
+        String command = enabled ? "SYSTEM START MERGES" : "SYSTEM STOP MERGES";
+        try (Connection connection = JdbcUtil.getDbConnection(TestClickHouseConstraintChecker.class);
+             Statement statement = connection.createStatement()) {
+            statement.execute(command);
+        }
+    }
+
+    private static String readResource(String resourceName) throws IOException {
+        try (InputStream input = TestClickHouseConstraintChecker.class.getClassLoader()
+                .getResourceAsStream(resourceName)) {
+            if (input == null) {
+                throw new IllegalStateException("Resource not found: " + resourceName);
+            }
+            return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private static List<String> splitStatements(String sql) {
+        StringBuilder cleaned = new StringBuilder();
+        String[] lines = sql.split("\\R");
+        for (String line : lines) {
+            String trimmed = line.trim();
+            if (trimmed.isEmpty() || trimmed.startsWith("--")) {
+                continue;
+            }
+            cleaned.append(line).append('\n');
+        }
+        List<String> statements = new ArrayList<>();
+        for (String statement : cleaned.toString().split(";")) {
+            String trimmed = statement.trim();
+            if (!trimmed.isEmpty()) {
+                statements.add(trimmed);
+            }
+        }
+        return statements;
+    }
+
+    private static String fkKey(String childTable, String childCols, String parentTable, String parentCols) {
+        return childTable + "|" + childCols + "|" + parentTable + "|" + parentCols;
+    }
+
+    private static String ukKey(String table, String columns) {
+        return table + "|" + columns;
+    }
+
+    private static Set<String> expectedForeignKeyConstraints() {
+        Set<String> keys = new LinkedHashSet<>();
+        addFk(keys, "cancer_study", "type_of_cancer_id", "type_of_cancer", "type_of_cancer_id");
+        addFk(keys, "cancer_study", "reference_genome_id", "reference_genome", "reference_genome_id");
+        addFk(keys, "cancer_study_tags", "cancer_study_id", "cancer_study", "cancer_study_id");
+        addFk(keys, "patient", "cancer_study_id", "cancer_study", "cancer_study_id");
+        addFk(keys, "sample", "patient_id", "patient", "internal_id");
+        addFk(keys, "sample_list", "cancer_study_id", "cancer_study", "cancer_study_id");
+        addFk(keys, "sample_list_list", "sample_id", "sample", "internal_id");
+        addFk(keys, "gene", "genetic_entity_id", "genetic_entity", "id");
+        addFk(keys, "gene_alias", "entrez_gene_id", "gene", "entrez_gene_id");
+        addFk(keys, "geneset", "genetic_entity_id", "genetic_entity", "id");
+        addFk(keys, "geneset_gene", "entrez_gene_id", "gene", "entrez_gene_id");
+        addFk(keys, "geneset_gene", "geneset_id", "geneset", "id");
+        addFk(keys, "geneset_hierarchy_leaf", "node_id", "geneset_hierarchy_node", "node_id");
+        addFk(keys, "geneset_hierarchy_leaf", "geneset_id", "geneset", "id");
+        addFk(keys, "generic_entity_properties", "genetic_entity_id", "genetic_entity", "id");
+        addFk(keys, "genetic_profile", "cancer_study_id", "cancer_study", "cancer_study_id");
+        addFk(keys, "genetic_profile_link", "referring_genetic_profile_id", "genetic_profile", "genetic_profile_id");
+        addFk(keys, "genetic_profile_link", "referred_genetic_profile_id", "genetic_profile", "genetic_profile_id");
+        addFk(keys, "genetic_alteration", "genetic_profile_id", "genetic_profile", "genetic_profile_id");
+        addFk(keys, "genetic_alteration", "genetic_entity_id", "genetic_entity", "id");
+        addFk(keys, "genetic_profile_samples", "genetic_profile_id", "genetic_profile", "genetic_profile_id");
+        addFk(keys, "gene_panel_list", "internal_id", "gene_panel", "internal_id");
+        addFk(keys, "gene_panel_list", "gene_id", "gene", "entrez_gene_id");
+        addFk(keys, "sample_profile", "genetic_profile_id", "genetic_profile", "genetic_profile_id");
+        addFk(keys, "sample_profile", "sample_id", "sample", "internal_id");
+        addFk(keys, "sample_profile", "panel_id", "gene_panel", "internal_id");
+        addFk(keys, "structural_variant", "sample_id", "sample", "internal_id");
+        addFk(keys, "structural_variant", "site1_entrez_gene_id", "gene", "entrez_gene_id");
+        addFk(keys, "structural_variant", "site2_entrez_gene_id", "gene", "entrez_gene_id");
+        addFk(keys, "structural_variant", "genetic_profile_id", "genetic_profile", "genetic_profile_id");
+        addFk(keys, "alteration_driver_annotation", "genetic_profile_id", "genetic_profile", "genetic_profile_id");
+        addFk(keys, "alteration_driver_annotation", "sample_id", "sample", "internal_id");
+        addFk(keys, "mutation_event", "entrez_gene_id", "gene", "entrez_gene_id");
+        addFk(keys, "mutation", "mutation_event_id", "mutation_event", "mutation_event_id");
+        addFk(keys, "mutation", "entrez_gene_id", "gene", "entrez_gene_id");
+        addFk(keys, "mutation", "genetic_profile_id", "genetic_profile", "genetic_profile_id");
+        addFk(keys, "mutation", "sample_id", "sample", "internal_id");
+        addFk(keys, "mutation_count_by_keyword", "genetic_profile_id", "genetic_profile", "genetic_profile_id");
+        addFk(keys, "mutation_count_by_keyword", "entrez_gene_id", "gene", "entrez_gene_id");
+        addFk(keys, "clinical_patient", "internal_id", "patient", "internal_id");
+        addFk(keys, "clinical_sample", "internal_id", "sample", "internal_id");
+        addFk(keys, "clinical_attribute_meta", "cancer_study_id", "cancer_study", "cancer_study_id");
+        addFk(keys, "mut_sig", "cancer_study_id", "cancer_study", "cancer_study_id");
+        addFk(keys, "mut_sig", "entrez_gene_id", "gene", "entrez_gene_id");
+        addFk(keys, "gistic", "cancer_study_id", "cancer_study", "cancer_study_id");
+        addFk(keys, "gistic_to_gene", "entrez_gene_id", "gene", "entrez_gene_id");
+        addFk(keys, "gistic_to_gene", "gistic_roi_id", "gistic", "gistic_roi_id");
+        addFk(keys, "cna_event", "entrez_gene_id", "gene", "entrez_gene_id");
+        addFk(keys, "sample_cna_event", "cna_event_id", "cna_event", "cna_event_id");
+        addFk(keys, "sample_cna_event", "genetic_profile_id", "genetic_profile", "genetic_profile_id");
+        addFk(keys, "sample_cna_event", "sample_id", "sample", "internal_id");
+        addFk(keys, "copy_number_seg", "cancer_study_id", "cancer_study", "cancer_study_id");
+        addFk(keys, "copy_number_seg", "sample_id", "sample", "internal_id");
+        addFk(keys, "copy_number_seg_file", "cancer_study_id", "cancer_study", "cancer_study_id");
+        addFk(keys, "clinical_event", "patient_id", "patient", "internal_id");
+        addFk(keys, "clinical_event_data", "clinical_event_id", "clinical_event", "clinical_event_id");
+        addFk(keys, "reference_genome_gene", "reference_genome_id", "reference_genome", "reference_genome_id");
+        addFk(keys, "reference_genome_gene", "entrez_gene_id", "gene", "entrez_gene_id");
+        addFk(keys, "data_access_tokens", "username", "users", "email");
+        addFk(keys, "allele_specific_copy_number", "mutation_event_id", "mutation_event", "mutation_event_id");
+        addFk(keys, "allele_specific_copy_number", "genetic_profile_id", "genetic_profile", "genetic_profile_id");
+        addFk(keys, "allele_specific_copy_number", "sample_id", "sample", "internal_id");
+        addFk(keys, "resource_definition", "cancer_study_id", "cancer_study", "cancer_study_id");
+        addFk(keys, "resource_sample", "internal_id", "sample", "internal_id");
+        addFk(keys, "resource_patient", "internal_id", "patient", "internal_id");
+        addFk(keys, "resource_study", "internal_id", "cancer_study", "cancer_study_id");
+        return keys;
+    }
+
+    private static Set<String> expectedUniqueKeyConstraints() {
+        Set<String> keys = new LinkedHashSet<>();
+        addUk(keys, "type_of_cancer", "type_of_cancer_id");
+        addUk(keys, "reference_genome", "reference_genome_id");
+        addUk(keys, "cancer_study", "cancer_study_id");
+        addUk(keys, "cancer_study_tags", "cancer_study_id");
+        addUk(keys, "users", "email");
+        addUk(keys, "patient", "internal_id");
+        addUk(keys, "sample", "internal_id");
+        addUk(keys, "sample_list", "list_id");
+        addUk(keys, "sample_list_list", "list_id,sample_id");
+        addUk(keys, "genetic_entity", "id");
+        addUk(keys, "gene", "entrez_gene_id");
+        addUk(keys, "gene_alias", "entrez_gene_id,gene_alias");
+        addUk(keys, "geneset", "id");
+        addUk(keys, "geneset_gene", "geneset_id,entrez_gene_id");
+        addUk(keys, "geneset_hierarchy_node", "node_id");
+        addUk(keys, "geneset_hierarchy_leaf", "node_id,geneset_id");
+        addUk(keys, "generic_entity_properties", "id");
+        addUk(keys, "genetic_profile", "genetic_profile_id");
+        addUk(keys, "genetic_profile_link", "referring_genetic_profile_id,referred_genetic_profile_id");
+        addUk(keys, "genetic_alteration", "genetic_profile_id,genetic_entity_id");
+        addUk(keys, "gene_panel", "internal_id");
+        addUk(keys, "gene_panel_list", "internal_id,gene_id");
+        addUk(keys, "structural_variant", "internal_id");
+        addUk(keys, "alteration_driver_annotation", "alteration_event_id,genetic_profile_id,sample_id");
+        addUk(keys, "mutation_event", "mutation_event_id");
+        addUk(keys, "clinical_patient", "internal_id,attr_id");
+        addUk(keys, "clinical_sample", "internal_id,attr_id");
+        addUk(keys, "clinical_attribute_meta", "attr_id,cancer_study_id");
+        addUk(keys, "mut_sig", "cancer_study_id,entrez_gene_id");
+        addUk(keys, "gistic", "gistic_roi_id");
+        addUk(keys, "gistic_to_gene", "gistic_roi_id,entrez_gene_id");
+        addUk(keys, "cna_event", "cna_event_id");
+        addUk(keys, "sample_cna_event", "cna_event_id,sample_id,genetic_profile_id");
+        addUk(keys, "copy_number_seg", "seg_id");
+        addUk(keys, "copy_number_seg_file", "seg_file_id");
+        addUk(keys, "clinical_event", "clinical_event_id");
+        addUk(keys, "reference_genome_gene", "entrez_gene_id,reference_genome_id");
+        addUk(keys, "data_access_tokens", "token");
+        addUk(keys, "resource_definition", "resource_id,cancer_study_id");
+        addUk(keys, "resource_sample", "internal_id,resource_id,url");
+        addUk(keys, "resource_patient", "internal_id,resource_id,url");
+        addUk(keys, "resource_study", "internal_id,resource_id,url");
+        addUk(keys, "reference_genome", "build_name");
+        addUk(keys, "cancer_study", "cancer_study_identifier");
+        addUk(keys, "sample_list", "stable_id");
+        addUk(keys, "gene", "genetic_entity_id");
+        addUk(keys, "geneset", "name");
+        addUk(keys, "geneset", "external_id");
+        addUk(keys, "geneset", "genetic_entity_id");
+        addUk(keys, "geneset_hierarchy_node", "node_name,parent_id");
+        addUk(keys, "generic_entity_properties", "genetic_entity_id,name");
+        addUk(keys, "genetic_profile", "stable_id");
+        addUk(keys, "genetic_profile_samples", "genetic_profile_id");
+        addUk(keys, "gene_panel", "stable_id");
+        addUk(keys, "sample_profile", "sample_id,genetic_profile_id");
+        addUk(keys, "mutation", "mutation_event_id,genetic_profile_id,sample_id");
+        addUk(keys, "cna_event", "entrez_gene_id,alteration");
+        addUk(keys, "allele_specific_copy_number", "mutation_event_id,genetic_profile_id,sample_id");
+        return keys;
+    }
+
+    private static void addFk(Set<String> keys, String childTable, String childCols, String parentTable, String parentCols) {
+        keys.add(fkKey(childTable, childCols, parentTable, parentCols));
+    }
+
+    private static void addUk(Set<String> keys, String table, String columns) {
+        keys.add(ukKey(table, columns));
+    }
+}

--- a/src/test/java/org/mskcc/cbio/portal/integrationTest/dao/TestClickHouseConstraintChecker.java
+++ b/src/test/java/org/mskcc/cbio/portal/integrationTest/dao/TestClickHouseConstraintChecker.java
@@ -26,6 +26,9 @@ public class TestClickHouseConstraintChecker extends IntegrationTestBase {
 
     @Test
     public void testForeignKeyViolations() throws Exception {
+        assertTrue("Expected no FK violations on clean data",
+                ClickHouseConstraintChecker.findForeignKeyViolations().isEmpty());
+
         applySqlResource(FK_VIOLATIONS_SQL, List.of());
 
         List<ForeignKeyViolation> violations = ClickHouseConstraintChecker.findForeignKeyViolations();
@@ -42,10 +45,16 @@ public class TestClickHouseConstraintChecker extends IntegrationTestBase {
         Set<String> missing = new LinkedHashSet<>(expected);
         missing.removeAll(actual);
         assertTrue("Missing foreign-key violations: " + missing, missing.isEmpty());
+        Set<String> unexpected = new LinkedHashSet<>(actual);
+        unexpected.removeAll(expected);
+        assertTrue("Unexpected foreign-key violations: " + unexpected, unexpected.isEmpty());
     }
 
     @Test
     public void testUniqueKeyViolations() throws Exception {
+        assertTrue("Expected no unique-key violations on clean data",
+                ClickHouseConstraintChecker.findUniqueKeyViolations().isEmpty());
+
         // ReplacingMergeTree tables can collapse duplicate keys during merges.
         setMergesEnabled(false);
         try {
@@ -61,13 +70,12 @@ public class TestClickHouseConstraintChecker extends IntegrationTestBase {
             Set<String> missing = new LinkedHashSet<>(expected);
             missing.removeAll(actual);
             assertTrue("Missing unique-key violations: " + missing, missing.isEmpty());
+            Set<String> unexpected = new LinkedHashSet<>(actual);
+            unexpected.removeAll(expected);
+            assertTrue("Unexpected unique-key violations: " + unexpected, unexpected.isEmpty());
         } finally {
             setMergesEnabled(true);
         }
-    }
-
-    private static void applySqlResource(String resourceName) throws Exception {
-        applySqlResource(resourceName, List.of());
     }
 
     private static void applySqlResource(String resourceName, List<String> preludeStatements) throws Exception {

--- a/src/test/resources/clickhouse_fk_violations.sql
+++ b/src/test/resources/clickhouse_fk_violations.sql
@@ -1,0 +1,127 @@
+-- Foreign-key violation fixtures for ClickHouseConstraintChecker
+
+INSERT INTO cancer_study (cancer_study_id, type_of_cancer_id, reference_genome_id) VALUES
+(910002, 'MISSING_TC', 900001);
+
+INSERT INTO cancer_study_tags (cancer_study_id, tags) VALUES
+(900002, 'missing_tag');
+
+INSERT INTO patient (internal_id, cancer_study_id) VALUES
+(910003, 900002);
+
+INSERT INTO sample (internal_id, patient_id) VALUES
+(910004, 900003);
+
+INSERT INTO sample_list (list_id, cancer_study_id) VALUES
+(910500, 900002);
+
+INSERT INTO sample_list_list (list_id, sample_id) VALUES
+(910500, 900004);
+
+INSERT INTO gene (entrez_gene_id, genetic_entity_id) VALUES
+(910005, 900006);
+
+INSERT INTO gene_alias (entrez_gene_id, gene_alias) VALUES
+(900005, 'missing_alias');
+
+INSERT INTO geneset (id, genetic_entity_id, name) VALUES
+(910007, 900006, 'missing_geneset');
+
+INSERT INTO geneset_gene (geneset_id, entrez_gene_id) VALUES
+(900007, 900005);
+
+INSERT INTO geneset_hierarchy_leaf (node_id, geneset_id) VALUES
+(900008, 900007);
+
+INSERT INTO generic_entity_properties (id, genetic_entity_id, name) VALUES
+(910600, 900006, 'missing_prop');
+
+INSERT INTO genetic_profile (genetic_profile_id, cancer_study_id) VALUES
+(910009, 900002);
+
+INSERT INTO genetic_profile_link (referring_genetic_profile_id, referred_genetic_profile_id) VALUES
+(900009, 900010);
+
+INSERT INTO genetic_alteration (genetic_profile_id, genetic_entity_id, `values`) VALUES
+(900009, 900006, 'missing');
+
+INSERT INTO genetic_profile_samples (genetic_profile_id, ordered_sample_list) VALUES
+(900009, 'missing_samples');
+
+INSERT INTO gene_panel_list (internal_id, gene_id) VALUES
+(900010, 900005);
+
+INSERT INTO sample_profile (sample_id, genetic_profile_id, panel_id) VALUES
+(900004, 900009, 900010);
+
+INSERT INTO structural_variant (internal_id, genetic_profile_id, sample_id, site1_entrez_gene_id, site2_entrez_gene_id) VALUES
+(910700, 900009, 900004, 900005, 900005);
+
+INSERT INTO alteration_driver_annotation (alteration_event_id, genetic_profile_id, sample_id) VALUES
+(910800, 900009, 900004);
+
+INSERT INTO mutation_event (mutation_event_id, entrez_gene_id) VALUES
+(910011, 900005);
+
+INSERT INTO mutation (mutation_event_id, genetic_profile_id, sample_id, entrez_gene_id) VALUES
+(900011, 900009, 900004, 900005);
+
+INSERT INTO mutation_count_by_keyword (genetic_profile_id, `keyword`, entrez_gene_id) VALUES
+(900009, 'missing_keyword', 900005);
+
+INSERT INTO clinical_patient (internal_id, attr_id, attr_value) VALUES
+(900003, 'ATTR1', 'VAL1');
+
+INSERT INTO clinical_sample (internal_id, attr_id, attr_value) VALUES
+(900004, 'ATTR1', 'VAL1');
+
+INSERT INTO clinical_attribute_meta (attr_id, cancer_study_id) VALUES
+('ATTRX', 900002);
+
+INSERT INTO mut_sig (cancer_study_id, entrez_gene_id) VALUES
+(900002, 900005);
+
+INSERT INTO gistic (gistic_roi_id, cancer_study_id) VALUES
+(910012, 900002);
+
+INSERT INTO gistic_to_gene (gistic_roi_id, entrez_gene_id) VALUES
+(900012, 900005);
+
+INSERT INTO cna_event (cna_event_id, entrez_gene_id) VALUES
+(910013, 900005);
+
+INSERT INTO sample_cna_event (cna_event_id, sample_id, genetic_profile_id) VALUES
+(900013, 900004, 900009);
+
+INSERT INTO copy_number_seg (seg_id, cancer_study_id, sample_id) VALUES
+(910900, 900002, 900004);
+
+INSERT INTO copy_number_seg_file (seg_file_id, cancer_study_id) VALUES
+(910901, 900002);
+
+INSERT INTO clinical_event (clinical_event_id, patient_id, event_type) VALUES
+(910014, 900003, 'MISSING');
+
+INSERT INTO clinical_event_data (clinical_event_id, `key`, `value`) VALUES
+(900014, 'missing_key', 'missing_value');
+
+INSERT INTO reference_genome_gene (reference_genome_id, entrez_gene_id) VALUES
+(900001, 900005);
+
+INSERT INTO data_access_tokens (token, username) VALUES
+('missing_token', 'missing_user@example.org');
+
+INSERT INTO allele_specific_copy_number (mutation_event_id, genetic_profile_id, sample_id) VALUES
+(900011, 900009, 900004);
+
+INSERT INTO resource_definition (resource_id, cancer_study_id) VALUES
+('res_missing', 900002);
+
+INSERT INTO resource_sample (internal_id, resource_id, url) VALUES
+(900004, 'res_missing', 'http://missing');
+
+INSERT INTO resource_patient (internal_id, resource_id, url) VALUES
+(900003, 'res_missing', 'http://missing');
+
+INSERT INTO resource_study (internal_id, resource_id, url) VALUES
+(900002, 'res_missing', 'http://missing');

--- a/src/test/resources/clickhouse_unique_violations.sql
+++ b/src/test/resources/clickhouse_unique_violations.sql
@@ -1,0 +1,296 @@
+-- Unique-key violation fixtures for ClickHouseConstraintChecker
+
+-- type_of_cancer
+INSERT INTO type_of_cancer (type_of_cancer_id, name) VALUES
+('UK_TC_1', 'Type A'),
+('UK_TC_1', 'Type B');
+
+-- reference_genome (reference_genome_id)
+INSERT INTO reference_genome (reference_genome_id, build_name, name) VALUES
+(700001, 'BUILD_A1', 'RG_A1'),
+(700001, 'BUILD_A2', 'RG_A2');
+
+-- reference_genome (build_name)
+INSERT INTO reference_genome (reference_genome_id, build_name, name) VALUES
+(700002, 'BUILD_DUP', 'RG_B1'),
+(700003, 'BUILD_DUP', 'RG_B2');
+
+-- cancer_study (cancer_study_id)
+INSERT INTO cancer_study (cancer_study_id, cancer_study_identifier, name) VALUES
+(700010, 'STUDY_A', 'Study A'),
+(700010, 'STUDY_B', 'Study B');
+
+-- cancer_study (cancer_study_identifier)
+INSERT INTO cancer_study (cancer_study_id, cancer_study_identifier, name) VALUES
+(700011, 'STUDY_DUP', 'Study C'),
+(700012, 'STUDY_DUP', 'Study D');
+
+-- cancer_study_tags
+INSERT INTO cancer_study_tags (cancer_study_id, tags) VALUES
+(700020, 'tag1'),
+(700020, 'tag2');
+
+-- users
+INSERT INTO users (email, name, enabled) VALUES
+('uk_user@example.org', 'User A', 1),
+('uk_user@example.org', 'User B', 1);
+
+-- patient
+INSERT INTO patient (internal_id, stable_id, cancer_study_id) VALUES
+(700030, 'PAT_A', 700010),
+(700030, 'PAT_B', 700011);
+
+-- sample
+INSERT INTO sample (internal_id, stable_id, patient_id) VALUES
+(700040, 'SAMP_A', 700030),
+(700040, 'SAMP_B', 700031);
+
+-- sample_list (list_id)
+INSERT INTO sample_list (list_id, stable_id, cancer_study_id) VALUES
+(700050, 'SL_A', 700010),
+(700050, 'SL_B', 700011);
+
+-- sample_list (stable_id)
+INSERT INTO sample_list (list_id, stable_id, cancer_study_id) VALUES
+(700051, 'SL_DUP', 700010),
+(700052, 'SL_DUP', 700010);
+
+-- sample_list_list
+INSERT INTO sample_list_list (list_id, sample_id) VALUES
+(700060, 700040),
+(700060, 700040);
+
+-- genetic_entity
+INSERT INTO genetic_entity (id, entity_type, stable_id) VALUES
+(700070, 'GENE', 'GE_A'),
+(700070, 'GENE', 'GE_B');
+
+-- gene (entrez_gene_id)
+INSERT INTO gene (entrez_gene_id, hugo_gene_symbol, genetic_entity_id) VALUES
+(700080, 'GENE_A', 700070),
+(700080, 'GENE_B', 700071);
+
+-- gene (genetic_entity_id)
+INSERT INTO gene (entrez_gene_id, hugo_gene_symbol, genetic_entity_id) VALUES
+(700081, 'GENE_C', 700072),
+(700082, 'GENE_D', 700072);
+
+-- gene_alias
+INSERT INTO gene_alias (entrez_gene_id, gene_alias) VALUES
+(700080, 'ALIAS_DUP'),
+(700080, 'ALIAS_DUP');
+
+-- geneset (id)
+INSERT INTO geneset (id, genetic_entity_id, name, external_id) VALUES
+(700090, 700073, 'GS_ID_A', 'GS_ID_A_EXT'),
+(700090, 700074, 'GS_ID_B', 'GS_ID_B_EXT');
+
+-- geneset (name)
+INSERT INTO geneset (id, genetic_entity_id, name, external_id) VALUES
+(700091, 700075, 'GS_DUP_NAME', 'GS_NAME_A_EXT'),
+(700092, 700076, 'GS_DUP_NAME', 'GS_NAME_B_EXT');
+
+-- geneset (external_id)
+INSERT INTO geneset (id, genetic_entity_id, name, external_id) VALUES
+(700093, 700077, 'GS_EXT_A', 'GS_DUP_EXT'),
+(700094, 700078, 'GS_EXT_B', 'GS_DUP_EXT');
+
+-- geneset (genetic_entity_id)
+INSERT INTO geneset (id, genetic_entity_id, name, external_id) VALUES
+(700095, 700079, 'GS_GE_A', 'GS_GE_A_EXT'),
+(700096, 700079, 'GS_GE_B', 'GS_GE_B_EXT');
+
+-- geneset_gene
+INSERT INTO geneset_gene (geneset_id, entrez_gene_id) VALUES
+(700090, 700080),
+(700090, 700080);
+
+-- geneset_hierarchy_node (node_id)
+INSERT INTO geneset_hierarchy_node (node_id, node_name, parent_id) VALUES
+(700100, 'NODE_A', 1),
+(700100, 'NODE_B', 2);
+
+-- geneset_hierarchy_node (node_name, parent_id)
+INSERT INTO geneset_hierarchy_node (node_id, node_name, parent_id) VALUES
+(700101, 'NODE_DUP', 700200),
+(700102, 'NODE_DUP', 700200);
+
+-- geneset_hierarchy_leaf
+INSERT INTO geneset_hierarchy_leaf (node_id, geneset_id) VALUES
+(700100, 700090),
+(700100, 700090);
+
+-- generic_entity_properties (id)
+INSERT INTO generic_entity_properties (id, genetic_entity_id, name, value) VALUES
+(700110, 700070, 'PROP_A', 'VAL_A'),
+(700110, 700071, 'PROP_B', 'VAL_B');
+
+-- generic_entity_properties (genetic_entity_id, name)
+INSERT INTO generic_entity_properties (id, genetic_entity_id, name, value) VALUES
+(700111, 700072, 'PROP_DUP', 'VAL_C'),
+(700112, 700072, 'PROP_DUP', 'VAL_D');
+
+-- genetic_profile (genetic_profile_id)
+INSERT INTO genetic_profile (genetic_profile_id, stable_id, cancer_study_id, name) VALUES
+(700120, 'GP_A', 700010, 'GP A'),
+(700120, 'GP_B', 700011, 'GP B');
+
+-- genetic_profile (stable_id)
+INSERT INTO genetic_profile (genetic_profile_id, stable_id, cancer_study_id, name) VALUES
+(700121, 'GP_DUP', 700010, 'GP C'),
+(700122, 'GP_DUP', 700011, 'GP D');
+
+-- genetic_profile_link
+INSERT INTO genetic_profile_link (referring_genetic_profile_id, referred_genetic_profile_id) VALUES
+(700120, 700121),
+(700120, 700121);
+
+-- genetic_alteration
+INSERT INTO genetic_alteration (genetic_profile_id, genetic_entity_id, `values`) VALUES
+(700120, 700070, 'A');
+INSERT INTO genetic_alteration (genetic_profile_id, genetic_entity_id, `values`) VALUES
+(700120, 700070, 'B');
+
+-- genetic_profile_samples
+INSERT INTO genetic_profile_samples (genetic_profile_id, ordered_sample_list) VALUES
+(700120, 'S1');
+INSERT INTO genetic_profile_samples (genetic_profile_id, ordered_sample_list) VALUES
+(700120, 'S2');
+
+-- gene_panel (internal_id)
+INSERT INTO gene_panel (internal_id, stable_id, description) VALUES
+(700130, 'PANEL_A', 'Panel A'),
+(700130, 'PANEL_B', 'Panel B');
+
+-- gene_panel (stable_id)
+INSERT INTO gene_panel (internal_id, stable_id, description) VALUES
+(700131, 'PANEL_DUP', 'Panel C'),
+(700132, 'PANEL_DUP', 'Panel D');
+
+-- gene_panel_list
+INSERT INTO gene_panel_list (internal_id, gene_id) VALUES
+(700130, 700080),
+(700130, 700080);
+
+-- sample_profile
+INSERT INTO sample_profile (sample_id, genetic_profile_id, panel_id) VALUES
+(700040, 700120, 700130);
+INSERT INTO sample_profile (sample_id, genetic_profile_id, panel_id) VALUES
+(700040, 700120, 700131);
+
+-- structural_variant
+INSERT INTO structural_variant (internal_id, genetic_profile_id, sample_id) VALUES
+(700140, 700120, 700040),
+(700140, 700121, 700041);
+
+-- alteration_driver_annotation
+INSERT INTO alteration_driver_annotation (alteration_event_id, genetic_profile_id, sample_id) VALUES
+(700150, 700120, 700040),
+(700150, 700120, 700040);
+
+-- mutation_event
+INSERT INTO mutation_event (mutation_event_id, entrez_gene_id) VALUES
+(700160, 700080),
+(700160, 700081);
+
+-- mutation
+INSERT INTO mutation (mutation_event_id, genetic_profile_id, sample_id, entrez_gene_id) VALUES
+(700160, 700120, 700040, 700080),
+(700160, 700120, 700040, 700081);
+
+-- clinical_patient
+INSERT INTO clinical_patient (internal_id, attr_id, attr_value) VALUES
+(700170, 'ATTR_DUP', 'V1');
+INSERT INTO clinical_patient (internal_id, attr_id, attr_value) VALUES
+(700170, 'ATTR_DUP', 'V2');
+
+-- clinical_sample
+INSERT INTO clinical_sample (internal_id, attr_id, attr_value) VALUES
+(700180, 'ATTR_DUP', 'V1');
+INSERT INTO clinical_sample (internal_id, attr_id, attr_value) VALUES
+(700180, 'ATTR_DUP', 'V2');
+
+-- clinical_attribute_meta
+INSERT INTO clinical_attribute_meta (attr_id, cancer_study_id, display_name) VALUES
+('ATTR_META_DUP', 700010, 'Attr A'),
+('ATTR_META_DUP', 700010, 'Attr B');
+
+-- mut_sig
+INSERT INTO mut_sig (cancer_study_id, entrez_gene_id, rank) VALUES
+(700010, 700080, 1),
+(700010, 700080, 2);
+
+-- gistic
+INSERT INTO gistic (gistic_roi_id, cancer_study_id) VALUES
+(700190, 700010),
+(700190, 700011);
+
+-- gistic_to_gene
+INSERT INTO gistic_to_gene (gistic_roi_id, entrez_gene_id) VALUES
+(700190, 700080),
+(700190, 700080);
+
+-- cna_event (cna_event_id)
+INSERT INTO cna_event (cna_event_id, entrez_gene_id, alteration) VALUES
+(700200, 700080, 1),
+(700200, 700081, 2);
+
+-- cna_event (entrez_gene_id, alteration)
+INSERT INTO cna_event (cna_event_id, entrez_gene_id, alteration) VALUES
+(700201, 700082, 3),
+(700202, 700082, 3);
+
+-- sample_cna_event
+INSERT INTO sample_cna_event (cna_event_id, sample_id, genetic_profile_id) VALUES
+(700200, 700040, 700120),
+(700200, 700040, 700120);
+
+-- copy_number_seg
+INSERT INTO copy_number_seg (seg_id, cancer_study_id, sample_id) VALUES
+(700210, 700010, 700040),
+(700210, 700011, 700041);
+
+-- copy_number_seg_file
+INSERT INTO copy_number_seg_file (seg_file_id, cancer_study_id) VALUES
+(700220, 700010),
+(700220, 700011);
+
+-- clinical_event
+INSERT INTO clinical_event (clinical_event_id, patient_id, event_type) VALUES
+(700230, 700170, 'EVT'),
+(700230, 700171, 'EVT');
+
+-- reference_genome_gene
+INSERT INTO reference_genome_gene (entrez_gene_id, reference_genome_id) VALUES
+(700080, 700001),
+(700080, 700001);
+
+-- data_access_tokens
+INSERT INTO data_access_tokens (token, username) VALUES
+('TOKEN_DUP', 'user1'),
+('TOKEN_DUP', 'user2');
+
+-- resource_definition
+INSERT INTO resource_definition (resource_id, cancer_study_id) VALUES
+('RES_DEF_DUP', 700010),
+('RES_DEF_DUP', 700010);
+
+-- resource_sample
+INSERT INTO resource_sample (internal_id, resource_id, url) VALUES
+(700040, 'RES_SAMPLE_DUP', 'http://sample'),
+(700040, 'RES_SAMPLE_DUP', 'http://sample');
+
+-- resource_patient
+INSERT INTO resource_patient (internal_id, resource_id, url) VALUES
+(700170, 'RES_PAT_DUP', 'http://patient'),
+(700170, 'RES_PAT_DUP', 'http://patient');
+
+-- resource_study
+INSERT INTO resource_study (internal_id, resource_id, url) VALUES
+(700010, 'RES_STUDY_DUP', 'http://study'),
+(700010, 'RES_STUDY_DUP', 'http://study');
+
+-- allele_specific_copy_number
+INSERT INTO allele_specific_copy_number (mutation_event_id, genetic_profile_id, sample_id) VALUES
+(700160, 700120, 700040),
+(700160, 700120, 700040);


### PR DESCRIPTION
## Summary

  This PR adds a Java-based ClickHouse constraint check and documents how to run it.

  ### What changed

  - Added `ClickHouseConstraintChecker` to detect ClickHouse foreign-key and unique-key violations for the cBioPortal schema.
  - Added `org.mskcc.cbio.portal.scripts.CheckClickHouseConstraints` as a runnable CLI entrypoint.
  - Kept backward compatibility with the older referential-integrity API through a deprecated `ClickHouseReferentialIntegrityChecker` wrapper.
  - Documented how to run the constraint check from both:
    - the built `core-*.jar`
    - the `cbioportal-core` Docker image

  ### Implementation details

  - Foreign-key violations are detected by generated ClickHouse SQL against the known schema relationships.
  - Unique-key violations are detected by grouping on expected key columns and reporting duplicate rows.
  - The CLI groups and formats violations for console output and exits with a non-zero status when violations are found.
  - The constraint definitions are centralized in code and intended to stay in sync with `clickhouse_cgds.sql`.

  ## Test coverage

  - Added integration tests for foreign-key violation detection.
  - Added integration tests for unique-key violation detection.
  - Added SQL fixtures covering violating rows across the ClickHouse schema.
  - Updated the ClickHouse integration test setup to support this validation flow.

  ## Documentation

  - Added a README section describing how to check ClickHouse constraint violations.
  - Included example commands for both direct JAR execution and Docker-based execution.

  ## Testing

  - Added integration tests:
    - `TestClickHouseConstraintChecker`
  - Added fixtures:
    - `clickhouse_fk_violations.sql`
    - `clickhouse_unique_violations.sql`

  If you want, I can also turn this into a shorter PR body plus a one-line PR title.
