### PR TITLE
Fix issue with long-running deletes

### DIFF
--- a/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseAutoIncrement.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseAutoIncrement.java
@@ -1,3 +1,35 @@
+/*
+ * Copyright (c) 2026 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package org.mskcc.cbio.portal.dao;
 
 import java.sql.Connection;

--- a/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseBulkDeleter.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseBulkDeleter.java
@@ -1,3 +1,35 @@
+/*
+ * Copyright (c) 2026 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package org.mskcc.cbio.portal.dao;
 
 import java.io.ByteArrayInputStream;

--- a/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseBulkDeleter.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseBulkDeleter.java
@@ -14,9 +14,10 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Bulk deleter that buffers IDs in memory, streams them into a ClickHouse temporary
- * table, and issues a single DELETE ... WHERE id IN (SELECT id FROM tmp) statement.
- * This avoids large numbers of parameterized IN-clause round-trips.
+ * Bulk deleter that buffers IDs in memory, streams them into a ClickHouse staging
+ * table via TSVWithNames, and issues a single DELETE ... WHERE id IN (SELECT id FROM
+ * staging_table) statement. The staging table is a real MergeTree table (not temporary)
+ * so that it persists across HTTP requests on ClickHouse Cloud.
  *
  * Mirrors the structure of ClickHouseBulkLoader.
  */
@@ -26,13 +27,13 @@ public class ClickHouseBulkDeleter {
 
     private final String targetTable;
     private final String idColumn;
-    private final String tmpTable;
+    private final String stagingTable;
     private final List<Long> pendingIds = new ArrayList<>();
 
     private ClickHouseBulkDeleter(String targetTable, String idColumn) {
         this.targetTable = targetTable;
         this.idColumn = idColumn;
-        this.tmpTable = "tmp_delete_" + targetTable;
+        this.stagingTable = "staging_delete_" + targetTable;
     }
 
     public static ClickHouseBulkDeleter getBulkDeleter(String targetTable, String idColumn) {
@@ -68,34 +69,42 @@ public class ClickHouseBulkDeleter {
         try {
             con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
 
-            // 1. Create temp table
+            // Drop any leftover staging table from a previous crashed run
             try (PreparedStatement stmt = con.prepareStatement(
-                    "CREATE TEMPORARY TABLE " + tmpTable + " (id Int64) ENGINE = Memory")) {
+                    "DROP TABLE IF EXISTS " + stagingTable)) {
                 stmt.executeUpdate();
             }
 
-            // 2. Bulk-insert IDs into temp table via TSV stream
+            // Create staging table
+            try (PreparedStatement stmt = con.prepareStatement(
+                    "CREATE TABLE " + stagingTable + " (id Int64) ENGINE = MergeTree() ORDER BY id")) {
+                stmt.executeUpdate();
+            }
+
+            // Insert IDs into staging table via TSV stream
             byte[] payload = buildTsvPayload();
             try (PreparedStatement stmt = con.prepareStatement(
-                    "INSERT INTO " + tmpTable + " (id) FORMAT TSVWithNames")) {
+                    "INSERT INTO " + stagingTable + " (id) FORMAT TSVWithNames")) {
                 stmt.setBinaryStream(1, new ByteArrayInputStream(payload));
                 stmt.executeUpdate();
             }
 
-            // 3. Execute delete
+            // Execute delete via staging table
+            int deleted;
             try (PreparedStatement stmt = con.prepareStatement(
-                    "DELETE FROM " + targetTable + " WHERE " + idColumn + " IN (SELECT id FROM " + tmpTable + ")")) {
-                int deleted = stmt.executeUpdate();
-                return deleted;
+                    "DELETE FROM " + targetTable + " WHERE " + idColumn + " IN (SELECT id FROM " + stagingTable + ")")) {
+                deleted = stmt.executeUpdate();
             }
+
+            return deleted;
         } catch (SQLException | IOException e) {
             throw new DaoException(e);
         } finally {
-            // 4. Always drop temp table to avoid session state leak back into the connection pool
+            // Always drop staging table
             try {
                 if (con != null) {
                     try (PreparedStatement drop = con.prepareStatement(
-                            "DROP TEMPORARY TABLE IF EXISTS " + tmpTable)) {
+                            "DROP TABLE IF EXISTS " + stagingTable)) {
                         drop.executeUpdate();
                     }
                 }

--- a/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseBulkDeleter.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseBulkDeleter.java
@@ -1,0 +1,121 @@
+package org.mskcc.cbio.portal.dao;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Bulk deleter that buffers IDs in memory, streams them into a ClickHouse temporary
+ * table, and issues a single DELETE ... WHERE id IN (SELECT id FROM tmp) statement.
+ * This avoids large numbers of parameterized IN-clause round-trips.
+ *
+ * Mirrors the structure of ClickHouseBulkLoader.
+ */
+public class ClickHouseBulkDeleter {
+
+    private static final Map<String, ClickHouseBulkDeleter> BULK_DELETERS = new LinkedHashMap<>();
+
+    private final String targetTable;
+    private final String idColumn;
+    private final String tmpTable;
+    private final List<Long> pendingIds = new ArrayList<>();
+
+    private ClickHouseBulkDeleter(String targetTable, String idColumn) {
+        this.targetTable = targetTable;
+        this.idColumn = idColumn;
+        this.tmpTable = "tmp_delete_" + targetTable;
+    }
+
+    public static ClickHouseBulkDeleter getBulkDeleter(String targetTable, String idColumn) {
+        String key = targetTable + ":" + idColumn;
+        return BULK_DELETERS.computeIfAbsent(key, k -> new ClickHouseBulkDeleter(targetTable, idColumn));
+    }
+
+    public void addId(long id) {
+        pendingIds.add(id);
+    }
+
+    public void addIds(Collection<? extends Number> ids) {
+        for (Number id : ids) {
+            pendingIds.add(id.longValue());
+        }
+    }
+
+    public static int flushAll() throws DaoException {
+        int totalDeleted = 0;
+        for (ClickHouseBulkDeleter deleter : BULK_DELETERS.values()) {
+            totalDeleted += deleter.flushPendingIds();
+        }
+        BULK_DELETERS.clear();
+        return totalDeleted;
+    }
+
+    private int flushPendingIds() throws DaoException {
+        if (pendingIds.isEmpty()) {
+            return 0;
+        }
+
+        Connection con = null;
+        PreparedStatement stmt = null;
+        try {
+            con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
+
+            // 1. Create temp table
+            stmt = con.prepareStatement(
+                "CREATE TEMPORARY TABLE " + tmpTable + " (id Int64) ENGINE = Memory");
+            stmt.executeUpdate();
+            stmt.close();
+
+            // 2. Bulk-insert IDs into temp table via TSV stream
+            byte[] payload = buildTsvPayload();
+            stmt = con.prepareStatement(
+                "INSERT INTO " + tmpTable + " (id) FORMAT TSVWithNames");
+            stmt.setBinaryStream(1, new ByteArrayInputStream(payload));
+            stmt.executeUpdate();
+            stmt.close();
+
+            // 3. Execute delete
+            stmt = con.prepareStatement(
+                "DELETE FROM " + targetTable + " WHERE " + idColumn + " IN (SELECT id FROM " + tmpTable + ")");
+            int deleted = stmt.executeUpdate();
+            stmt.close();
+
+            return deleted;
+        } catch (SQLException | IOException e) {
+            throw new DaoException(e);
+        } finally {
+            // 4. Always drop temp table to avoid session state leak back into the connection pool
+            try {
+                if (con != null) {
+                    PreparedStatement drop = con.prepareStatement(
+                        "DROP TEMPORARY TABLE IF EXISTS " + tmpTable);
+                    drop.executeUpdate();
+                    drop.close();
+                }
+            } catch (SQLException ignored) {
+            }
+            JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, stmt, null);
+            pendingIds.clear();
+        }
+    }
+
+    private byte[] buildTsvPayload() throws IOException {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        // header row
+        buffer.write("id\n".getBytes(StandardCharsets.UTF_8));
+        // data rows
+        for (Long id : pendingIds) {
+            buffer.write((id.toString() + "\n").getBytes(StandardCharsets.UTF_8));
+        }
+        return buffer.toByteArray();
+    }
+}

--- a/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseBulkDeleter.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseBulkDeleter.java
@@ -65,45 +65,43 @@ public class ClickHouseBulkDeleter {
         }
 
         Connection con = null;
-        PreparedStatement stmt = null;
         try {
             con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
 
             // 1. Create temp table
-            stmt = con.prepareStatement(
-                "CREATE TEMPORARY TABLE " + tmpTable + " (id Int64) ENGINE = Memory");
-            stmt.executeUpdate();
-            stmt.close();
+            try (PreparedStatement stmt = con.prepareStatement(
+                    "CREATE TEMPORARY TABLE " + tmpTable + " (id Int64) ENGINE = Memory")) {
+                stmt.executeUpdate();
+            }
 
             // 2. Bulk-insert IDs into temp table via TSV stream
             byte[] payload = buildTsvPayload();
-            stmt = con.prepareStatement(
-                "INSERT INTO " + tmpTable + " (id) FORMAT TSVWithNames");
-            stmt.setBinaryStream(1, new ByteArrayInputStream(payload));
-            stmt.executeUpdate();
-            stmt.close();
+            try (PreparedStatement stmt = con.prepareStatement(
+                    "INSERT INTO " + tmpTable + " (id) FORMAT TSVWithNames")) {
+                stmt.setBinaryStream(1, new ByteArrayInputStream(payload));
+                stmt.executeUpdate();
+            }
 
             // 3. Execute delete
-            stmt = con.prepareStatement(
-                "DELETE FROM " + targetTable + " WHERE " + idColumn + " IN (SELECT id FROM " + tmpTable + ")");
-            int deleted = stmt.executeUpdate();
-            stmt.close();
-
-            return deleted;
+            try (PreparedStatement stmt = con.prepareStatement(
+                    "DELETE FROM " + targetTable + " WHERE " + idColumn + " IN (SELECT id FROM " + tmpTable + ")")) {
+                int deleted = stmt.executeUpdate();
+                return deleted;
+            }
         } catch (SQLException | IOException e) {
             throw new DaoException(e);
         } finally {
             // 4. Always drop temp table to avoid session state leak back into the connection pool
             try {
                 if (con != null) {
-                    PreparedStatement drop = con.prepareStatement(
-                        "DROP TEMPORARY TABLE IF EXISTS " + tmpTable);
-                    drop.executeUpdate();
-                    drop.close();
+                    try (PreparedStatement drop = con.prepareStatement(
+                            "DROP TEMPORARY TABLE IF EXISTS " + tmpTable)) {
+                        drop.executeUpdate();
+                    }
                 }
             } catch (SQLException ignored) {
             }
-            JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, stmt, null);
+            JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
             pendingIds.clear();
         }
     }

--- a/src/main/java/org/mskcc/cbio/portal/dao/DaoCancerStudy.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/DaoCancerStudy.java
@@ -62,8 +62,6 @@ import java.util.Set;
  */
 public final class DaoCancerStudy {
 
-    private static final int DELETE_BATCH_SIZE = 500;
-
     public static enum Status {
         UNAVAILABLE,
         AVAILABLE
@@ -526,29 +524,31 @@ public final class DaoCancerStudy {
             List<Integer> gisticIds = collectIds(con,
                 "SELECT gistic_roi_id FROM gistic WHERE cancer_study_id=?", internalCancerStudyId);
 
-            deleteByIds(con, "DELETE FROM sample_cna_event WHERE genetic_profile_id IN ", geneticProfileIds);
-            deleteByIds(con, "DELETE FROM genetic_alteration WHERE genetic_profile_id IN ", geneticProfileIds);
-            deleteByIds(con, "DELETE FROM genetic_profile_samples WHERE genetic_profile_id IN ", geneticProfileIds);
-            deleteByIds(con, "DELETE FROM sample_profile WHERE genetic_profile_id IN ", geneticProfileIds);
-            deleteByIds(con, "DELETE FROM mutation WHERE genetic_profile_id IN ", geneticProfileIds);
-            deleteByIds(con, "DELETE FROM alteration_driver_annotation WHERE genetic_profile_id IN ", geneticProfileIds);
-            deleteByIds(con, "DELETE FROM mutation_count_by_keyword WHERE genetic_profile_id IN ", geneticProfileIds);
-            deleteByIds(con, "DELETE FROM structural_variant WHERE genetic_profile_id IN ", geneticProfileIds);
-            deleteByIds(con, "DELETE FROM genetic_profile_link WHERE referred_genetic_profile_id IN ", geneticProfileIds);
+            ClickHouseBulkDeleter.getBulkDeleter("sample_cna_event", "genetic_profile_id").addIds(geneticProfileIds);
+            ClickHouseBulkDeleter.getBulkDeleter("genetic_alteration", "genetic_profile_id").addIds(geneticProfileIds);
+            ClickHouseBulkDeleter.getBulkDeleter("genetic_profile_samples", "genetic_profile_id").addIds(geneticProfileIds);
+            ClickHouseBulkDeleter.getBulkDeleter("sample_profile", "genetic_profile_id").addIds(geneticProfileIds);
+            ClickHouseBulkDeleter.getBulkDeleter("mutation", "genetic_profile_id").addIds(geneticProfileIds);
+            ClickHouseBulkDeleter.getBulkDeleter("alteration_driver_annotation", "genetic_profile_id").addIds(geneticProfileIds);
+            ClickHouseBulkDeleter.getBulkDeleter("mutation_count_by_keyword", "genetic_profile_id").addIds(geneticProfileIds);
+            ClickHouseBulkDeleter.getBulkDeleter("structural_variant", "genetic_profile_id").addIds(geneticProfileIds);
+            ClickHouseBulkDeleter.getBulkDeleter("genetic_profile_link", "referred_genetic_profile_id").addIds(geneticProfileIds);
 
-            deleteByIds(con, "DELETE FROM gistic_to_gene WHERE gistic_roi_id IN ", gisticIds);
+            ClickHouseBulkDeleter.getBulkDeleter("gistic_to_gene", "gistic_roi_id").addIds(gisticIds);
 
-            deleteByIds(con, "DELETE FROM clinical_event_data WHERE clinical_event_id IN ", clinicalEventIds);
-            deleteByIds(con, "DELETE FROM clinical_event WHERE clinical_event_id IN ", clinicalEventIds);
+            ClickHouseBulkDeleter.getBulkDeleter("clinical_event_data", "clinical_event_id").addIds(clinicalEventIds);
+            ClickHouseBulkDeleter.getBulkDeleter("clinical_event", "clinical_event_id").addIds(clinicalEventIds);
 
-            deleteByIds(con, "DELETE FROM sample_list_list WHERE list_id IN ", sampleListIds);
+            ClickHouseBulkDeleter.getBulkDeleter("sample_list_list", "list_id").addIds(sampleListIds);
 
-            deleteByIds(con, "DELETE FROM clinical_sample WHERE internal_id IN ", sampleIds);
-            deleteByIds(con, "DELETE FROM resource_sample WHERE internal_id IN ", sampleIds);
+            ClickHouseBulkDeleter.getBulkDeleter("clinical_sample", "internal_id").addIds(sampleIds);
+            ClickHouseBulkDeleter.getBulkDeleter("resource_sample", "internal_id").addIds(sampleIds);
 
-            deleteByIds(con, "DELETE FROM sample WHERE internal_id IN ", sampleIds);
-            deleteByIds(con, "DELETE FROM clinical_patient WHERE internal_id IN ", patientIds);
-            deleteByIds(con, "DELETE FROM resource_patient WHERE internal_id IN ", patientIds);
+            ClickHouseBulkDeleter.getBulkDeleter("sample", "internal_id").addIds(sampleIds);
+            ClickHouseBulkDeleter.getBulkDeleter("clinical_patient", "internal_id").addIds(patientIds);
+            ClickHouseBulkDeleter.getBulkDeleter("resource_patient", "internal_id").addIds(patientIds);
+
+            ClickHouseBulkDeleter.flushAll();
 
             deleteByStudyId(con, "DELETE FROM clinical_attribute_meta WHERE cancer_study_id=?", internalCancerStudyId);
             deleteByStudyId(con, "DELETE FROM resource_definition WHERE cancer_study_id=?", internalCancerStudyId);
@@ -564,6 +564,8 @@ public final class DaoCancerStudy {
             deleteByStudyId(con, "DELETE FROM cancer_study WHERE cancer_study_id=?", internalCancerStudyId);
 
             removeCancerStudyFromCache(internalCancerStudyId);
+        } catch (DaoException e) {
+            throw e;
         } catch (SQLException e) {
             throw new DaoException(e);
         } finally {
@@ -621,24 +623,6 @@ public final class DaoCancerStudy {
         try (PreparedStatement pstmt = con.prepareStatement(sql)) {
             pstmt.setInt(1, cancerStudyId);
             pstmt.executeUpdate();
-        }
-    }
-
-    private static void deleteByIds(Connection con, String sqlPrefix, List<Integer> ids) throws SQLException {
-        if (ids.isEmpty()) {
-            return;
-        }
-        for (int start = 0; start < ids.size(); start += DELETE_BATCH_SIZE) {
-            int end = Math.min(start + DELETE_BATCH_SIZE, ids.size());
-            List<Integer> chunk = ids.subList(start, end);
-            String placeholders = String.join(",", Collections.nCopies(chunk.size(), "?"));
-            try (PreparedStatement pstmt = con.prepareStatement(sqlPrefix + "(" + placeholders + ")")) {
-                int idx = 1;
-                for (Integer id : chunk) {
-                    pstmt.setInt(idx++, id);
-                }
-                pstmt.executeUpdate();
-            }
         }
     }
 

--- a/src/main/java/org/mskcc/cbio/portal/dao/DaoPatient.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/DaoPatient.java
@@ -256,11 +256,15 @@ public class DaoPatient {
             con = JdbcUtil.getDbConnection(DaoPatient.class);
             List<Integer> clinicalEventIds = collectIds(con,
                     "SELECT clinical_event_id FROM clinical_event WHERE patient_id IN ", internalPatientIds);
-            deleteByIds(con, "DELETE FROM clinical_event_data WHERE clinical_event_id IN ", clinicalEventIds);
-            deleteByIds(con, "DELETE FROM clinical_event WHERE clinical_event_id IN ", clinicalEventIds);
-            deleteByIds(con, "DELETE FROM clinical_patient WHERE internal_id IN ", internalPatientIds);
-            deleteByIds(con, "DELETE FROM resource_patient WHERE internal_id IN ", internalPatientIds);
-            deleteByIds(con, "DELETE FROM patient WHERE internal_id IN ", internalPatientIds);
+            ClickHouseBulkDeleter.getBulkDeleter("clinical_event_data", "clinical_event_id").addIds(clinicalEventIds);
+            ClickHouseBulkDeleter.getBulkDeleter("clinical_event", "clinical_event_id").addIds(clinicalEventIds);
+            ClickHouseBulkDeleter.getBulkDeleter("clinical_patient", "internal_id").addIds(internalPatientIds);
+            ClickHouseBulkDeleter.getBulkDeleter("resource_patient", "internal_id").addIds(internalPatientIds);
+            ClickHouseBulkDeleter.getBulkDeleter("patient", "internal_id").addIds(internalPatientIds);
+            ClickHouseBulkDeleter.flushAll();
+        }
+        catch (DaoException e) {
+            throw e;
         }
         catch (SQLException e) {
             throw new DaoException(e);
@@ -307,17 +311,4 @@ public class DaoPatient {
         return collected;
     }
 
-    private static void deleteByIds(Connection con, String sqlPrefix, Collection<Integer> ids) throws SQLException {
-        if (ids == null || ids.isEmpty()) {
-            return;
-        }
-        String placeholders = String.join(",", Collections.nCopies(ids.size(), "?"));
-        try (PreparedStatement pstmt = con.prepareStatement(sqlPrefix + "(" + placeholders + ")")) {
-            int index = 1;
-            for (Integer id : ids) {
-                pstmt.setInt(index++, id);
-            }
-            pstmt.executeUpdate();
-        }
-    }
 }

--- a/src/main/java/org/mskcc/cbio/portal/dao/DaoPatient.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/DaoPatient.java
@@ -255,11 +255,15 @@ public class DaoPatient {
             con = JdbcUtil.getDbConnection(DaoPatient.class);
             List<Integer> clinicalEventIds = collectIds(con,
                     "SELECT clinical_event_id FROM clinical_event WHERE patient_id IN ", internalPatientIds);
-            deleteByIds(con, "DELETE FROM clinical_event_data WHERE clinical_event_id IN ", clinicalEventIds);
-            deleteByIds(con, "DELETE FROM clinical_event WHERE clinical_event_id IN ", clinicalEventIds);
-            deleteByIds(con, "DELETE FROM clinical_patient WHERE internal_id IN ", internalPatientIds);
-            deleteByIds(con, "DELETE FROM resource_patient WHERE internal_id IN ", internalPatientIds);
-            deleteByIds(con, "DELETE FROM patient WHERE internal_id IN ", internalPatientIds);
+            ClickHouseBulkDeleter.getBulkDeleter("clinical_event_data", "clinical_event_id").addIds(clinicalEventIds);
+            ClickHouseBulkDeleter.getBulkDeleter("clinical_event", "clinical_event_id").addIds(clinicalEventIds);
+            ClickHouseBulkDeleter.getBulkDeleter("clinical_patient", "internal_id").addIds(internalPatientIds);
+            ClickHouseBulkDeleter.getBulkDeleter("resource_patient", "internal_id").addIds(internalPatientIds);
+            ClickHouseBulkDeleter.getBulkDeleter("patient", "internal_id").addIds(internalPatientIds);
+            ClickHouseBulkDeleter.flushAll();
+        }
+        catch (DaoException e) {
+            throw e;
         }
         catch (SQLException e) {
             throw new DaoException(e);
@@ -306,17 +310,4 @@ public class DaoPatient {
         return collected;
     }
 
-    private static void deleteByIds(Connection con, String sqlPrefix, Collection<Integer> ids) throws SQLException {
-        if (ids == null || ids.isEmpty()) {
-            return;
-        }
-        String placeholders = String.join(",", Collections.nCopies(ids.size(), "?"));
-        try (PreparedStatement pstmt = con.prepareStatement(sqlPrefix + "(" + placeholders + ")")) {
-            int index = 1;
-            for (Integer id : ids) {
-                pstmt.setInt(index++, id);
-            }
-            pstmt.executeUpdate();
-        }
-    }
 }

--- a/src/main/java/org/mskcc/cbio/portal/dao/DaoPatient.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/DaoPatient.java
@@ -271,6 +271,7 @@ public class DaoPatient {
         finally {
             JdbcUtil.closeAll(DaoPatient.class, con, null, null);
         }
+        clearCache();
         log.info("Removing {} patients from study with internal id={} done.", patientStableIds, internalStudyId);
     }
 

--- a/src/main/java/org/mskcc/cbio/portal/dao/DaoSample.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/DaoSample.java
@@ -296,27 +296,18 @@ public class DaoSample {
         Set<Integer> internalSampleIds = findInternalSampleIdsInStudy(internalStudyId, sampleStableIds);
         removeSamplesInGeneticAlterationsForStudy(internalStudyId, internalSampleIds);
 
-        Connection con = null;
-        try {
-            con = JdbcUtil.getDbConnection(DaoSample.class);
-            deleteByIds(con, "DELETE FROM alteration_driver_annotation WHERE sample_id IN ", internalSampleIds);
-            deleteByIds(con, "DELETE FROM sample_cna_event WHERE sample_id IN ", internalSampleIds);
-            deleteByIds(con, "DELETE FROM mutation WHERE sample_id IN ", internalSampleIds);
-            deleteByIds(con, "DELETE FROM structural_variant WHERE sample_id IN ", internalSampleIds);
-            deleteByIds(con, "DELETE FROM sample_profile WHERE sample_id IN ", internalSampleIds);
-            deleteByIds(con, "DELETE FROM sample_list_list WHERE sample_id IN ", internalSampleIds);
-            deleteByIds(con, "DELETE FROM copy_number_seg WHERE sample_id IN ", internalSampleIds);
-            deleteByIds(con, "DELETE FROM allele_specific_copy_number WHERE sample_id IN ", internalSampleIds);
-            deleteByIds(con, "DELETE FROM clinical_sample WHERE internal_id IN ", internalSampleIds);
-            deleteByIds(con, "DELETE FROM resource_sample WHERE internal_id IN ", internalSampleIds);
-            deleteByIds(con, "DELETE FROM sample WHERE internal_id IN ", internalSampleIds);
-        }
-        catch (SQLException e) {
-            throw new DaoException(e);
-        }
-        finally {
-            JdbcUtil.closeAll(DaoSample.class, con, null, null);
-        }
+        ClickHouseBulkDeleter.getBulkDeleter("alteration_driver_annotation", "sample_id").addIds(internalSampleIds);
+        ClickHouseBulkDeleter.getBulkDeleter("sample_cna_event", "sample_id").addIds(internalSampleIds);
+        ClickHouseBulkDeleter.getBulkDeleter("mutation", "sample_id").addIds(internalSampleIds);
+        ClickHouseBulkDeleter.getBulkDeleter("structural_variant", "sample_id").addIds(internalSampleIds);
+        ClickHouseBulkDeleter.getBulkDeleter("sample_profile", "sample_id").addIds(internalSampleIds);
+        ClickHouseBulkDeleter.getBulkDeleter("sample_list_list", "sample_id").addIds(internalSampleIds);
+        ClickHouseBulkDeleter.getBulkDeleter("copy_number_seg", "sample_id").addIds(internalSampleIds);
+        ClickHouseBulkDeleter.getBulkDeleter("allele_specific_copy_number", "sample_id").addIds(internalSampleIds);
+        ClickHouseBulkDeleter.getBulkDeleter("clinical_sample", "internal_id").addIds(internalSampleIds);
+        ClickHouseBulkDeleter.getBulkDeleter("resource_sample", "internal_id").addIds(internalSampleIds);
+        ClickHouseBulkDeleter.getBulkDeleter("sample", "internal_id").addIds(internalSampleIds);
+        ClickHouseBulkDeleter.flushAll();
         DaoCancerStudy.purgeUnreferencedRecordsAfterDeletionOfStudy();
         log.info("Removing {} samples from study with internal id={} done.", sampleStableIds, internalStudyId);
     }
@@ -395,17 +386,4 @@ public class DaoSample {
         return internalSampleIds;
     }
 
-    private static void deleteByIds(Connection con, String sqlPrefix, Collection<Integer> ids) throws SQLException {
-        if (ids == null || ids.isEmpty()) {
-            return;
-        }
-        String placeholders = String.join(",", Collections.nCopies(ids.size(), "?"));
-        try (PreparedStatement pstmt = con.prepareStatement(sqlPrefix + "(" + placeholders + ")")) {
-            int index = 1;
-            for (Integer id : ids) {
-                pstmt.setInt(index++, id);
-            }
-            pstmt.executeUpdate();
-        }
-    }
 }

--- a/src/main/java/org/mskcc/cbio/portal/dao/DaoSample.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/DaoSample.java
@@ -308,6 +308,7 @@ public class DaoSample {
         ClickHouseBulkDeleter.getBulkDeleter("resource_sample", "internal_id").addIds(internalSampleIds);
         ClickHouseBulkDeleter.getBulkDeleter("sample", "internal_id").addIds(internalSampleIds);
         ClickHouseBulkDeleter.flushAll();
+        clearCache();
         DaoCancerStudy.purgeUnreferencedRecordsAfterDeletionOfStudy();
         log.info("Removing {} samples from study with internal id={} done.", sampleStableIds, internalStudyId);
     }

--- a/src/test/java/org/mskcc/cbio/portal/integrationTest/dao/AbstractDaoDeleteTest.java
+++ b/src/test/java/org/mskcc/cbio/portal/integrationTest/dao/AbstractDaoDeleteTest.java
@@ -1,5 +1,6 @@
 /*
  * This file is part of cBioPortal.
+ * Copyright (C) 2026  Memorial Sloan-Kettering Cancer Center.
  *
  * cBioPortal is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/test/java/org/mskcc/cbio/portal/integrationTest/dao/AbstractDaoDeleteTest.java
+++ b/src/test/java/org/mskcc/cbio/portal/integrationTest/dao/AbstractDaoDeleteTest.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mskcc.cbio.portal.integrationTest.dao;
+
+import org.mskcc.cbio.portal.dao.ClickHouseBulkDeleter;
+import org.mskcc.cbio.portal.dao.DaoException;
+import org.mskcc.cbio.portal.dao.JdbcUtil;
+import org.mskcc.cbio.portal.integrationTest.IntegrationTestBase;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Shared helpers for integration tests that verify the ClickHouseBulkDeleter-based
+ * delete paths in DaoCancerStudy, DaoPatient, and DaoSample.
+ */
+abstract class AbstractDaoDeleteTest extends IntegrationTestBase {
+
+    /**
+     * Count rows in {@code table} where {@code column = value}.
+     */
+    protected long countRowsWhereEq(String table, String column, long value) throws DaoException {
+        Connection con = null;
+        try {
+            con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
+            PreparedStatement ps = con.prepareStatement(
+                "SELECT count() FROM " + table + " WHERE " + column + " = ?");
+            ps.setLong(1, value);
+            ResultSet rs = ps.executeQuery();
+            rs.next();
+            return rs.getLong(1);
+        } catch (SQLException e) {
+            throw new DaoException(e);
+        } finally {
+            JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
+        }
+    }
+
+    /**
+     * Assert no staging tables created by {@link ClickHouseBulkDeleter} were left behind.
+     * These are named {@code staging_delete_<targetTable>}.
+     */
+    protected void assertNoStagingTablesRemain() throws DaoException {
+        Connection con = null;
+        try {
+            con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
+            PreparedStatement ps = con.prepareStatement(
+                "SELECT count() FROM system.tables WHERE database = currentDatabase() AND name LIKE 'staging_delete_%'");
+            ResultSet rs = ps.executeQuery();
+            rs.next();
+            assertEquals("No staging_delete_* tables should remain after flush", 0, rs.getLong(1));
+        } catch (SQLException e) {
+            throw new DaoException(e);
+        } finally {
+            JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
+        }
+    }
+}

--- a/src/test/java/org/mskcc/cbio/portal/integrationTest/dao/TestDaoCancerStudyDelete.java
+++ b/src/test/java/org/mskcc/cbio/portal/integrationTest/dao/TestDaoCancerStudyDelete.java
@@ -1,5 +1,6 @@
 /*
  * This file is part of cBioPortal.
+ * Copyright (C) 2026  Memorial Sloan-Kettering Cancer Center.
  *
  * cBioPortal is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/test/java/org/mskcc/cbio/portal/integrationTest/dao/TestDaoCancerStudyDelete.java
+++ b/src/test/java/org/mskcc/cbio/portal/integrationTest/dao/TestDaoCancerStudyDelete.java
@@ -1,0 +1,140 @@
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mskcc.cbio.portal.integrationTest.dao;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mskcc.cbio.portal.dao.DaoCancerStudy;
+import org.mskcc.cbio.portal.dao.DaoException;
+import org.mskcc.cbio.portal.dao.DaoGeneticProfile;
+import org.mskcc.cbio.portal.dao.DaoSample;
+import org.mskcc.cbio.portal.dao.JdbcUtil;
+import org.mskcc.cbio.portal.dao.ClickHouseBulkDeleter;
+import org.mskcc.cbio.portal.model.CancerStudy;
+import org.mskcc.cbio.portal.model.GeneticProfile;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {"classpath:/applicationContext-dao.xml"})
+public class TestDaoCancerStudyDelete extends AbstractDaoDeleteTest {
+
+    private CancerStudy study;
+    private int studyId;
+
+    @Before
+    public void setUp() throws DaoException {
+        DaoCancerStudy.reCacheAll();
+        study = DaoCancerStudy.getCancerStudyByStableId("study_tcga_pub");
+        assertNotNull("seed data must contain study_tcga_pub", study);
+        studyId = study.getInternalId();
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testDeleteCancerStudy_studyIsGone() throws DaoException {
+        DaoCancerStudy.deleteCancerStudy(studyId);
+
+        assertNull("study should no longer be accessible after deletion",
+            DaoCancerStudy.getCancerStudyByStableId("study_tcga_pub"));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testDeleteCancerStudy_geneticProfileRowsAreGone() throws Exception {
+        List<Integer> profileIds = collectIds(
+            "SELECT genetic_profile_id FROM genetic_profile WHERE cancer_study_id=?", studyId);
+        assertFalse("seed data must have genetic profiles", profileIds.isEmpty());
+
+        DaoCancerStudy.deleteCancerStudy(studyId);
+
+        for (int profileId : profileIds) {
+            assertEquals(0L, countRowsWhereEq("genetic_alteration",        "genetic_profile_id", profileId));
+            assertEquals(0L, countRowsWhereEq("genetic_profile_samples",   "genetic_profile_id", profileId));
+            assertEquals(0L, countRowsWhereEq("sample_profile",            "genetic_profile_id", profileId));
+            assertEquals(0L, countRowsWhereEq("mutation",                  "genetic_profile_id", profileId));
+            assertEquals(0L, countRowsWhereEq("sample_cna_event",          "genetic_profile_id", profileId));
+        }
+        assertFalse("genetic_profile rows should be gone",
+            DaoGeneticProfile.getAllGeneticProfiles(studyId).stream()
+                .anyMatch(p -> profileIds.contains(p.getGeneticProfileId())));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testDeleteCancerStudy_sampleAndPatientRowsAreGone() throws Exception {
+        List<Integer> sampleIds = collectIds(
+            "SELECT s.internal_id FROM sample s JOIN patient p ON s.patient_id = p.internal_id WHERE p.cancer_study_id=?",
+            studyId);
+        List<Integer> patientIds = collectIds(
+            "SELECT internal_id FROM patient WHERE cancer_study_id=?", studyId);
+
+        assertFalse("seed data must have samples", sampleIds.isEmpty());
+        assertFalse("seed data must have patients", patientIds.isEmpty());
+
+        DaoCancerStudy.deleteCancerStudy(studyId);
+
+        for (int sampleId : sampleIds) {
+            assertEquals(0L, countRowsWhereEq("sample",          "internal_id", sampleId));
+            assertEquals(0L, countRowsWhereEq("clinical_sample", "internal_id", sampleId));
+        }
+        for (int patientId : patientIds) {
+            assertEquals(0L, countRowsWhereEq("patient",          "internal_id", patientId));
+            assertEquals(0L, countRowsWhereEq("clinical_patient", "internal_id", patientId));
+        }
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testDeleteCancerStudy_noStagingTablesRemain() throws DaoException {
+        DaoCancerStudy.deleteCancerStudy(studyId);
+        assertNoStagingTablesRemain();
+    }
+
+    // ── helper ──────────────────────────────────────────────────────────────
+
+    private List<Integer> collectIds(String sql, int param) throws DaoException {
+        Connection con = null;
+        try {
+            con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
+            PreparedStatement ps = con.prepareStatement(sql);
+            ps.setInt(1, param);
+            ResultSet rs = ps.executeQuery();
+            List<Integer> ids = new ArrayList<>();
+            while (rs.next()) ids.add(rs.getInt(1));
+            return ids;
+        } catch (SQLException e) {
+            throw new DaoException(e);
+        } finally {
+            JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
+        }
+    }
+}

--- a/src/test/java/org/mskcc/cbio/portal/integrationTest/dao/TestDaoPatientDelete.java
+++ b/src/test/java/org/mskcc/cbio/portal/integrationTest/dao/TestDaoPatientDelete.java
@@ -1,5 +1,6 @@
 /*
  * This file is part of cBioPortal.
+ * Copyright (C) 2026  Memorial Sloan-Kettering Cancer Center.
  *
  * cBioPortal is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/test/java/org/mskcc/cbio/portal/integrationTest/dao/TestDaoPatientDelete.java
+++ b/src/test/java/org/mskcc/cbio/portal/integrationTest/dao/TestDaoPatientDelete.java
@@ -1,0 +1,105 @@
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mskcc.cbio.portal.integrationTest.dao;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mskcc.cbio.portal.dao.DaoCancerStudy;
+import org.mskcc.cbio.portal.dao.DaoException;
+import org.mskcc.cbio.portal.dao.DaoPatient;
+import org.mskcc.cbio.portal.dao.DaoSample;
+import org.mskcc.cbio.portal.model.CancerStudy;
+import org.mskcc.cbio.portal.model.Patient;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {"classpath:/applicationContext-dao.xml"})
+public class TestDaoPatientDelete extends AbstractDaoDeleteTest {
+
+    // Seed patient TCGA-A1-A0SB has one sample: TCGA-A1-A0SB-01
+    private static final String PATIENT_STABLE_ID = "TCGA-A1-A0SB";
+    private static final String SAMPLE_STABLE_ID  = "TCGA-A1-A0SB-01";
+
+    private CancerStudy study;
+    private int studyId;
+    private int patientInternalId;
+    private int sampleInternalId;
+
+    @Before
+    public void setUp() throws DaoException {
+        DaoCancerStudy.reCacheAll();
+        study = DaoCancerStudy.getCancerStudyByStableId("study_tcga_pub");
+        assertNotNull(study);
+        studyId = study.getInternalId();
+
+        Patient patient = DaoPatient.getPatientByCancerStudyAndPatientId(studyId, PATIENT_STABLE_ID);
+        assertNotNull("seed data must contain " + PATIENT_STABLE_ID, patient);
+        patientInternalId = patient.getInternalId();
+
+        sampleInternalId = DaoSample.getSampleByCancerStudyAndSampleId(studyId, SAMPLE_STABLE_ID).getInternalId();
+    }
+
+    @Test
+    public void testDeletePatients_patientIsGone() throws DaoException {
+        DaoPatient.deletePatients(studyId, Set.of(PATIENT_STABLE_ID));
+
+        assertNull("patient should be gone after deletion",
+            DaoPatient.getPatientByCancerStudyAndPatientId(studyId, PATIENT_STABLE_ID));
+    }
+
+    @Test
+    public void testDeletePatients_patientRowsAreGone() throws DaoException {
+        DaoPatient.deletePatients(studyId, Set.of(PATIENT_STABLE_ID));
+
+        assertEquals(0L, countRowsWhereEq("patient",          "internal_id", patientInternalId));
+        assertEquals(0L, countRowsWhereEq("clinical_patient", "internal_id", patientInternalId));
+    }
+
+    @Test
+    public void testDeletePatients_cascadesToSamples() throws DaoException {
+        DaoPatient.deletePatients(studyId, Set.of(PATIENT_STABLE_ID));
+
+        assertNull("patient's sample should be gone after patient deletion",
+            DaoSample.getSampleByCancerStudyAndSampleId(studyId, SAMPLE_STABLE_ID));
+        assertEquals(0L, countRowsWhereEq("sample",          "internal_id", sampleInternalId));
+        assertEquals(0L, countRowsWhereEq("clinical_sample", "internal_id", sampleInternalId));
+        assertEquals(0L, countRowsWhereEq("sample_profile",  "sample_id",   sampleInternalId));
+    }
+
+    @Test
+    public void testDeletePatients_noStagingTablesRemain() throws DaoException {
+        DaoPatient.deletePatients(studyId, Set.of(PATIENT_STABLE_ID));
+        assertNoStagingTablesRemain();
+    }
+
+    @Test
+    public void testDeletePatients_emptyInput_isNoOp() throws DaoException {
+        DaoPatient.deletePatients(studyId, Set.of());
+
+        assertNotNull("patient should still exist when nothing was deleted",
+            DaoPatient.getPatientByCancerStudyAndPatientId(studyId, PATIENT_STABLE_ID));
+    }
+}

--- a/src/test/java/org/mskcc/cbio/portal/integrationTest/dao/TestDaoSampleDelete.java
+++ b/src/test/java/org/mskcc/cbio/portal/integrationTest/dao/TestDaoSampleDelete.java
@@ -1,5 +1,6 @@
 /*
  * This file is part of cBioPortal.
+ * Copyright (C) 2026  Memorial Sloan-Kettering Cancer Center.
  *
  * cBioPortal is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/test/java/org/mskcc/cbio/portal/integrationTest/dao/TestDaoSampleDelete.java
+++ b/src/test/java/org/mskcc/cbio/portal/integrationTest/dao/TestDaoSampleDelete.java
@@ -1,0 +1,113 @@
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mskcc.cbio.portal.integrationTest.dao;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mskcc.cbio.portal.dao.DaoCancerStudy;
+import org.mskcc.cbio.portal.dao.DaoException;
+import org.mskcc.cbio.portal.dao.DaoPatient;
+import org.mskcc.cbio.portal.dao.DaoSample;
+import org.mskcc.cbio.portal.model.CancerStudy;
+import org.mskcc.cbio.portal.model.Patient;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {"classpath:/applicationContext-dao.xml"})
+public class TestDaoSampleDelete extends AbstractDaoDeleteTest {
+
+    // Seed sample TCGA-A1-A0SB-01 belongs to patient TCGA-A1-A0SB
+    private static final String SAMPLE_STABLE_ID  = "TCGA-A1-A0SB-01";
+    private static final String PATIENT_STABLE_ID = "TCGA-A1-A0SB";
+
+    private CancerStudy study;
+    private int studyId;
+    private int sampleInternalId;
+    private int patientInternalId;
+
+    @Before
+    public void setUp() throws DaoException {
+        DaoCancerStudy.reCacheAll();
+        study = DaoCancerStudy.getCancerStudyByStableId("study_tcga_pub");
+        assertNotNull(study);
+        studyId = study.getInternalId();
+
+        sampleInternalId = DaoSample.getSampleByCancerStudyAndSampleId(studyId, SAMPLE_STABLE_ID).getInternalId();
+
+        Patient patient = DaoPatient.getPatientByCancerStudyAndPatientId(studyId, PATIENT_STABLE_ID);
+        assertNotNull(patient);
+        patientInternalId = patient.getInternalId();
+    }
+
+    @Test
+    public void testDeleteSamples_sampleIsGone() throws DaoException {
+        DaoSample.deleteSamples(studyId, Set.of(SAMPLE_STABLE_ID));
+
+        assertNull("sample should be gone after deletion",
+            DaoSample.getSampleByCancerStudyAndSampleId(studyId, SAMPLE_STABLE_ID));
+    }
+
+    @Test
+    public void testDeleteSamples_sampleRowsAreGone() throws DaoException {
+        DaoSample.deleteSamples(studyId, Set.of(SAMPLE_STABLE_ID));
+
+        assertEquals(0L, countRowsWhereEq("sample",          "internal_id", sampleInternalId));
+        assertEquals(0L, countRowsWhereEq("clinical_sample", "internal_id", sampleInternalId));
+    }
+
+    @Test
+    public void testDeleteSamples_relatedProfileRowsAreGone() throws DaoException {
+        DaoSample.deleteSamples(studyId, Set.of(SAMPLE_STABLE_ID));
+
+        assertEquals(0L, countRowsWhereEq("sample_profile",   "sample_id", sampleInternalId));
+        assertEquals(0L, countRowsWhereEq("sample_cna_event", "sample_id", sampleInternalId));
+        assertEquals(0L, countRowsWhereEq("mutation",         "sample_id", sampleInternalId));
+    }
+
+    @Test
+    public void testDeleteSamples_patientIsPreserved() throws DaoException {
+        DaoSample.deleteSamples(studyId, Set.of(SAMPLE_STABLE_ID));
+
+        // Deleting a sample must not delete the parent patient
+        assertNotNull("patient should still exist after sample-only deletion",
+            DaoPatient.getPatientByCancerStudyAndPatientId(studyId, PATIENT_STABLE_ID));
+        assertEquals(1L, countRowsWhereEq("patient", "internal_id", patientInternalId));
+    }
+
+    @Test
+    public void testDeleteSamples_noStagingTablesRemain() throws DaoException {
+        DaoSample.deleteSamples(studyId, Set.of(SAMPLE_STABLE_ID));
+        assertNoStagingTablesRemain();
+    }
+
+    @Test
+    public void testDeleteSamples_emptyInput_isNoOp() throws DaoException {
+        DaoSample.deleteSamples(studyId, Set.of());
+
+        assertNotNull("sample should still exist when nothing was deleted",
+            DaoSample.getSampleByCancerStudyAndSampleId(studyId, SAMPLE_STABLE_ID));
+    }
+}


### PR DESCRIPTION
- Add `ClickHouseBulkDeleter` class instead of manually batching deletes
  - Uploads the IDs we want to delete into a staging ClickHouse table
  - Calls `DELETE FROM target_table WHERE id in (SELECT id FROM tmp_table)`
  - Deletes the staging table

cc @sheridancbio @forus 