### PR TITLE
fix: raise error (not warning) when patient ID in sample file is absent from patient file

### DIFF
--- a/scripts/importer/validateData.py
+++ b/scripts/importer/validateData.py
@@ -3008,9 +3008,9 @@ class PatientClinicalValidator(ClinicalValidator):
         if PATIENTS_WITH_SAMPLES:
             for patient_id in PATIENTS_WITH_SAMPLES:
                 if patient_id not in self.patient_id_lines:
-                    self.logger.warning(
-                        'Missing clinical data for a patient associated with '
-                        'samples',
+                    self.logger.error(
+                        'Patient ID defined in the clinical sample file is '
+                        'not present in the clinical patient file',
                         extra={'cause': patient_id})
         super(PatientClinicalValidator, self).onComplete()
 

--- a/tests/unit_tests_validate_data.py
+++ b/tests/unit_tests_validate_data.py
@@ -387,17 +387,17 @@ class PatientAttrFileTestCase(PostClinicalDataFileTestCase):
         self.assertIn('sample', record.getMessage().lower())
 
     def test_patient_without_attributes(self):
-        """Test if a warning is issued for patients absent in the patient file."""
-        self.logger.setLevel(logging.WARNING)
+        """Test if an error is issued for patients absent in the patient file."""
+        self.logger.setLevel(logging.ERROR)
         record_list = self.validate('data_clin_missing_patient.txt',
                                     validateData.PatientClinicalValidator)
         self.assertEqual(1, len(record_list))
         record = record_list.pop()
-        self.assertEqual(logging.WARNING, record.levelno)
+        self.assertEqual(logging.ERROR, record.levelno)
         self.assertFalse(hasattr(record, 'line_number'),
                          'logrecord is about a specific line')
         self.assertEqual('TEST-PAT4', record.cause)
-        self.assertIn('missing', record.getMessage().lower())
+        self.assertIn('patient', record.getMessage().lower())
 
     def test_hardcoded_attr_values(self):
         """Test if attributes with set meanings have recognized values."""
@@ -460,6 +460,11 @@ class PatientAttrFileTestCase(PostClinicalDataFileTestCase):
     def test_date_in_nondate_column(self):
         """Test when a sample is defined twice in the same file."""
         self.logger.setLevel(logging.ERROR)
+        # Set PATIENTS_WITH_SAMPLES to only the patients present in this file
+        # to avoid triggering unrelated "patient not in patient file" errors
+        validateData.PATIENTS_WITH_SAMPLES = {
+            'TCGA-A2-A04P', 'TCGA-A1-A0SK', 'TCGA-A2-A0CM',
+            'TCGA-AR-A1AR', 'TCGA-B6-A0WX', 'TCGA-BH-A1F0', 'TCGA-B6-A0I6'}
         record_list = self.validate('data_clin_date_in_nondate_column.txt',
                                     validateData.PatientClinicalValidator)
         self.assertEqual(2, len(record_list))


### PR DESCRIPTION
Fixes #86

## Root Cause
`PatientClinicalValidator.onComplete()` already detected when a `PATIENT_ID` referenced in the clinical sample file was absent from the patient file, but emitted `logger.warning` instead of `logger.error`. Since warnings don't affect the validator's exit code, validation passed and data loaded silently with the inconsistency intact.

## Changes
- **`validateData.py`**: `logger.warning` → `logger.error` in `PatientClinicalValidator.onComplete()`
- Improved message to match the issue description: `'Patient ID defined in the clinical sample file is not present in the clinical patient file'`
- **`unit_tests_validate_data.py`**: Updated `test_patient_without_attributes` to expect `logging.ERROR` and reflect the new message text
- Fixed `test_date_in_nondate_column` to scope `PATIENTS_WITH_SAMPLES` to only the patients in that test file, preventing unrelated "missing patient" errors from polluting an unrelated test

## Tests
```
156 passed, 2 failed
```
The 2 failures (`test_duplicate_sample`, `test_incremental_data_validation`) are pre-existing on `main` before this change and are unrelated to this fix.