### PR TITLE
Backup ga tables before sample removal

### DIFF
--- a/src/main/java/org/mskcc/cbio/portal/dao/BackupUtil.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/BackupUtil.java
@@ -4,8 +4,6 @@ import org.mskcc.cbio.portal.util.ProgressMonitor;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 public class BackupUtil {
@@ -31,6 +29,10 @@ public class BackupUtil {
             return;
         }
 
+        backup(tableNames, fn);
+    }
+
+    public static void backup(List<String> tableNames, ThrowingRunnable fn) throws Exception {
         try {
             for (String table : tableNames) {
                 backup(table);

--- a/src/main/java/org/mskcc/cbio/portal/dao/DaoSample.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/DaoSample.java
@@ -321,17 +321,28 @@ public class DaoSample {
     }
 
     /**
-     * Removes sample in genetic alterations' data for a study
-     * @param internalStudyId - internal id of study to remove samples in genetic alterations data
-     * @param internalSampleIdsToRemove - internal ids of samples to remove
-     * @throws DaoException
+     * Removes samples from genetic alteration data for a study.
+     * <p>
+     * The affected {@code genetic_alteration} and {@code genetic_profile_samples}
+     * tables are backed up before removal starts and restored from backup if the
+     * operation fails.
+     *
+     * @param internalStudyId internal ID of the study whose genetic alteration sample data should be updated
+     * @param internalSampleIdsToRemove internal IDs of samples to remove
+     * @throws DaoException if removing samples from genetic alteration data fails
      */
     private static void removeSamplesInGeneticAlterationsForStudy(int internalStudyId, Set<Integer> internalSampleIdsToRemove) throws DaoException {
-        List<GeneticProfile> geneticProfiles = DaoGeneticProfile.getAllGeneticProfiles(internalStudyId);
-        for (GeneticProfile geneticProfile : geneticProfiles) {
-            Set<Integer> removedInternalSampleIds = removeSamplesInGeneticAlterationsForGeneticProfile(geneticProfile, internalSampleIdsToRemove);
-            log.debug("Genetic alterations data for {} sample ids ouf of {} requested have been removed for genetic profile with stable id={}",
-                    removedInternalSampleIds, internalSampleIdsToRemove, geneticProfile.getStableId());
+        try {
+            BackupUtil.backup(List.of("genetic_alteration", "genetic_profile_samples"), () -> {
+                List<GeneticProfile> geneticProfiles = DaoGeneticProfile.getAllGeneticProfiles(internalStudyId);
+                for (GeneticProfile geneticProfile : geneticProfiles) {
+                    Set<Integer> removedInternalSampleIds = removeSamplesInGeneticAlterationsForGeneticProfile(geneticProfile, internalSampleIdsToRemove);
+                    log.debug("Genetic alterations data for {} sample ids ouf of {} requested have been removed for genetic profile with stable id={}",
+                            removedInternalSampleIds, internalSampleIdsToRemove, geneticProfile.getStableId());
+                }
+            });
+        } catch (Exception e) {
+            throw new DaoException(e);
         }
     }
 


### PR DESCRIPTION
The genetic alteration tables, genetic_alteration and genetic_profile_samples, are not crash-safe.
If sample removal fails partway through, the tables can be left in an inconsistent state,
with some rows updated and others still referencing the removed sample.
    
Reuse the backup-and-restore approach already used by incremental upload: back up the affected tables
before removal and restore them if an error occurs.
    
This code path is used when removing a sample and when removing a patient.