### PR TITLE
drop async settings for derived tables

### DIFF
--- a/scripts/clickhouse_import_support/create_derived_tables_in_clickhouse_database.sh
+++ b/scripts/clickhouse_import_support/create_derived_tables_in_clickhouse_database.sh
@@ -235,20 +235,6 @@ function sql_statement_includes_insert_into() {
     return 1
 }
 
-function append_async_settings_suffix() {
-    local sql_filepath="$1"
-    local sql_filepath_amended="$sql_filepath.amended"
-    local async_settings_suffix=" SETTINGS async_insert=1, wait_for_async_insert=1, async_insert_busy_timeout_ms=300000, async_insert_max_data_size=$clickhouse_max_memory_use_target, async_insert_max_query_number=10000;"
-    local linecount=$(cat $sql_filepath | wc -l)
-    local linecount_minus_one=$(($linecount-1))
-    head -n $linecount_minus_one $sql_filepath > $sql_filepath_amended
-    local last_line_from_file="$(tail -n 1 $sql_filepath)"
-    local line_without_semicolon="${last_line_from_file%;*}"
-    echo "$line_without_semicolon" >> $sql_filepath_amended
-    echo "$async_settings_suffix" >> $sql_filepath_amended
-    mv $sql_filepath_amended $sql_filepath
-}
-
 function create_all_derived_tables() {
     local pos=0
     while [ $pos -lt ${#derived_table_simple_sql_filepaths[@]} ] ; do
@@ -269,14 +255,16 @@ function create_all_derived_tables() {
             pos=$(($pos+1))
             continue
         fi
-        if sql_statement_includes_insert_into $sql_filepath ; then
-            append_async_settings_suffix $sql_filepath
-        fi
         if ! execute_sql_statement_from_file_via_clickhouse_client "$sql_filepath" "create_derived_table_result_filepath" ; then
             echo "Error : failure occurred during execution of sql statements in file $sql_filepath" >&2
             echo "    beginning with:" >&2
             head -n 4 $sql_filepath >&2
             return 1
+        fi
+        if grep OPTIMIZE "$sql_filepath" | grep FINAL ; then
+            WAIT_AFTER_OPTIMIZE=90
+            echo "sleeping $WAIT_AFTER_OPTIMIZE seconds after executing statement above"
+            sleep $WAIT_AFTER_OPTIMIZE
         fi
         pos=$(($pos+1))
     done

--- a/scripts/clickhouse_import_support/create_derived_tables_in_clickhouse_database_async.py
+++ b/scripts/clickhouse_import_support/create_derived_tables_in_clickhouse_database_async.py
@@ -33,7 +33,7 @@ def get_list_of_profile_ids_from_clickhouse(yaml_config_filename, get_profile_id
     profile_id_list = profile_id_list_string.splitlines()
     return profile_id_list, profile_query_result.returncode
 
-def convert_insert_to_be_async(original_insert_sql_statement, expected_where_for_profile_type, profiles_to_be_skipped, max_memory_target):
+def convert_insert(original_insert_sql_statement, expected_where_for_profile_type, profiles_to_be_skipped, max_memory_target, apply_async_settings):
     one_line_insert_sql_statement = re.sub('\s+', ' ', original_insert_sql_statement)
     if one_line_insert_sql_statement.endswith(" "):
         one_line_insert_sql_statement = one_line_insert_sql_statement.strip()
@@ -45,6 +45,8 @@ def convert_insert_to_be_async(original_insert_sql_statement, expected_where_for
         exclude_profiles_term = f"{EXCLUDE_PROFILES_CLAUSE_STRING} ({profiles_to_be_skipped_string})"
     replacement_string = f"{expected_where_for_profile_type}{exclude_profiles_term}"
     suffix_string = f" SETTINGS async_insert=1, wait_for_async_insert=1, async_insert_busy_timeout_ms=300000, async_insert_max_data_size={max_memory_target}, async_insert_max_query_number=10000;"
+    if not apply_async_settings:
+        suffix_string = f" ;"
     adjusted_insert_statement = one_line_insert_sql_statement.replace(expected_where_for_profile_type, replacement_string) + suffix_string
     return adjusted_insert_statement
 
@@ -107,7 +109,7 @@ def create_sql_insert_statement_from_clickhouse(sql_filepath, expected_insert_st
             print(f"\tExpected query start is '{expected_insert_statement_start}'", file=sys.stderr)
             print(f"\tExpected query contains '{expected_where_for_profile_type}'", file=sys.stderr)
             sys.exit(1)
-    insert_by_profile_statement = convert_insert_to_be_async(original_insert_sql_statement, expected_where_for_profile_type, profiles_to_be_skipped, max_memory_target)
+    insert_by_profile_statement = convert_insert(original_insert_sql_statement, expected_where_for_profile_type, profiles_to_be_skipped, max_memory_target, False)
     print(f"executing : {insert_by_profile_statement}")
     return insert_by_profile_statement
 

--- a/scripts/importer/cbioportal_common.py
+++ b/scripts/importer/cbioportal_common.py
@@ -12,8 +12,6 @@ from collections import OrderedDict
 from subprocess import Popen, PIPE, STDOUT
 from typing import Dict, Optional
 import dsnparse
-import pymysql
-pymysql.install_as_MySQLdb()
 
 # MySQLdb import should come after the install_as_MySQLdb() line above
 import MySQLdb

--- a/scripts/importer/cbioportal_common.py
+++ b/scripts/importer/cbioportal_common.py
@@ -13,9 +13,6 @@ from subprocess import Popen, PIPE, STDOUT
 from typing import Dict, Optional
 import dsnparse
 
-# MySQLdb import should come after the install_as_MySQLdb() line above
-import MySQLdb
-
 # ------------------------------------------------------------------------------
 # globals
 
@@ -1140,32 +1137,35 @@ def parse_properties_file(properties_filename: str) -> Dict[str, str]:
             properties[name] = value.strip()
     return properties
 
-def get_db_cursor(portal_properties: PortalProperties):
-
-    try:
-        url_elements = dsnparse.parse(portal_properties.database_url)
-        connection_kwargs = {
-            "host": url_elements.host,
-            "port": url_elements.port if url_elements.port is not None else 3306,
-            "db": url_elements.paths[0],
-            "user": portal_properties.database_user,
-            "passwd": portal_properties.database_pw
-        }
-        if url_elements.query.get("useSSL") == "true":
-            connection_kwargs['ssl_mode'] = 'REQUIRED'
-            connection_kwargs['ssl'] = {"ssl_mode": True}
-        else:
-            if url_elements.query.get("get-server-public-key") == "true":
-                connection_kwargs['ssl'] = {
-                    'MYSQL_OPT_GET_SERVER_PUBLIC_KEY': True
-                }
-        connection = MySQLdb.connect(**connection_kwargs)
-    except MySQLdb.Error as exception:
-        print(exception, file=ERROR_FILE)
-        message = (
-            "--> Error connecting to server with URL: "
-            + portal_properties.database_url)
-        print(message, file=ERROR_FILE)
-        raise ConnectionError(message) from exception
-    if connection is not None:
-        return connection, connection.cursor()
+"""
+The following function is based on creating a connection to a mysql database, which is no longer part of the cbioportal system. In order to use similar functionality this functionality would need to be adapted to interact with a clickhouse database.
+"""
+####def get_db_cursor(portal_properties: PortalProperties):
+####
+####    try:
+####        url_elements = dsnparse.parse(portal_properties.database_url)
+####        connection_kwargs = {
+####            "host": url_elements.host,
+####            "port": url_elements.port if url_elements.port is not None else 3306,
+####            "db": url_elements.paths[0],
+####            "user": portal_properties.database_user,
+####            "passwd": portal_properties.database_pw
+####        }
+####        if url_elements.query.get("useSSL") == "true":
+####            connection_kwargs['ssl_mode'] = 'REQUIRED'
+####            connection_kwargs['ssl'] = {"ssl_mode": True}
+####        else:
+####            if url_elements.query.get("get-server-public-key") == "true":
+####                connection_kwargs['ssl'] = {
+####                    'MYSQL_OPT_GET_SERVER_PUBLIC_KEY': True
+####                }
+####        connection = MySQLdb.connect(**connection_kwargs)
+####    except MySQLdb.Error as exception:
+####        print(exception, file=ERROR_FILE)
+####        message = (
+####            "--> Error connecting to server with URL: "
+####            + portal_properties.database_url)
+####        print(message, file=ERROR_FILE)
+####        raise ConnectionError(message) from exception
+####    if connection is not None:
+####        return connection, connection.cursor()

--- a/scripts/importer/updateOncokbAnnotations.py
+++ b/scripts/importer/updateOncokbAnnotations.py
@@ -23,267 +23,276 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-"""Script to update OncoKB annotation for the provided study.
+""" THIS SCRIPT IS BASED ON A MYSQL DATABASE INTERACTION WHICH IS NO
+LONGER AVAILABLE. IN ORDER TO PROVIDE THIS FUNCTIONALITY AGAIN THIS
+SCRIPT NEEDS TO BE REWRITTEN TO INTERACT WITH A CLICKHOUSE DATABASE
 """
 
-import argparse
-import importlib
-import logging.handlers
+####"""Script to update OncoKB annotation for the provided study.
+####"""
+####
+####import argparse
+####import importlib
+####import logging.handlers
+####import sys
+####import MySQLdb
+####from pathlib import Path
+####from cbioportal_common import get_database_properties, get_db_cursor
+####import libImportOncokb
+####
+####
+##### configure relative imports if running as a script; see PEP 366
+##### it might passed as empty string by certain tooling to mark a top level module
+####if __name__ == "__main__" and (__package__ is None or __package__ == ''):
+####    # replace the script's location in the Python search path by the main
+####    # scripts/ folder, above it, so that the importer package folder is in
+####    # scope and *not* directly in sys.path; see PEP 395
+####    sys.path[0] = str(Path(sys.path[0]).resolve().parent)
+####    __package__ = 'importer'
+####    # explicitly import the package, which is needed on CPython 3.4 because it
+####    # doesn't include https://github.com/python/cpython/pull/2639
+####    importlib.import_module(__package__)
+####
+####
+####ERROR_FILE = sys.stderr
+####REFERENCE_GENOME = {'hg19': 'GRCh37', 'hg38': 'GRCh38'}
+####
+##### from: cbioportal-frontend file CopyNumberUtils.ts
+####cna_alteration_types = {
+####    "DELETION": -2,
+####    "LOSS": -1,
+####    "GAIN": 1,
+####    "AMPLIFICATION": 2,
+####}
+####
+####def get_current_mutation_data(study_id, cursor):
+####    """ Get mutation data from the current study.
+####        Returns an array of dictionaries, with the following keys:
+####        id, geneticProfileId, entrezGeneId, alteration, and consequence
+####    """
+####    mutations = []
+####    try:
+####        cursor.execute('SELECT genetic_profile.GENETIC_PROFILE_ID, mutation_event.ENTREZ_GENE_ID, PROTEIN_CHANGE as ALTERATION, ' +
+####        'MUTATION_TYPE as CONSEQUENCE, mutation.MUTATION_EVENT_ID, mutation.SAMPLE_ID FROM cbioportal.mutation_event ' +
+####        'inner join mutation on mutation.MUTATION_EVENT_ID = mutation_event.MUTATION_EVENT_ID ' +
+####        'inner join genetic_profile on genetic_profile.GENETIC_PROFILE_ID = mutation.GENETIC_PROFILE_ID ' +
+####        'inner join cancer_study on cancer_study.CANCER_STUDY_ID = genetic_profile.CANCER_STUDY_ID ' +
+####        'WHERE cancer_study.CANCER_STUDY_IDENTIFIER = "'+study_id +'"')
+####        for row in cursor.fetchall():
+####            mutations += [{ "id": "_".join([str(row[4]), str(row[0]), str(row[5])]), "geneticProfileId": row[0], "entrezGeneId": row[1],
+####                            "alteration": row[2], "consequence": row[3]}]
+####    except MySQLdb.Error as msg:
+####        print(msg, file=ERROR_FILE)
+####        return None
+####    return mutations
+####
+####def get_current_cna_data(study_id, cursor):
+####    """ Get cna data from the current study.
+####        Returns an array of dictionaries, with the following keys:
+####        id, geneticProfileId, entrezGeneId, and alteration
+####    """
+####    cna = []
+####    try:
+####        cursor.execute('SELECT genetic_profile.GENETIC_PROFILE_ID, '+ 'cna_event.ENTREZ_GENE_ID, cna_event.ALTERATION, '+
+####        'sample_cna_event.CNA_EVENT_ID, sample_cna_event.SAMPLE_ID from cbioportal.cna_event ' +
+####        'inner join sample_cna_event on sample_cna_event.CNA_EVENT_ID = cna_event.CNA_EVENT_ID '+
+####        'inner join genetic_profile on genetic_profile.GENETIC_PROFILE_ID = sample_cna_event.GENETIC_PROFILE_ID '+
+####        'inner join cancer_study on cancer_study.CANCER_STUDY_ID = genetic_profile.CANCER_STUDY_ID '+
+####        'WHERE cancer_study.CANCER_STUDY_IDENTIFIER = "'+study_id +'"')
+####        for row in cursor.fetchall():
+####            alteration = list(cna_alteration_types.keys())[
+####                list(cna_alteration_types.values()).index(row[2])]
+####            cna += [{"id": "_".join([str(row[3]), str(row[0]), str(row[4])]), "geneticProfileId": row[0], "entrezGeneId": row[1],
+####                    "alteration": alteration}]
+####    except MySQLdb.Error as msg:
+####        print(msg, file=ERROR_FILE)
+####        return None
+####    return cna
+####
+####def get_current_sv_data(study_id, cursor):
+####    """ Get structural variant data from the current study.
+####        Returns an array of dictionaries, with the following keys:
+####        id, geneticProfileId, entrezGeneIdA, entrezGeneIdB, and structuralVariantType
+####    """
+####    sv = []
+####    try:
+####        cursor.execute('SELECT genetic_profile.GENETIC_PROFILE_ID, '+ 'structural_variant.SITE1_ENTREZ_GENE_ID, '+
+####        'structural_variant.SITE2_ENTREZ_GENE_ID, structural_variant.EVENT_INFO, ' +
+####        'structural_variant.INTERNAL_ID, structural_variant.SAMPLE_ID from cbioportal.structural_variant ' +
+####        'inner join genetic_profile on genetic_profile.GENETIC_PROFILE_ID = structural_variant.GENETIC_PROFILE_ID '+
+####        'inner join cancer_study on cancer_study.CANCER_STUDY_ID = genetic_profile.CANCER_STUDY_ID '+
+####        'WHERE cancer_study.CANCER_STUDY_IDENTIFIER = "'+study_id +'"')
+####        for row in cursor.fetchall():
+####            sv += [{"id": "_".join([str(row[4]), str(row[0]), str(row[5])]), "geneticProfileId": row[0], "entrezGeneIdA": row[1],
+####                    "entrezGeneIdB": row[2], "structuralVariantType": row[3]}]
+####    except MySQLdb.Error as msg:
+####        print(msg, file=ERROR_FILE)
+####        return None
+####    return sv
+####
+####def get_reference_genome(study_id, cursor):
+####    """ Get reference genome from the study """
+####    ref_genome = []
+####    try:
+####        cursor.execute('SELECT reference_genome.NAME FROM reference_genome ' +
+####        'inner join cancer_study ON cancer_study.reference_genome_id = reference_genome.reference_genome_id ' +
+####        'WHERE cancer_study.CANCER_STUDY_IDENTIFIER = "'+study_id +'"')
+####        for row in cursor.fetchall():
+####            ref_genome += [row[0]]
+####        if len(ref_genome) == 1:
+####            return REFERENCE_GENOME[ref_genome[0]]
+####        else:
+####            raise ValueError("There is an error when retrieving the reference genome, as multiple values have been retrieved: "+ref_genome)
+####    except MySQLdb.Error as msg:
+####        print(msg, file=ERROR_FILE)
+####
+####def fetch_oncokb_mutation_annotations(mutation_data, ref_genome):
+####    request_url = libImportOncokb.DEFAULT_ONCOKB_URL + "/annotate/mutations/byProteinChange"
+####    request_payload = create_mutation_request_payload(mutation_data, ref_genome)
+####    result = libImportOncokb.fetch_oncokb_annotations(request_payload, request_url)
+####    return result
+####
+####def create_mutation_request_payload(mutation_data, ref_genome):
+####    elements = {}
+####    for mutation in mutation_data:
+####        elements[mutation["id"]] = '{"alteration": "' + mutation["alteration"] + '", "consequence": "'+mutation["consequence"] + \
+####                            '", "gene": {"entrezGeneId": '+ str(mutation["entrezGeneId"]) +'}, "id": "'+mutation["id"] + \
+####                            '", "referenceGenome": "'+ref_genome+'"}'
+####
+####    return list(elements.values())
+####
+####def fetch_oncokb_copy_number_annotations(copy_number_data, ref_genome):
+####    request_url = libImportOncokb.DEFAULT_ONCOKB_URL + "/annotate/copyNumberAlterations"
+####    request_payload = create_copy_number_request_payload(copy_number_data, ref_genome)
+####    result = libImportOncokb.fetch_oncokb_annotations(request_payload, request_url)
+####    return result
+####
+####def create_copy_number_request_payload(copy_number_data, ref_genome):
+####    elements = {}
+####    for copy_number in copy_number_data:
+####        elements[copy_number["id"]] = '{"copyNameAlterationType":"'+ copy_number["alteration"]+'", "gene":{"entrezGeneId":'+str(copy_number["entrezGeneId"])+ \
+####            '}, "id":"'+copy_number["id"]+'", "referenceGenome": "'+ref_genome+'"}'
+####
+####    return list(elements.values())
+####
+####def fetch_oncokb_sv_annotations(sv_data, ref_genome):
+####    request_url = libImportOncokb.DEFAULT_ONCOKB_URL + "/annotate/structuralVariants"
+####    request_payload = create_sv_request_payload(sv_data, ref_genome)
+####    result = libImportOncokb.fetch_oncokb_annotations(request_payload, request_url, sv=True)
+####    return result
+####
+####def create_sv_request_payload(sv_data, ref_genome):
+####    elements = {}
+####    for sv in sv_data:
+####        elements[sv["id"]] = '{"structuralVariantType":"'+ sv["structuralVariantType"].upper()+'", "geneA":{"entrezGeneId":'+str(sv["entrezGeneIdA"])+ \
+####            '}, "geneB":{"entrezGeneId":'+str(sv["entrezGeneIdB"])+'}, "id":"'+sv["id"]+'", "referenceGenome": "'+ref_genome+'"}'
+####
+####    return list(elements.values())
+####
+####def get_current_annotation_data(connection, cursor, study_id):
+####    annotation_data = []
+####    try:
+####        cursor.execute('SELECT ALTERATION_EVENT_ID, alteration_driver_annotation.GENETIC_PROFILE_ID, SAMPLE_ID, DRIVER_FILTER_ANNOTATION,' +
+####            ' DRIVER_TIERS_FILTER, DRIVER_TIERS_FILTER_ANNOTATION FROM cbioportal.alteration_driver_annotation' +
+####            ' INNER JOIN cbioportal.genetic_profile ON (genetic_profile.GENETIC_PROFILE_ID = alteration_driver_annotation.GENETIC_PROFILE_ID)' +
+####            ' INNER JOIN cbioportal.cancer_study ON (cancer_study.CANCER_STUDY_ID = genetic_profile.CANCER_STUDY_ID)' +
+####            ' WHERE cancer_study.CANCER_STUDY_IDENTIFIER = "'+study_id+'"')
+####        for row in cursor.fetchall():
+####            annotation_data += ["_".join([str(row[0]), str(row[1]), str(row[2])])]
+####    except MySQLdb.Error as msg:
+####        print(msg, file=ERROR_FILE)
+####    return annotation_data
+####
+####def update_annotations(result, connection, cursor, study_id):
+####    current_annotation_data = get_current_annotation_data(connection, cursor, study_id)
+####    #Go over all the entries retrieved and add them to the database
+####    for entry in result:
+####        parsed_id = entry["query"]["id"].split("_")
+####        event_id = parsed_id[0]
+####        genetic_profile_id = parsed_id[1]
+####        sample_id = parsed_id[2]
+####        oncogenic = libImportOncokb.evaluate_driver_passenger(entry["oncogenic"])
+####        if entry["query"]["id"] in current_annotation_data:
+####            try:
+####                cursor.execute('UPDATE cbioportal.alteration_driver_annotation'+
+####                ' SET DRIVER_FILTER = "' + oncogenic + '"' +
+####                ' WHERE ALTERATION_EVENT_ID = ' + event_id + ' AND GENETIC_PROFILE_ID = '+ genetic_profile_id + 
+####                ' AND SAMPLE_ID = '+ sample_id)
+####            except MySQLdb.Error as msg:
+####                print(msg, file=ERROR_FILE)
+####        else:
+####            try:
+####                cursor.execute('INSERT INTO cbioportal.alteration_driver_annotation'+
+####                ' VALUES (' + event_id + ', '+ genetic_profile_id + ', '+ sample_id + ', "'+ oncogenic + '", "", "", "")')
+####            except MySQLdb.Error as msg:
+####                print(msg, file=ERROR_FILE)
+####        
+####def main_import(study_id, properties_filename):
+####
+####    portal_properties = get_database_properties(properties_filename)
+####    if portal_properties is None:
+####        print('failure reading properties file (%s)' % properties_filename, file=ERROR_FILE)
+####        sys.exit(1)
+####
+####    # Connect to the database.
+####    # TODO: must be a unique transaction
+####    connection, cursor = get_db_cursor(portal_properties)
+####    if cursor is None:
+####        print('failure connecting to sql database', file=ERROR_FILE)
+####        sys.exit(1)
+####
+####    # Query DB to get mutation, cna and structural variant data of the study.
+####    mutation_study_data = get_current_mutation_data(study_id, cursor)
+####    cna_study_data = get_current_cna_data(study_id, cursor)
+####    sv_study_data = get_current_sv_data(study_id, cursor)
+####
+####    # Call OncoKB to get annotations for the mutation, cna and structural variant data retrieved.
+####    ref_genome = get_reference_genome(study_id, cursor)
+####    mutation_result = fetch_oncokb_mutation_annotations(mutation_study_data, ref_genome)
+####    cna_result = fetch_oncokb_copy_number_annotations(cna_study_data, ref_genome)
+####    sv_result = fetch_oncokb_sv_annotations(sv_study_data, ref_genome)
+####    all_results = mutation_result + cna_result + sv_result
+####    
+####    # Query DB to update alteration_driver_annotation table data, one record at a time.
+####    update_annotations(all_results, connection, cursor, study_id)
+####
+####    # Commit changes to the database at once to ensure a unique transaction.
+####    try:
+####        connection.commit()
+####        print('Update complete')
+####        return 0
+####    except MySQLdb.Error as msg:
+####        print(msg, file=ERROR_FILE)
+####        connection.rollback()
+####        return 1
+####
+####
+####def interface():
+####    parser = argparse.ArgumentParser(description='cBioPortal OncoKB annotation updater')
+####    parser.add_argument('-s', '--study_id',
+####                        type=str,
+####                        required=True,
+####                        help='Study Identifier')
+####    parser.add_argument('-p', '--portal_properties', type=str, required=True,
+####                        help='application.properties of cBioPortal')
+####    parser = parser.parse_args()
+####    return parser
+####
+####
+####if __name__ == '__main__':
+####    try:
+####        parsed_args = interface()
+####        exit_status = main_import(parsed_args.study_id, parsed_args.portal_properties)
+####    finally:
+####        logging.shutdown()
+####        del logging._handlerList[:]  # workaround for harmless exceptions on exit
+####    print(('Update of OncoKB annotations for mutations {status}.'.format(
+####        status={0: 'succeeded',
+####                1: 'failed',
+####                2: 'not performed as problems occurred',
+####                3: 'succeeded with warnings'}.get(exit_status, 'unknown'))), file=sys.stderr)
+####    sys.exit(exit_status)
 import sys
-import MySQLdb
-from pathlib import Path
-from cbioportal_common import get_database_properties, get_db_cursor
-import libImportOncokb
-
-
-# configure relative imports if running as a script; see PEP 366
-# it might passed as empty string by certain tooling to mark a top level module
-if __name__ == "__main__" and (__package__ is None or __package__ == ''):
-    # replace the script's location in the Python search path by the main
-    # scripts/ folder, above it, so that the importer package folder is in
-    # scope and *not* directly in sys.path; see PEP 395
-    sys.path[0] = str(Path(sys.path[0]).resolve().parent)
-    __package__ = 'importer'
-    # explicitly import the package, which is needed on CPython 3.4 because it
-    # doesn't include https://github.com/python/cpython/pull/2639
-    importlib.import_module(__package__)
-
-
-ERROR_FILE = sys.stderr
-REFERENCE_GENOME = {'hg19': 'GRCh37', 'hg38': 'GRCh38'}
-
-# from: cbioportal-frontend file CopyNumberUtils.ts
-cna_alteration_types = {
-    "DELETION": -2,
-    "LOSS": -1,
-    "GAIN": 1,
-    "AMPLIFICATION": 2,
-}
-
-def get_current_mutation_data(study_id, cursor):
-    """ Get mutation data from the current study.
-        Returns an array of dictionaries, with the following keys:
-        id, geneticProfileId, entrezGeneId, alteration, and consequence
-    """
-    mutations = []
-    try:
-        cursor.execute('SELECT genetic_profile.GENETIC_PROFILE_ID, mutation_event.ENTREZ_GENE_ID, PROTEIN_CHANGE as ALTERATION, ' +
-        'MUTATION_TYPE as CONSEQUENCE, mutation.MUTATION_EVENT_ID, mutation.SAMPLE_ID FROM cbioportal.mutation_event ' +
-        'inner join mutation on mutation.MUTATION_EVENT_ID = mutation_event.MUTATION_EVENT_ID ' +
-        'inner join genetic_profile on genetic_profile.GENETIC_PROFILE_ID = mutation.GENETIC_PROFILE_ID ' +
-        'inner join cancer_study on cancer_study.CANCER_STUDY_ID = genetic_profile.CANCER_STUDY_ID ' +
-        'WHERE cancer_study.CANCER_STUDY_IDENTIFIER = "'+study_id +'"')
-        for row in cursor.fetchall():
-            mutations += [{ "id": "_".join([str(row[4]), str(row[0]), str(row[5])]), "geneticProfileId": row[0], "entrezGeneId": row[1],
-                            "alteration": row[2], "consequence": row[3]}]
-    except MySQLdb.Error as msg:
-        print(msg, file=ERROR_FILE)
-        return None
-    return mutations
-
-def get_current_cna_data(study_id, cursor):
-    """ Get cna data from the current study.
-        Returns an array of dictionaries, with the following keys:
-        id, geneticProfileId, entrezGeneId, and alteration
-    """
-    cna = []
-    try:
-        cursor.execute('SELECT genetic_profile.GENETIC_PROFILE_ID, '+ 'cna_event.ENTREZ_GENE_ID, cna_event.ALTERATION, '+
-        'sample_cna_event.CNA_EVENT_ID, sample_cna_event.SAMPLE_ID from cbioportal.cna_event ' +
-        'inner join sample_cna_event on sample_cna_event.CNA_EVENT_ID = cna_event.CNA_EVENT_ID '+
-        'inner join genetic_profile on genetic_profile.GENETIC_PROFILE_ID = sample_cna_event.GENETIC_PROFILE_ID '+
-        'inner join cancer_study on cancer_study.CANCER_STUDY_ID = genetic_profile.CANCER_STUDY_ID '+
-        'WHERE cancer_study.CANCER_STUDY_IDENTIFIER = "'+study_id +'"')
-        for row in cursor.fetchall():
-            alteration = list(cna_alteration_types.keys())[
-                list(cna_alteration_types.values()).index(row[2])]
-            cna += [{"id": "_".join([str(row[3]), str(row[0]), str(row[4])]), "geneticProfileId": row[0], "entrezGeneId": row[1],
-                    "alteration": alteration}]
-    except MySQLdb.Error as msg:
-        print(msg, file=ERROR_FILE)
-        return None
-    return cna
-
-def get_current_sv_data(study_id, cursor):
-    """ Get structural variant data from the current study.
-        Returns an array of dictionaries, with the following keys:
-        id, geneticProfileId, entrezGeneIdA, entrezGeneIdB, and structuralVariantType
-    """
-    sv = []
-    try:
-        cursor.execute('SELECT genetic_profile.GENETIC_PROFILE_ID, '+ 'structural_variant.SITE1_ENTREZ_GENE_ID, '+
-        'structural_variant.SITE2_ENTREZ_GENE_ID, structural_variant.EVENT_INFO, ' +
-        'structural_variant.INTERNAL_ID, structural_variant.SAMPLE_ID from cbioportal.structural_variant ' +
-        'inner join genetic_profile on genetic_profile.GENETIC_PROFILE_ID = structural_variant.GENETIC_PROFILE_ID '+
-        'inner join cancer_study on cancer_study.CANCER_STUDY_ID = genetic_profile.CANCER_STUDY_ID '+
-        'WHERE cancer_study.CANCER_STUDY_IDENTIFIER = "'+study_id +'"')
-        for row in cursor.fetchall():
-            sv += [{"id": "_".join([str(row[4]), str(row[0]), str(row[5])]), "geneticProfileId": row[0], "entrezGeneIdA": row[1],
-                    "entrezGeneIdB": row[2], "structuralVariantType": row[3]}]
-    except MySQLdb.Error as msg:
-        print(msg, file=ERROR_FILE)
-        return None
-    return sv
-
-def get_reference_genome(study_id, cursor):
-    """ Get reference genome from the study """
-    ref_genome = []
-    try:
-        cursor.execute('SELECT reference_genome.NAME FROM reference_genome ' +
-        'inner join cancer_study ON cancer_study.reference_genome_id = reference_genome.reference_genome_id ' +
-        'WHERE cancer_study.CANCER_STUDY_IDENTIFIER = "'+study_id +'"')
-        for row in cursor.fetchall():
-            ref_genome += [row[0]]
-        if len(ref_genome) == 1:
-            return REFERENCE_GENOME[ref_genome[0]]
-        else:
-            raise ValueError("There is an error when retrieving the reference genome, as multiple values have been retrieved: "+ref_genome)
-    except MySQLdb.Error as msg:
-        print(msg, file=ERROR_FILE)
-
-def fetch_oncokb_mutation_annotations(mutation_data, ref_genome):
-    request_url = libImportOncokb.DEFAULT_ONCOKB_URL + "/annotate/mutations/byProteinChange"
-    request_payload = create_mutation_request_payload(mutation_data, ref_genome)
-    result = libImportOncokb.fetch_oncokb_annotations(request_payload, request_url)
-    return result
-
-def create_mutation_request_payload(mutation_data, ref_genome):
-    elements = {}
-    for mutation in mutation_data:
-        elements[mutation["id"]] = '{"alteration": "' + mutation["alteration"] + '", "consequence": "'+mutation["consequence"] + \
-                            '", "gene": {"entrezGeneId": '+ str(mutation["entrezGeneId"]) +'}, "id": "'+mutation["id"] + \
-                            '", "referenceGenome": "'+ref_genome+'"}'
-
-    return list(elements.values())
-
-def fetch_oncokb_copy_number_annotations(copy_number_data, ref_genome):
-    request_url = libImportOncokb.DEFAULT_ONCOKB_URL + "/annotate/copyNumberAlterations"
-    request_payload = create_copy_number_request_payload(copy_number_data, ref_genome)
-    result = libImportOncokb.fetch_oncokb_annotations(request_payload, request_url)
-    return result
-
-def create_copy_number_request_payload(copy_number_data, ref_genome):
-    elements = {}
-    for copy_number in copy_number_data:
-        elements[copy_number["id"]] = '{"copyNameAlterationType":"'+ copy_number["alteration"]+'", "gene":{"entrezGeneId":'+str(copy_number["entrezGeneId"])+ \
-            '}, "id":"'+copy_number["id"]+'", "referenceGenome": "'+ref_genome+'"}'
-
-    return list(elements.values())
-
-def fetch_oncokb_sv_annotations(sv_data, ref_genome):
-    request_url = libImportOncokb.DEFAULT_ONCOKB_URL + "/annotate/structuralVariants"
-    request_payload = create_sv_request_payload(sv_data, ref_genome)
-    result = libImportOncokb.fetch_oncokb_annotations(request_payload, request_url, sv=True)
-    return result
-
-def create_sv_request_payload(sv_data, ref_genome):
-    elements = {}
-    for sv in sv_data:
-        elements[sv["id"]] = '{"structuralVariantType":"'+ sv["structuralVariantType"].upper()+'", "geneA":{"entrezGeneId":'+str(sv["entrezGeneIdA"])+ \
-            '}, "geneB":{"entrezGeneId":'+str(sv["entrezGeneIdB"])+'}, "id":"'+sv["id"]+'", "referenceGenome": "'+ref_genome+'"}'
-
-    return list(elements.values())
-
-def get_current_annotation_data(connection, cursor, study_id):
-    annotation_data = []
-    try:
-        cursor.execute('SELECT ALTERATION_EVENT_ID, alteration_driver_annotation.GENETIC_PROFILE_ID, SAMPLE_ID, DRIVER_FILTER_ANNOTATION,' +
-            ' DRIVER_TIERS_FILTER, DRIVER_TIERS_FILTER_ANNOTATION FROM cbioportal.alteration_driver_annotation' +
-            ' INNER JOIN cbioportal.genetic_profile ON (genetic_profile.GENETIC_PROFILE_ID = alteration_driver_annotation.GENETIC_PROFILE_ID)' +
-            ' INNER JOIN cbioportal.cancer_study ON (cancer_study.CANCER_STUDY_ID = genetic_profile.CANCER_STUDY_ID)' +
-            ' WHERE cancer_study.CANCER_STUDY_IDENTIFIER = "'+study_id+'"')
-        for row in cursor.fetchall():
-            annotation_data += ["_".join([str(row[0]), str(row[1]), str(row[2])])]
-    except MySQLdb.Error as msg:
-        print(msg, file=ERROR_FILE)
-    return annotation_data
-
-def update_annotations(result, connection, cursor, study_id):
-    current_annotation_data = get_current_annotation_data(connection, cursor, study_id)
-    #Go over all the entries retrieved and add them to the database
-    for entry in result:
-        parsed_id = entry["query"]["id"].split("_")
-        event_id = parsed_id[0]
-        genetic_profile_id = parsed_id[1]
-        sample_id = parsed_id[2]
-        oncogenic = libImportOncokb.evaluate_driver_passenger(entry["oncogenic"])
-        if entry["query"]["id"] in current_annotation_data:
-            try:
-                cursor.execute('UPDATE cbioportal.alteration_driver_annotation'+
-                ' SET DRIVER_FILTER = "' + oncogenic + '"' +
-                ' WHERE ALTERATION_EVENT_ID = ' + event_id + ' AND GENETIC_PROFILE_ID = '+ genetic_profile_id + 
-                ' AND SAMPLE_ID = '+ sample_id)
-            except MySQLdb.Error as msg:
-                print(msg, file=ERROR_FILE)
-        else:
-            try:
-                cursor.execute('INSERT INTO cbioportal.alteration_driver_annotation'+
-                ' VALUES (' + event_id + ', '+ genetic_profile_id + ', '+ sample_id + ', "'+ oncogenic + '", "", "", "")')
-            except MySQLdb.Error as msg:
-                print(msg, file=ERROR_FILE)
-        
-def main_import(study_id, properties_filename):
-
-    portal_properties = get_database_properties(properties_filename)
-    if portal_properties is None:
-        print('failure reading properties file (%s)' % properties_filename, file=ERROR_FILE)
-        sys.exit(1)
-
-    # Connect to the database.
-    # TODO: must be a unique transaction
-    connection, cursor = get_db_cursor(portal_properties)
-    if cursor is None:
-        print('failure connecting to sql database', file=ERROR_FILE)
-        sys.exit(1)
-
-    # Query DB to get mutation, cna and structural variant data of the study.
-    mutation_study_data = get_current_mutation_data(study_id, cursor)
-    cna_study_data = get_current_cna_data(study_id, cursor)
-    sv_study_data = get_current_sv_data(study_id, cursor)
-
-    # Call OncoKB to get annotations for the mutation, cna and structural variant data retrieved.
-    ref_genome = get_reference_genome(study_id, cursor)
-    mutation_result = fetch_oncokb_mutation_annotations(mutation_study_data, ref_genome)
-    cna_result = fetch_oncokb_copy_number_annotations(cna_study_data, ref_genome)
-    sv_result = fetch_oncokb_sv_annotations(sv_study_data, ref_genome)
-    all_results = mutation_result + cna_result + sv_result
-    
-    # Query DB to update alteration_driver_annotation table data, one record at a time.
-    update_annotations(all_results, connection, cursor, study_id)
-
-    # Commit changes to the database at once to ensure a unique transaction.
-    try:
-        connection.commit()
-        print('Update complete')
-        return 0
-    except MySQLdb.Error as msg:
-        print(msg, file=ERROR_FILE)
-        connection.rollback()
-        return 1
-
-
-def interface():
-    parser = argparse.ArgumentParser(description='cBioPortal OncoKB annotation updater')
-    parser.add_argument('-s', '--study_id',
-                        type=str,
-                        required=True,
-                        help='Study Identifier')
-    parser.add_argument('-p', '--portal_properties', type=str, required=True,
-                        help='application.properties of cBioPortal')
-    parser = parser.parse_args()
-    return parser
-
-
 if __name__ == '__main__':
-    try:
-        parsed_args = interface()
-        exit_status = main_import(parsed_args.study_id, parsed_args.portal_properties)
-    finally:
-        logging.shutdown()
-        del logging._handlerList[:]  # workaround for harmless exceptions on exit
-    print(('Update of OncoKB annotations for mutations {status}.'.format(
-        status={0: 'succeeded',
-                1: 'failed',
-                2: 'not performed as problems occurred',
-                3: 'succeeded with warnings'}.get(exit_status, 'unknown'))), file=sys.stderr)
-    sys.exit(exit_status)
+    print('This script (updateOncokbAnnotations.py) was written to interact with a mysql database, and the cbioportal system no longer uses a mysql database. This script must be adapted to a clickhouse database interaction approach before it will be runnable.', file=sys.stderr)
+    sys.exit(1)

--- a/scripts/migrate_db.py
+++ b/scripts/migrate_db.py
@@ -1,453 +1,458 @@
 #!/usr/bin/env python3
 
-import os
-import re
+####import os
+####import re
+####import sys
+####import contextlib
+####import argparse
+####from collections import OrderedDict
+####
+####from importer.cbioportal_common import get_database_properties, get_db_cursor
+####
+####import MySQLdb
+####from pathlib import Path
+####
+##### globals
+####ERROR_FILE = sys.stderr
+####OUTPUT_FILE = sys.stdout
+####VERSION_TABLE = 'info'
+####VERSION_FIELD = 'DB_SCHEMA_VERSION'
+####ALLOWABLE_GENOME_REFERENCES = ['37', 'hg19', 'GRCh37', '38', 'hg38', 'GRCh38', 'mm10', 'GRCm38']
+####DEFAULT_GENOME_REFERENCE = 'hg19'
+####MULTI_REFERENCE_GENOME_SUPPORT_MIGRATION_STEP = (2, 11, 0)
+####GENERIC_ASSAY_MIGRATION_STEP = (2, 12, 1)
+####SAMPLE_FK_MIGRATION_STEP = (2, 12, 9)
+####FUSIONS_VERBOTEN_STEP = (2, 12, 14)
+####
+####
+####class PortalProperties(object):
+####    """ Properties object class, just has fields for db conn """
+####
+####    def __init__(self, database_user, database_pw, database_url):
+####        self.database_user = database_user
+####        self.database_pw = database_pw
+####        self.database_url = database_url
+####
+####
+####def get_db_version(cursor):
+####    """ gets the version number of the database """
+####    # First, see if the version table exists
+####    version_table_exists = False
+####    try:
+####        cursor.execute('select table_name from information_schema.tables')
+####        for row in cursor.fetchall():
+####            if VERSION_TABLE == row[0].lower().strip():
+####                version_table_exists = True
+####    except MySQLdb.Error as msg:
+####        print(msg, file=ERROR_FILE)
+####        return None
+####    if not version_table_exists:
+####        return (0, 0, 0)
+####    # Now query the table for the version number
+####    try:
+####        cursor.execute('select ' + VERSION_FIELD + ' from ' + VERSION_TABLE)
+####        for row in cursor.fetchall():
+####            version = tuple(map(int, row[0].strip().split('.')))
+####    except MySQLdb.Error as msg:
+####        print(msg, file=ERROR_FILE)
+####        return None
+####    return version
+####
+####
+####def is_version_larger(version1, version2):
+####    """ Checks if version 1 is larger than version 2 """
+####    if version1[0] > version2[0]:
+####        return True
+####    if version2[0] > version1[0]:
+####        return False
+####    if version1[1] > version2[1]:
+####        return True
+####    if version2[1] > version1[1]:
+####        return False
+####    if version1[2] > version2[2]:
+####        return True
+####    return False
+####
+####
+####def is_version_equal(version1, version2):
+####    """ Checks if version 1 is equal to version 2"""
+####    return version1[0] == version2[0] and version1[1] == version2[1] and version1[2] == version2[2]
+####
+####
+####def print_all_check_reference_genome_warnings(warnings, force_migration):
+####    """ Format warnings for output according to mode, and print to ERROR_FILE """
+####    space = ' '
+####    indent = 28 * space
+####    allowable_reference_genome_string = ','.join(ALLOWABLE_GENOME_REFERENCES)
+####    clean_up_string = ' Please clean up the mutation_event table and ensure it only contains references to one of the valid reference genomes (%s).' % (
+####        allowable_reference_genome_string)
+####    use_default_string = 'the default reference genome (%s) will be used in place of invalid reference genomes and the first encountered reference genome will be used.' % (
+####        DEFAULT_GENOME_REFERENCE)
+####    use_force_string = 'OR use the "--force" option to override this warning, then %s' % (use_default_string)
+####    forcing_string = '--force option in effect : %s' % (use_default_string)
+####    for warning in warnings:
+####        if force_migration:
+####            print('%s%s\n%s%s\n' % (indent, warning, indent, forcing_string), file=ERROR_FILE)
+####        else:
+####            print('%s%s%s\n%s%s\n' % (indent, warning, clean_up_string, indent, use_force_string), file=ERROR_FILE)
+####
+####
+####def validate_reference_genome_values_for_study(warnings, ncbi_to_count, study):
+####    """ check if there are unrecognized or varied ncbi_build values for the study, add to warnings if problems are found """
+####    if len(ncbi_to_count) == 1:
+####        for retrieved_ncbi_build in ncbi_to_count:  # single iteration
+####            if retrieved_ncbi_build.upper() not in [x.upper() for x in ALLOWABLE_GENOME_REFERENCES]:
+####                msg = 'WARNING: Study %s contains mutation_event records with unsupported NCBI_BUILD value %s.' % (
+####                study, retrieved_ncbi_build)
+####                warnings.append(msg)
+####    elif len(ncbi_to_count) > 1:
+####        msg = 'WARNING: Study %s contains mutation_event records with %s NCBI_BUILD values {ncbi_build:record_count,...} %s.' % (
+####        study, len(ncbi_to_count), ncbi_to_count)
+####        warnings.append(msg)
+####
+####
+####def check_reference_genome(portal_properties, cursor, force_migration):
+####    """ query database for ncbi_build values, aggregate per study, then validate and report problems """
+####    print('Checking database contents for reference genome information', file=OUTPUT_FILE)
+####    """ Retrieve reference genomes from database """
+####    warnings = []
+####    try:
+####        sql_statement = """
+####                           select NCBI_BUILD, count(NCBI_BUILD), CANCER_STUDY_IDENTIFIER
+####                           from mutation_event
+####                           join mutation on mutation.MUTATION_EVENT_ID = mutation_event.MUTATION_EVENT_ID
+####                           join genetic_profile on genetic_profile.GENETIC_PROFILE_ID = mutation.GENETIC_PROFILE_ID
+####                           join cancer_study on cancer_study.CANCER_STUDY_ID = genetic_profile.CANCER_STUDY_ID
+####                           group by CANCER_STUDY_IDENTIFIER, NCBI_BUILD
+####                       """
+####        cursor.execute(sql_statement)
+####        study_to_ncbi_to_count = {}  # {cancer_study_identifier : {ncbi_build  : record_count}}
+####        for row in cursor.fetchall():
+####            retrieved_ncbi_build, ref_count, study = row
+####            if study in study_to_ncbi_to_count:
+####                study_to_ncbi_to_count[study][retrieved_ncbi_build] = ref_count
+####            else:
+####                study_to_ncbi_to_count[study] = {retrieved_ncbi_build: ref_count}
+####        for study in study_to_ncbi_to_count:
+####            validate_reference_genome_values_for_study(warnings, study_to_ncbi_to_count[study], study)
+####    except MySQLdb.Error as msg:
+####        print(msg, file=ERROR_FILE)
+####        sys.exit(1)
+####    if warnings:
+####        print_all_check_reference_genome_warnings(warnings, force_migration)
+####        if not force_migration:
+####            sys.exit(1)
+####
+####
+####def check_and_exit_if_fusions(cursor):
+####    try:
+####        cursor.execute(
+####            """
+####                SELECT COUNT(*)
+####                FROM mutation_event
+####                WHERE MUTATION_TYPE = "Fusion";
+####            """)
+####        fusion_count = cursor.fetchone()
+####        if (fusion_count[0] >= 1):
+####            print(
+####                'Found %i records in the mutation_event table where the mutation_type was "Fusion". The latest database schema does not allow records in the mutation table where mutation_type is set to "Fusion". Studies linked to existing records of this type should be deleted in order to migrate to DB version 2.12.14' % (
+####                    fusion_count), file=ERROR_FILE)
+####            # get the list of studies that need to be cleaned up
+####            cursor.execute(
+####                """
+####                    SELECT cancer_study.CANCER_STUDY_IDENTIFIER, COUNT(mutation.MUTATION_EVENT_ID)
+####                    FROM cancer_study,
+####                        genetic_profile
+####                    LEFT JOIN mutation ON genetic_profile.GENETIC_PROFILE_ID = mutation.GENETIC_PROFILE_ID
+####                    LEFT JOIN mutation_event ON mutation.MUTATION_EVENT_ID = mutation_event.MUTATION_EVENT_ID
+####                    WHERE 
+####                        genetic_profile.CANCER_STUDY_ID = cancer_study.CANCER_STUDY_ID
+####                        AND mutation_event.MUTATION_TYPE = "Fusion"
+####                    GROUP BY cancer_study.CANCER_STUDY_IDENTIFIER
+####                    HAVING count(mutation.MUTATION_EVENT_ID) > 0
+####                """)
+####            rows = cursor.fetchall()
+####            print("The following studies have fusions in the mutation_event table:", file=ERROR_FILE)
+####            for row in rows:
+####                print("\t%s" % (row[0]), file=ERROR_FILE)
+####            sys.exit(1)
+####
+####    except MySQLdb.Error as msg:
+####        print(msg, file=ERROR_FILE)
+####        sys.exit(1)
+####
+####
+##### TODO: remove this after we update mysql version
+####def check_and_remove_invalid_foreign_keys(cursor):
+####    try:
+####        # if genetic_alteration_ibfk_2 exists
+####        cursor.execute(
+####            """
+####                SELECT *
+####                FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+####                    WHERE CONSTRAINT_TYPE = 'FOREIGN KEY'
+####                    AND TABLE_SCHEMA = DATABASE()
+####                    AND CONSTRAINT_NAME = 'genetic_alteration_ibfk_2'
+####            """)
+####        rows = cursor.fetchall()
+####        if (len(rows) >= 1):
+####            # if genetic_alteration_fk_2 also exists, delete it
+####            cursor.execute(
+####                """
+####                    SELECT *
+####                    FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+####                        WHERE CONSTRAINT_TYPE = 'FOREIGN KEY'
+####                        AND TABLE_SCHEMA = DATABASE()
+####                        AND CONSTRAINT_NAME = 'genetic_alteration_fk_2'
+####                """)
+####            rows = cursor.fetchall()
+####            if (len(rows) >= 1):
+####                print('Invalid foreign key found.', file=OUTPUT_FILE)
+####                cursor.execute(
+####                    """
+####                        ALTER TABLE `genetic_alteration` DROP FOREIGN KEY genetic_alteration_fk_2;
+####                    """)
+####                print('Invalid foreign key has been deleted.', file=OUTPUT_FILE)
+####    except MySQLdb.Error as msg:
+####        print(msg, file=ERROR_FILE)
+####        sys.exit(1)
+####
+####
+####def check_and_remove_type_of_cancer_id_foreign_key(cursor):
+####    """The TYPE_OF_CANCER_ID foreign key in the sample table can be either sample_ibfk_1 or sample_ibfk_2. Figure out which one it is and remove it"""
+####    try:
+####        # if sample_ibfk_1 exists
+####        cursor.execute(
+####            """
+####                SELECT *
+####                FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
+####                    WHERE CONSTRAINT_SCHEMA = DATABASE()
+####                    AND TABLE_NAME = 'sample'
+####                    AND REFERENCED_TABLE_NAME = 'type_of_cancer'
+####                    AND CONSTRAINT_NAME = 'sample_ibfk_1'
+####            """)
+####        rows = cursor.fetchall()
+####        if (len(rows) >= 1):
+####            print(
+####                'sample_ibfk_1 is the foreign key in table sample for type_of_cancer_id column in table type_of_cancer.',
+####                file=OUTPUT_FILE)
+####            cursor.execute(
+####                """
+####                    ALTER TABLE `sample` DROP FOREIGN KEY sample_ibfk_1;
+####                """)
+####            print('sample_ibfk_1 foreign key has been deleted.', file=OUTPUT_FILE)
+####        # if sample_ibfk_2 exists
+####        cursor.execute(
+####            """
+####                SELECT *
+####                FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
+####                    WHERE CONSTRAINT_SCHEMA = DATABASE()
+####                    AND TABLE_NAME = 'sample'
+####                    AND REFERENCED_TABLE_NAME = 'type_of_cancer'
+####                    AND CONSTRAINT_NAME = 'sample_ibfk_2'
+####            """)
+####        rows = cursor.fetchall()
+####        if (len(rows) >= 1):
+####            print(
+####                'sample_ibfk_2 is the foreign key in table sample for type_of_cancer_id column in table type_of_cancer.',
+####                file=OUTPUT_FILE)
+####            cursor.execute(
+####                """
+####                    ALTER TABLE `sample` DROP FOREIGN KEY sample_ibfk_2;
+####                """)
+####            print('sample_ibfk_2 foreign key has been deleted.', file=OUTPUT_FILE)
+####    except MySQLdb.Error as msg:
+####        print(msg, file=ERROR_FILE)
+####        sys.exit(1)
+####
+####
+####def strip_trailing_comment_from_line(line):
+####    line_parts = re.split("--\s", line)
+####    return line_parts[0]
+####
+####
+####def run_migration(db_version, sql_filename, connection, cursor, no_transaction, stop_at_version=None):
+####    """
+####        Goes through the sql and runs lines based on the version numbers. SQL version should be stated as follows:
+####
+####        ##version: 1.0.0
+####        INSERT INTO ...
+####
+####        ##version: 1.1.0
+####        CREATE TABLE ...
+####    """
+####    sql_file = open(sql_filename, 'r')
+####    sql_version = (0, 0, 0)
+####    run_line = False
+####    statements = OrderedDict()
+####    statement = ''
+####    for line in sql_file:
+####        if line.startswith('##'):
+####            sql_version = tuple(map(int, line.split(':')[1].strip().split('.')))
+####            # stop at the version specified
+####            if stop_at_version is not None and is_version_equal(sql_version, stop_at_version):
+####                break
+####            else:
+####                run_line = is_version_larger(sql_version, db_version)
+####                continue
+####        # skip blank lines
+####        if len(line.strip()) < 1:
+####            continue
+####        # skip comments
+####        if line.startswith('#'):
+####            continue
+####        # skip sql comments
+####        if line.startswith('--') and len(line) > 2 and line[2].isspace():
+####            continue
+####        # only execute sql line if the last version seen in the file is greater than the db_version
+####        if run_line:
+####            line = line.strip()
+####            simplified_line = strip_trailing_comment_from_line(line)
+####            statement = statement + ' ' + simplified_line
+####            if simplified_line.endswith(';'):
+####                if sql_version not in statements:
+####                    statements[sql_version] = [statement]
+####                else:
+####                    statements[sql_version].append(statement)
+####                statement = ''
+####    if len(statements) > 0:
+####        run_statements(statements, connection, cursor, no_transaction)
+####    else:
+####        print('Everything up to date, nothing to migrate.', file=OUTPUT_FILE)
+####
+####
+####def run_statements(statements, connection, cursor, no_transaction):
+####    try:
+####        if no_transaction:
+####            cursor.execute('SET autocommit=1;')
+####        else:
+####            cursor.execute('SET autocommit=0;')
+####    except MySQLdb.Error as msg:
+####        print(msg, file=ERROR_FILE)
+####        sys.exit(1)
+####    for version, statement_list in statements.items():
+####        print(
+####            'Running statements for version: %s' % ('.'.join(map(str, version))),
+####            file=OUTPUT_FILE)
+####        for statement in statement_list:
+####            print(
+####                '\tExecuting statement: %s' % (statement.strip()),
+####                file=OUTPUT_FILE)
+####            try:
+####                cursor.execute(statement.strip())
+####            except MySQLdb.Error as msg:
+####                print(msg, file=ERROR_FILE)
+####                sys.exit(1)
+####        connection.commit()
+####
+####
+####def warn_user():
+####    """Warn the user to back up their database before the script runs."""
+####    response = input(
+####        'WARNING: This script will alter your database! Be sure to back up your data before running.\n'
+####        'Continue running DB migration? (y/n) '
+####    ).strip()
+####    while response.lower() != 'y' and response.lower() != 'n':
+####        response = input(
+####            'Did not recognize response.\nContinue running DB migration? (y/n) '
+####        ).strip()
+####    if response.lower() == 'n':
+####        sys.exit()
+####
+####
+####def usage():
+####    print(
+####        'migrate_db.py --properties-file [portal properties file] --sql [sql migration file]',
+####        file=OUTPUT_FILE)
+####
+####
+####def main():
+####    """ main function to run mysql migration """
+####    parser = argparse.ArgumentParser(description='cBioPortal DB migration script')
+####    parser.add_argument('-y', '--suppress_confirmation', default=False, action='store_true')
+####    parser.add_argument('-p', '--properties-file', type=str, required=False,
+####                        help='Path to application.properties file (default: locate it '
+####                             'relative to the script)')
+####    parser.add_argument('-s', '--sql', type=str, required=False,
+####                        help='Path to official migration.sql script. (default: locate it '
+####                             'relative to the script)')
+####    parser.add_argument('-f', '--force', default=False, action='store_true', help='Force to run database migration')
+####    parser.add_argument('--no-transaction', default=False, action='store_true', help="""
+####        Do not run migration in a single transaction. Only use this when you known what you are doing!!!
+####    """)
+####    parser = parser.parse_args()
+####
+####    properties_filename = parser.properties_file
+####    if properties_filename is None:
+####        # get the directory name of the currently running script,
+####        # resolving any symlinks
+####        script_dir = Path(__file__).resolve().parent
+####        # go up from cbioportal/core/src/main/scripts/ to cbioportal/
+####        src_root = script_dir.parent.parent.parent.parent
+####        properties_filename = src_root / 'application.properties'
+####                
+####    sql_filename = parser.sql
+####    if sql_filename is None:
+####        # get the directory name of the currently running script,
+####        # resolving any symlinks
+####        script_dir = Path(__file__).resolve().parent
+####        # go up from cbioportal/core/src/main/scripts/ to cbioportal/
+####        src_root = script_dir.parent.parent.parent.parent
+####        sql_filename = src_root / 'src/main/resources/db-scripts/migration.sql'
+####
+####    if not os.path.exists(sql_filename):
+####        print('sql file %s cannot be found' % (sql_filename), file=ERROR_FILE)
+####        usage()
+####        sys.exit(2)
+####
+####    # parse properties file
+####    portal_properties = get_database_properties(properties_filename)
+####    if portal_properties is None:
+####        print('failure reading properties file (%s)' % properties_filename, file=ERROR_FILE)
+####        sys.exit(1)
+####
+####    # warn user
+####    if not parser.suppress_confirmation:
+####        warn_user()
+####
+####    # set up - get db cursor
+####    connection, cursor = get_db_cursor(portal_properties)
+####    if cursor is None:
+####        print('failure connecting to sql database', file=ERROR_FILE)
+####        sys.exit(1)
+####
+####    # execute - get the database version and run the migration
+####    with contextlib.closing(connection):
+####        db_version = get_db_version(cursor)
+####        if is_version_larger(MULTI_REFERENCE_GENOME_SUPPORT_MIGRATION_STEP, db_version):
+####            run_migration(db_version, sql_filename, connection, cursor, parser.no_transaction,
+####                          stop_at_version=MULTI_REFERENCE_GENOME_SUPPORT_MIGRATION_STEP)
+####            # retrieve reference genomes from database
+####            check_reference_genome(portal_properties, cursor, parser.force)
+####            db_version = get_db_version(cursor)
+####        if is_version_larger(SAMPLE_FK_MIGRATION_STEP, db_version):
+####            run_migration(db_version, sql_filename, connection, cursor, parser.no_transaction,
+####                          stop_at_version=SAMPLE_FK_MIGRATION_STEP)
+####            check_and_remove_type_of_cancer_id_foreign_key(cursor)
+####            db_version = get_db_version(cursor)
+####        if is_version_larger(FUSIONS_VERBOTEN_STEP, db_version):
+####            run_migration(db_version, sql_filename, connection, cursor, parser.no_transaction,
+####                          stop_at_version=FUSIONS_VERBOTEN_STEP)
+####            check_and_exit_if_fusions(cursor)
+####            db_version = get_db_version(cursor)
+####        run_migration(db_version, sql_filename, connection, cursor, parser.no_transaction)
+####        # TODO: remove this after we update mysql version
+####        # check invalid foreign key only when current db version larger or qeuals to GENERIC_ASSAY_MIGRATION_STEP
+####        if not is_version_larger(GENERIC_ASSAY_MIGRATION_STEP, db_version):
+####            check_and_remove_invalid_foreign_keys(cursor)
+####    print('Finished.', file=OUTPUT_FILE)
+####
+####
+##### do main
+####if __name__ == '__main__':
+####    main()
+
 import sys
-import contextlib
-import argparse
-from collections import OrderedDict
-
-from importer.cbioportal_common import get_database_properties, get_db_cursor
-
-import MySQLdb
-from pathlib import Path
-
-# globals
-ERROR_FILE = sys.stderr
-OUTPUT_FILE = sys.stdout
-VERSION_TABLE = 'info'
-VERSION_FIELD = 'DB_SCHEMA_VERSION'
-ALLOWABLE_GENOME_REFERENCES = ['37', 'hg19', 'GRCh37', '38', 'hg38', 'GRCh38', 'mm10', 'GRCm38']
-DEFAULT_GENOME_REFERENCE = 'hg19'
-MULTI_REFERENCE_GENOME_SUPPORT_MIGRATION_STEP = (2, 11, 0)
-GENERIC_ASSAY_MIGRATION_STEP = (2, 12, 1)
-SAMPLE_FK_MIGRATION_STEP = (2, 12, 9)
-FUSIONS_VERBOTEN_STEP = (2, 12, 14)
-
-
-class PortalProperties(object):
-    """ Properties object class, just has fields for db conn """
-
-    def __init__(self, database_user, database_pw, database_url):
-        self.database_user = database_user
-        self.database_pw = database_pw
-        self.database_url = database_url
-
-
-def get_db_version(cursor):
-    """ gets the version number of the database """
-    # First, see if the version table exists
-    version_table_exists = False
-    try:
-        cursor.execute('select table_name from information_schema.tables')
-        for row in cursor.fetchall():
-            if VERSION_TABLE == row[0].lower().strip():
-                version_table_exists = True
-    except MySQLdb.Error as msg:
-        print(msg, file=ERROR_FILE)
-        return None
-    if not version_table_exists:
-        return (0, 0, 0)
-    # Now query the table for the version number
-    try:
-        cursor.execute('select ' + VERSION_FIELD + ' from ' + VERSION_TABLE)
-        for row in cursor.fetchall():
-            version = tuple(map(int, row[0].strip().split('.')))
-    except MySQLdb.Error as msg:
-        print(msg, file=ERROR_FILE)
-        return None
-    return version
-
-
-def is_version_larger(version1, version2):
-    """ Checks if version 1 is larger than version 2 """
-    if version1[0] > version2[0]:
-        return True
-    if version2[0] > version1[0]:
-        return False
-    if version1[1] > version2[1]:
-        return True
-    if version2[1] > version1[1]:
-        return False
-    if version1[2] > version2[2]:
-        return True
-    return False
-
-
-def is_version_equal(version1, version2):
-    """ Checks if version 1 is equal to version 2"""
-    return version1[0] == version2[0] and version1[1] == version2[1] and version1[2] == version2[2]
-
-
-def print_all_check_reference_genome_warnings(warnings, force_migration):
-    """ Format warnings for output according to mode, and print to ERROR_FILE """
-    space = ' '
-    indent = 28 * space
-    allowable_reference_genome_string = ','.join(ALLOWABLE_GENOME_REFERENCES)
-    clean_up_string = ' Please clean up the mutation_event table and ensure it only contains references to one of the valid reference genomes (%s).' % (
-        allowable_reference_genome_string)
-    use_default_string = 'the default reference genome (%s) will be used in place of invalid reference genomes and the first encountered reference genome will be used.' % (
-        DEFAULT_GENOME_REFERENCE)
-    use_force_string = 'OR use the "--force" option to override this warning, then %s' % (use_default_string)
-    forcing_string = '--force option in effect : %s' % (use_default_string)
-    for warning in warnings:
-        if force_migration:
-            print('%s%s\n%s%s\n' % (indent, warning, indent, forcing_string), file=ERROR_FILE)
-        else:
-            print('%s%s%s\n%s%s\n' % (indent, warning, clean_up_string, indent, use_force_string), file=ERROR_FILE)
-
-
-def validate_reference_genome_values_for_study(warnings, ncbi_to_count, study):
-    """ check if there are unrecognized or varied ncbi_build values for the study, add to warnings if problems are found """
-    if len(ncbi_to_count) == 1:
-        for retrieved_ncbi_build in ncbi_to_count:  # single iteration
-            if retrieved_ncbi_build.upper() not in [x.upper() for x in ALLOWABLE_GENOME_REFERENCES]:
-                msg = 'WARNING: Study %s contains mutation_event records with unsupported NCBI_BUILD value %s.' % (
-                study, retrieved_ncbi_build)
-                warnings.append(msg)
-    elif len(ncbi_to_count) > 1:
-        msg = 'WARNING: Study %s contains mutation_event records with %s NCBI_BUILD values {ncbi_build:record_count,...} %s.' % (
-        study, len(ncbi_to_count), ncbi_to_count)
-        warnings.append(msg)
-
-
-def check_reference_genome(portal_properties, cursor, force_migration):
-    """ query database for ncbi_build values, aggregate per study, then validate and report problems """
-    print('Checking database contents for reference genome information', file=OUTPUT_FILE)
-    """ Retrieve reference genomes from database """
-    warnings = []
-    try:
-        sql_statement = """
-                           select NCBI_BUILD, count(NCBI_BUILD), CANCER_STUDY_IDENTIFIER
-                           from mutation_event
-                           join mutation on mutation.MUTATION_EVENT_ID = mutation_event.MUTATION_EVENT_ID
-                           join genetic_profile on genetic_profile.GENETIC_PROFILE_ID = mutation.GENETIC_PROFILE_ID
-                           join cancer_study on cancer_study.CANCER_STUDY_ID = genetic_profile.CANCER_STUDY_ID
-                           group by CANCER_STUDY_IDENTIFIER, NCBI_BUILD
-                       """
-        cursor.execute(sql_statement)
-        study_to_ncbi_to_count = {}  # {cancer_study_identifier : {ncbi_build  : record_count}}
-        for row in cursor.fetchall():
-            retrieved_ncbi_build, ref_count, study = row
-            if study in study_to_ncbi_to_count:
-                study_to_ncbi_to_count[study][retrieved_ncbi_build] = ref_count
-            else:
-                study_to_ncbi_to_count[study] = {retrieved_ncbi_build: ref_count}
-        for study in study_to_ncbi_to_count:
-            validate_reference_genome_values_for_study(warnings, study_to_ncbi_to_count[study], study)
-    except MySQLdb.Error as msg:
-        print(msg, file=ERROR_FILE)
-        sys.exit(1)
-    if warnings:
-        print_all_check_reference_genome_warnings(warnings, force_migration)
-        if not force_migration:
-            sys.exit(1)
-
-
-def check_and_exit_if_fusions(cursor):
-    try:
-        cursor.execute(
-            """
-                SELECT COUNT(*)
-                FROM mutation_event
-                WHERE MUTATION_TYPE = "Fusion";
-            """)
-        fusion_count = cursor.fetchone()
-        if (fusion_count[0] >= 1):
-            print(
-                'Found %i records in the mutation_event table where the mutation_type was "Fusion". The latest database schema does not allow records in the mutation table where mutation_type is set to "Fusion". Studies linked to existing records of this type should be deleted in order to migrate to DB version 2.12.14' % (
-                    fusion_count), file=ERROR_FILE)
-            # get the list of studies that need to be cleaned up
-            cursor.execute(
-                """
-                    SELECT cancer_study.CANCER_STUDY_IDENTIFIER, COUNT(mutation.MUTATION_EVENT_ID)
-                    FROM cancer_study,
-                        genetic_profile
-                    LEFT JOIN mutation ON genetic_profile.GENETIC_PROFILE_ID = mutation.GENETIC_PROFILE_ID
-                    LEFT JOIN mutation_event ON mutation.MUTATION_EVENT_ID = mutation_event.MUTATION_EVENT_ID
-                    WHERE 
-                        genetic_profile.CANCER_STUDY_ID = cancer_study.CANCER_STUDY_ID
-                        AND mutation_event.MUTATION_TYPE = "Fusion"
-                    GROUP BY cancer_study.CANCER_STUDY_IDENTIFIER
-                    HAVING count(mutation.MUTATION_EVENT_ID) > 0
-                """)
-            rows = cursor.fetchall()
-            print("The following studies have fusions in the mutation_event table:", file=ERROR_FILE)
-            for row in rows:
-                print("\t%s" % (row[0]), file=ERROR_FILE)
-            sys.exit(1)
-
-    except MySQLdb.Error as msg:
-        print(msg, file=ERROR_FILE)
-        sys.exit(1)
-
-
-# TODO: remove this after we update mysql version
-def check_and_remove_invalid_foreign_keys(cursor):
-    try:
-        # if genetic_alteration_ibfk_2 exists
-        cursor.execute(
-            """
-                SELECT *
-                FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
-                    WHERE CONSTRAINT_TYPE = 'FOREIGN KEY'
-                    AND TABLE_SCHEMA = DATABASE()
-                    AND CONSTRAINT_NAME = 'genetic_alteration_ibfk_2'
-            """)
-        rows = cursor.fetchall()
-        if (len(rows) >= 1):
-            # if genetic_alteration_fk_2 also exists, delete it
-            cursor.execute(
-                """
-                    SELECT *
-                    FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
-                        WHERE CONSTRAINT_TYPE = 'FOREIGN KEY'
-                        AND TABLE_SCHEMA = DATABASE()
-                        AND CONSTRAINT_NAME = 'genetic_alteration_fk_2'
-                """)
-            rows = cursor.fetchall()
-            if (len(rows) >= 1):
-                print('Invalid foreign key found.', file=OUTPUT_FILE)
-                cursor.execute(
-                    """
-                        ALTER TABLE `genetic_alteration` DROP FOREIGN KEY genetic_alteration_fk_2;
-                    """)
-                print('Invalid foreign key has been deleted.', file=OUTPUT_FILE)
-    except MySQLdb.Error as msg:
-        print(msg, file=ERROR_FILE)
-        sys.exit(1)
-
-
-def check_and_remove_type_of_cancer_id_foreign_key(cursor):
-    """The TYPE_OF_CANCER_ID foreign key in the sample table can be either sample_ibfk_1 or sample_ibfk_2. Figure out which one it is and remove it"""
-    try:
-        # if sample_ibfk_1 exists
-        cursor.execute(
-            """
-                SELECT *
-                FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
-                    WHERE CONSTRAINT_SCHEMA = DATABASE()
-                    AND TABLE_NAME = 'sample'
-                    AND REFERENCED_TABLE_NAME = 'type_of_cancer'
-                    AND CONSTRAINT_NAME = 'sample_ibfk_1'
-            """)
-        rows = cursor.fetchall()
-        if (len(rows) >= 1):
-            print(
-                'sample_ibfk_1 is the foreign key in table sample for type_of_cancer_id column in table type_of_cancer.',
-                file=OUTPUT_FILE)
-            cursor.execute(
-                """
-                    ALTER TABLE `sample` DROP FOREIGN KEY sample_ibfk_1;
-                """)
-            print('sample_ibfk_1 foreign key has been deleted.', file=OUTPUT_FILE)
-        # if sample_ibfk_2 exists
-        cursor.execute(
-            """
-                SELECT *
-                FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
-                    WHERE CONSTRAINT_SCHEMA = DATABASE()
-                    AND TABLE_NAME = 'sample'
-                    AND REFERENCED_TABLE_NAME = 'type_of_cancer'
-                    AND CONSTRAINT_NAME = 'sample_ibfk_2'
-            """)
-        rows = cursor.fetchall()
-        if (len(rows) >= 1):
-            print(
-                'sample_ibfk_2 is the foreign key in table sample for type_of_cancer_id column in table type_of_cancer.',
-                file=OUTPUT_FILE)
-            cursor.execute(
-                """
-                    ALTER TABLE `sample` DROP FOREIGN KEY sample_ibfk_2;
-                """)
-            print('sample_ibfk_2 foreign key has been deleted.', file=OUTPUT_FILE)
-    except MySQLdb.Error as msg:
-        print(msg, file=ERROR_FILE)
-        sys.exit(1)
-
-
-def strip_trailing_comment_from_line(line):
-    line_parts = re.split("--\s", line)
-    return line_parts[0]
-
-
-def run_migration(db_version, sql_filename, connection, cursor, no_transaction, stop_at_version=None):
-    """
-        Goes through the sql and runs lines based on the version numbers. SQL version should be stated as follows:
-
-        ##version: 1.0.0
-        INSERT INTO ...
-
-        ##version: 1.1.0
-        CREATE TABLE ...
-    """
-    sql_file = open(sql_filename, 'r')
-    sql_version = (0, 0, 0)
-    run_line = False
-    statements = OrderedDict()
-    statement = ''
-    for line in sql_file:
-        if line.startswith('##'):
-            sql_version = tuple(map(int, line.split(':')[1].strip().split('.')))
-            # stop at the version specified
-            if stop_at_version is not None and is_version_equal(sql_version, stop_at_version):
-                break
-            else:
-                run_line = is_version_larger(sql_version, db_version)
-                continue
-        # skip blank lines
-        if len(line.strip()) < 1:
-            continue
-        # skip comments
-        if line.startswith('#'):
-            continue
-        # skip sql comments
-        if line.startswith('--') and len(line) > 2 and line[2].isspace():
-            continue
-        # only execute sql line if the last version seen in the file is greater than the db_version
-        if run_line:
-            line = line.strip()
-            simplified_line = strip_trailing_comment_from_line(line)
-            statement = statement + ' ' + simplified_line
-            if simplified_line.endswith(';'):
-                if sql_version not in statements:
-                    statements[sql_version] = [statement]
-                else:
-                    statements[sql_version].append(statement)
-                statement = ''
-    if len(statements) > 0:
-        run_statements(statements, connection, cursor, no_transaction)
-    else:
-        print('Everything up to date, nothing to migrate.', file=OUTPUT_FILE)
-
-
-def run_statements(statements, connection, cursor, no_transaction):
-    try:
-        if no_transaction:
-            cursor.execute('SET autocommit=1;')
-        else:
-            cursor.execute('SET autocommit=0;')
-    except MySQLdb.Error as msg:
-        print(msg, file=ERROR_FILE)
-        sys.exit(1)
-    for version, statement_list in statements.items():
-        print(
-            'Running statements for version: %s' % ('.'.join(map(str, version))),
-            file=OUTPUT_FILE)
-        for statement in statement_list:
-            print(
-                '\tExecuting statement: %s' % (statement.strip()),
-                file=OUTPUT_FILE)
-            try:
-                cursor.execute(statement.strip())
-            except MySQLdb.Error as msg:
-                print(msg, file=ERROR_FILE)
-                sys.exit(1)
-        connection.commit()
-
-
-def warn_user():
-    """Warn the user to back up their database before the script runs."""
-    response = input(
-        'WARNING: This script will alter your database! Be sure to back up your data before running.\n'
-        'Continue running DB migration? (y/n) '
-    ).strip()
-    while response.lower() != 'y' and response.lower() != 'n':
-        response = input(
-            'Did not recognize response.\nContinue running DB migration? (y/n) '
-        ).strip()
-    if response.lower() == 'n':
-        sys.exit()
-
-
-def usage():
-    print(
-        'migrate_db.py --properties-file [portal properties file] --sql [sql migration file]',
-        file=OUTPUT_FILE)
-
-
-def main():
-    """ main function to run mysql migration """
-    parser = argparse.ArgumentParser(description='cBioPortal DB migration script')
-    parser.add_argument('-y', '--suppress_confirmation', default=False, action='store_true')
-    parser.add_argument('-p', '--properties-file', type=str, required=False,
-                        help='Path to application.properties file (default: locate it '
-                             'relative to the script)')
-    parser.add_argument('-s', '--sql', type=str, required=False,
-                        help='Path to official migration.sql script. (default: locate it '
-                             'relative to the script)')
-    parser.add_argument('-f', '--force', default=False, action='store_true', help='Force to run database migration')
-    parser.add_argument('--no-transaction', default=False, action='store_true', help="""
-        Do not run migration in a single transaction. Only use this when you known what you are doing!!!
-    """)
-    parser = parser.parse_args()
-
-    properties_filename = parser.properties_file
-    if properties_filename is None:
-        # get the directory name of the currently running script,
-        # resolving any symlinks
-        script_dir = Path(__file__).resolve().parent
-        # go up from cbioportal/core/src/main/scripts/ to cbioportal/
-        src_root = script_dir.parent.parent.parent.parent
-        properties_filename = src_root / 'application.properties'
-                
-    sql_filename = parser.sql
-    if sql_filename is None:
-        # get the directory name of the currently running script,
-        # resolving any symlinks
-        script_dir = Path(__file__).resolve().parent
-        # go up from cbioportal/core/src/main/scripts/ to cbioportal/
-        src_root = script_dir.parent.parent.parent.parent
-        sql_filename = src_root / 'src/main/resources/db-scripts/migration.sql'
-
-    if not os.path.exists(sql_filename):
-        print('sql file %s cannot be found' % (sql_filename), file=ERROR_FILE)
-        usage()
-        sys.exit(2)
-
-    # parse properties file
-    portal_properties = get_database_properties(properties_filename)
-    if portal_properties is None:
-        print('failure reading properties file (%s)' % properties_filename, file=ERROR_FILE)
-        sys.exit(1)
-
-    # warn user
-    if not parser.suppress_confirmation:
-        warn_user()
-
-    # set up - get db cursor
-    connection, cursor = get_db_cursor(portal_properties)
-    if cursor is None:
-        print('failure connecting to sql database', file=ERROR_FILE)
-        sys.exit(1)
-
-    # execute - get the database version and run the migration
-    with contextlib.closing(connection):
-        db_version = get_db_version(cursor)
-        if is_version_larger(MULTI_REFERENCE_GENOME_SUPPORT_MIGRATION_STEP, db_version):
-            run_migration(db_version, sql_filename, connection, cursor, parser.no_transaction,
-                          stop_at_version=MULTI_REFERENCE_GENOME_SUPPORT_MIGRATION_STEP)
-            # retrieve reference genomes from database
-            check_reference_genome(portal_properties, cursor, parser.force)
-            db_version = get_db_version(cursor)
-        if is_version_larger(SAMPLE_FK_MIGRATION_STEP, db_version):
-            run_migration(db_version, sql_filename, connection, cursor, parser.no_transaction,
-                          stop_at_version=SAMPLE_FK_MIGRATION_STEP)
-            check_and_remove_type_of_cancer_id_foreign_key(cursor)
-            db_version = get_db_version(cursor)
-        if is_version_larger(FUSIONS_VERBOTEN_STEP, db_version):
-            run_migration(db_version, sql_filename, connection, cursor, parser.no_transaction,
-                          stop_at_version=FUSIONS_VERBOTEN_STEP)
-            check_and_exit_if_fusions(cursor)
-            db_version = get_db_version(cursor)
-        run_migration(db_version, sql_filename, connection, cursor, parser.no_transaction)
-        # TODO: remove this after we update mysql version
-        # check invalid foreign key only when current db version larger or qeuals to GENERIC_ASSAY_MIGRATION_STEP
-        if not is_version_larger(GENERIC_ASSAY_MIGRATION_STEP, db_version):
-            check_and_remove_invalid_foreign_keys(cursor)
-    print('Finished.', file=OUTPUT_FILE)
-
-
-# do main
 if __name__ == '__main__':
-    main()
+    print('This script (migrate_db.py) was written to manage updates to the schema of a cbioportal mysql database. cbioportal no longer involves an interaction with a mysql database. An analogous clickhouse version of this script is under development and will become available in the future. Until then, database schema migration in clickhouse will not be available in an automated script.', file=sys.stderr)
+    sys.exit(1)


### PR DESCRIPTION
- also pause 90 seconds after each OPTIMIZE TABLE x FINAL statement (too many rapid calls to OPTIMIZE TABLE causes out of memory failure)
- in order to get the CI tests to pass, all scripts which formed a connection to a mysql database needed to be crippled/commented out. These scripts are no longer functional and will need to be adapted to clickhouse in order to make them functional again:
    - updateOncokbAnnotations.py
    - migrate_db.py