### PR TITLE
Add simplified derived tables script to metaImport.py

### DIFF
--- a/scripts/importer/cbioportalImporter.py
+++ b/scripts/importer/cbioportalImporter.py
@@ -697,18 +697,11 @@ def main(args):
     if args.java_opts is not None and '-cp' in args.java_opts:
         locate_jar_path = False
     if locate_jar_path:
-        # Check IMPORTER_JAR_FILEPATH env var first, fall back to auto-locate
-        jar_path = os.environ.get('IMPORTER_JAR_FILEPATH')
-        if jar_path:
-            if not os.path.exists(jar_path):
-                print('IMPORTER_JAR_FILEPATH is set but file not found:', jar_path)
-                sys.exit(2)
-        else:
-            try:
-                jar_path = locate_jar()
-            except FileNotFoundError as e:
-                print(e)
-                sys.exit(2)
+        try:
+            jar_path = locate_jar()
+        except FileNotFoundError as e:
+            print(e)
+            sys.exit(2)
         print('Data loading step using', jar_path)
         print()
         if args.java_opts is None:
@@ -740,7 +733,6 @@ def main(args):
             args.patient_ids if hasattr(args, 'patient_ids') else None,
             args.sample_ids if hasattr(args, 'sample_ids') else None,
             args.update_generic_assay_entity)
-        print_need_to_update_derived_tables_warning()
 
 # ------------------------------------------------------------------------------
 # ready to roll

--- a/scripts/importer/cbioportalImporter.py
+++ b/scripts/importer/cbioportalImporter.py
@@ -11,13 +11,8 @@ import importlib
 import argparse
 import logging
 import re
-import urllib.request
-import urllib.parse
-import json
 from pathlib import Path
 from typing import Dict, Tuple
-
-from scripts.importer import derive_tables
 
 # configure relative imports if running as a script; see PEP 366
 # it might passed as empty string by certain tooling to mark a top level module
@@ -661,18 +656,6 @@ def locate_jar():
     return str(jars[0])
 
 
-def print_need_to_update_derived_tables_warning():
-    """Warns user to re-derive the derived tables."""
-    BOLD = '\033[1m'
-    END = '\033[0m'
-    rederive_warning_msg = BOLD + \
-            'The database has been altered. It is now necessary to reconstitute\n' + \
-            'the derived tables before using the database with the cBioPortal\n' + \
-            'web application. Run:\n' + \
-            '    metaImport.py derive-tables\n' + \
-            END
-    LOGGER.warning(rederive_warning_msg)
-    
 def main(args):
     global LOGGER
 

--- a/scripts/importer/cbioportalImporter.py
+++ b/scripts/importer/cbioportalImporter.py
@@ -63,7 +63,6 @@ REMOVE_SAMPLES = "remove-samples"
 REMOVE_PATIENTS = "remove-patients"
 IMPORT_STUDY_DATA = "import-study-data"
 IMPORT_CASE_LIST = "import-case-list"
-DERIVE_TABLES = "derive-tables"
 
 COMMANDS = [IMPORT_CANCER_TYPE, IMPORT_STUDY, IMPORT_STUDY_DATA, IMPORT_CASE_LIST, REMOVE_STUDY, REMOVE_SAMPLES, REMOVE_PATIENTS]
 
@@ -671,8 +670,6 @@ def print_need_to_update_derived_tables_warning():
             'the derived tables before using the database with the cBioPortal\n' + \
             'web application. Run:\n' + \
             '    metaImport.py derive-tables\n' + \
-            'See: https://github.com/cBioPortal/cbioportal-core/blob/main/\n' + \
-            '     scripts/clickhouse_import_support/README.md' + \
             END
     LOGGER.warning(rederive_warning_msg)
     

--- a/scripts/importer/cbioportalImporter.py
+++ b/scripts/importer/cbioportalImporter.py
@@ -11,8 +11,13 @@ import importlib
 import argparse
 import logging
 import re
+import urllib.request
+import urllib.parse
+import json
 from pathlib import Path
 from typing import Dict, Tuple
+
+from scripts.importer import derive_tables
 
 # configure relative imports if running as a script; see PEP 366
 # it might passed as empty string by certain tooling to mark a top level module
@@ -60,7 +65,7 @@ IMPORT_STUDY_DATA = "import-study-data"
 IMPORT_CASE_LIST = "import-case-list"
 DERIVE_TABLES = "derive-tables"
 
-COMMANDS = [IMPORT_CANCER_TYPE, IMPORT_STUDY, IMPORT_STUDY_DATA, IMPORT_CASE_LIST, REMOVE_STUDY, REMOVE_SAMPLES, REMOVE_PATIENTS, DERIVE_TABLES]
+COMMANDS = [IMPORT_CANCER_TYPE, IMPORT_STUDY, IMPORT_STUDY_DATA, IMPORT_CASE_LIST, REMOVE_STUDY, REMOVE_SAMPLES, REMOVE_PATIENTS]
 
 # ------------------------------------------------------------------------------
 # sub-routines
@@ -269,20 +274,6 @@ def process_command(jvm_args, command, meta_filename, data_filename, study_ids, 
         import_data(jvm_args, meta_filename, data_filename, update_generic_assay_entity)
     elif command == IMPORT_CASE_LIST:
         import_case_list(jvm_args, meta_filename)
-    elif command == DERIVE_TABLES:
-        # Derive tables standalone — no JVM needed
-        from . import derive_tables as dt
-        ch_props = getattr(args, 'ch_props', None)
-        sql_dir = getattr(args, 'sql_dir', None)
-        github_branch = getattr(args, 'github_branch', None)
-        # Resolve ch_props path
-        if not ch_props:
-            ch_props = os.environ.get('IMPORTER_PROPERTIES_FILEPATH',
-                                       '/cbioportal/application.properties')
-        success = dt.main_derive(ch_props, github_branch=github_branch,
-                                 sql_dir=sql_dir)
-        if not success:
-            sys.exit(1)
 
 def get_meta_filenames(data_directory):
     meta_filenames = [
@@ -632,18 +623,6 @@ def interface(args=None):
     remove_patients.add_argument('--patient_ids', type=str, required=True,
                         help='Patient ID(s). Comma separated, if multiple.')
 
-    derive_tables_parser = subparsers.add_parser('derive-tables', parents=[], add_help=True)
-    derive_tables_parser.add_argument('--ch-props', type=str,
-                        help='Path to ClickHouse application.properties. '
-                             'Default: $IMPORTER_PROPERTIES_FILEPATH or '
-                             '/cbioportal/application.properties')
-    derive_tables_parser.add_argument('--sql-dir', type=str,
-                        help='Local directory with derived table SQL files '
-                             '(default: download from GitHub).')
-    derive_tables_parser.add_argument('--github-branch', type=str,
-                        help='GitHub branch for derived table SQL '
-                             '(default: master).')
-
     parser.add_argument('-c', '--command', type=str, required=False,
                         help='This argument is outdated. Please use the listed subcommands, without the -c flag. '
                         'Command for import. Allowed commands: ' + allowed_commands_csv)
@@ -682,6 +661,7 @@ def locate_jar():
             'Expected to find 1 scripts-*.jar, but found ' + str(len(jars)))
     return str(jars[0])
 
+
 def print_need_to_update_derived_tables_warning():
     """Warns user to re-derive the derived tables."""
     BOLD = '\033[1m'
@@ -691,8 +671,6 @@ def print_need_to_update_derived_tables_warning():
             'the derived tables before using the database with the cBioPortal\n' + \
             'web application. Run:\n' + \
             '    metaImport.py derive-tables\n' + \
-            'or:\n' + \
-            '    cbioportalImporter.py derive-tables\n' + \
             'See: https://github.com/cBioPortal/cbioportal-core/blob/main/\n' + \
             '     scripts/clickhouse_import_support/README.md' + \
             END
@@ -709,19 +687,6 @@ def main(args):
     error_handler.setLevel(logging.ERROR)
     module_logger.addHandler(error_handler)
     LOGGER = module_logger
-
-    # derive-tables doesn't need JVM — handle early
-    if getattr(args, 'command', None) == DERIVE_TABLES:
-        process_command(
-            None,  # jvm_args not needed
-            args.command,
-            args.meta_filename,
-            args.data_filename,
-            args.study_ids,
-            args.patient_ids if hasattr(args, 'patient_ids') else None,
-            args.sample_ids if hasattr(args, 'sample_ids') else None,
-            args.update_generic_assay_entity)
-        return
 
     # move jar_path to java_opts if it exists
     if args.jar_path:
@@ -753,11 +718,6 @@ def main(args):
 
     # process the options
     jvm_args = "-Dspring.profiles.active=dbcp " + args.java_opts
-
-    # If IMPORTER_PROPERTIES_FILEPATH is set, add it as spring config location
-    importer_properties_filepath = os.environ.get('IMPORTER_PROPERTIES_FILEPATH')
-    if importer_properties_filepath:
-        jvm_args += f" --spring.config.location=file:{importer_properties_filepath}"
 
     # check if DB version and application version are in sync
     check_version(jvm_args)

--- a/scripts/importer/cbioportalImporter.py
+++ b/scripts/importer/cbioportalImporter.py
@@ -58,8 +58,9 @@ REMOVE_SAMPLES = "remove-samples"
 REMOVE_PATIENTS = "remove-patients"
 IMPORT_STUDY_DATA = "import-study-data"
 IMPORT_CASE_LIST = "import-case-list"
+DERIVE_TABLES = "derive-tables"
 
-COMMANDS = [IMPORT_CANCER_TYPE, IMPORT_STUDY, IMPORT_STUDY_DATA, IMPORT_CASE_LIST, REMOVE_STUDY, REMOVE_SAMPLES, REMOVE_PATIENTS]
+COMMANDS = [IMPORT_CANCER_TYPE, IMPORT_STUDY, IMPORT_STUDY_DATA, IMPORT_CASE_LIST, REMOVE_STUDY, REMOVE_SAMPLES, REMOVE_PATIENTS, DERIVE_TABLES]
 
 # ------------------------------------------------------------------------------
 # sub-routines
@@ -268,6 +269,20 @@ def process_command(jvm_args, command, meta_filename, data_filename, study_ids, 
         import_data(jvm_args, meta_filename, data_filename, update_generic_assay_entity)
     elif command == IMPORT_CASE_LIST:
         import_case_list(jvm_args, meta_filename)
+    elif command == DERIVE_TABLES:
+        # Derive tables standalone — no JVM needed
+        from . import derive_tables as dt
+        ch_props = getattr(args, 'ch_props', None)
+        sql_dir = getattr(args, 'sql_dir', None)
+        github_branch = getattr(args, 'github_branch', None)
+        # Resolve ch_props path
+        if not ch_props:
+            ch_props = os.environ.get('IMPORTER_PROPERTIES_FILEPATH',
+                                       '/cbioportal/application.properties')
+        success = dt.main_derive(ch_props, github_branch=github_branch,
+                                 sql_dir=sql_dir)
+        if not success:
+            sys.exit(1)
 
 def get_meta_filenames(data_directory):
     meta_filenames = [
@@ -617,6 +632,18 @@ def interface(args=None):
     remove_patients.add_argument('--patient_ids', type=str, required=True,
                         help='Patient ID(s). Comma separated, if multiple.')
 
+    derive_tables_parser = subparsers.add_parser('derive-tables', parents=[], add_help=True)
+    derive_tables_parser.add_argument('--ch-props', type=str,
+                        help='Path to ClickHouse application.properties. '
+                             'Default: $IMPORTER_PROPERTIES_FILEPATH or '
+                             '/cbioportal/application.properties')
+    derive_tables_parser.add_argument('--sql-dir', type=str,
+                        help='Local directory with derived table SQL files '
+                             '(default: download from GitHub).')
+    derive_tables_parser.add_argument('--github-branch', type=str,
+                        help='GitHub branch for derived table SQL '
+                             '(default: master).')
+
     parser.add_argument('-c', '--command', type=str, required=False,
                         help='This argument is outdated. Please use the listed subcommands, without the -c flag. '
                         'Command for import. Allowed commands: ' + allowed_commands_csv)
@@ -662,8 +689,12 @@ def print_need_to_update_derived_tables_warning():
     rederive_warning_msg = BOLD + \
             'The database has been altered. It is now necessary to reconstitute\n' + \
             'the derived tables before using the database with the cBioPortal\n' + \
-            'web application. See this page for more details:\n' + \
-            'https://github.com/cBioPortal/cbioportal-core/blob/main/scripts/clickhouse_import_support/README.md' + \
+            'web application. Run:\n' + \
+            '    metaImport.py derive-tables\n' + \
+            'or:\n' + \
+            '    cbioportalImporter.py derive-tables\n' + \
+            'See: https://github.com/cBioPortal/cbioportal-core/blob/main/\n' + \
+            '     scripts/clickhouse_import_support/README.md' + \
             END
     LOGGER.warning(rederive_warning_msg)
     
@@ -679,6 +710,19 @@ def main(args):
     module_logger.addHandler(error_handler)
     LOGGER = module_logger
 
+    # derive-tables doesn't need JVM — handle early
+    if getattr(args, 'command', None) == DERIVE_TABLES:
+        process_command(
+            None,  # jvm_args not needed
+            args.command,
+            args.meta_filename,
+            args.data_filename,
+            args.study_ids,
+            args.patient_ids if hasattr(args, 'patient_ids') else None,
+            args.sample_ids if hasattr(args, 'sample_ids') else None,
+            args.update_generic_assay_entity)
+        return
+
     # move jar_path to java_opts if it exists
     if args.jar_path:
         args.java_opts = f"-cp {args.jar_path} {args.java_opts}"
@@ -688,11 +732,18 @@ def main(args):
     if args.java_opts is not None and '-cp' in args.java_opts:
         locate_jar_path = False
     if locate_jar_path:
-        try:
-            jar_path = locate_jar()
-        except FileNotFoundError as e:
-            print(e)
-            sys.exit(2)
+        # Check IMPORTER_JAR_FILEPATH env var first, fall back to auto-locate
+        jar_path = os.environ.get('IMPORTER_JAR_FILEPATH')
+        if jar_path:
+            if not os.path.exists(jar_path):
+                print('IMPORTER_JAR_FILEPATH is set but file not found:', jar_path)
+                sys.exit(2)
+        else:
+            try:
+                jar_path = locate_jar()
+            except FileNotFoundError as e:
+                print(e)
+                sys.exit(2)
         print('Data loading step using', jar_path)
         print()
         if args.java_opts is None:
@@ -702,6 +753,11 @@ def main(args):
 
     # process the options
     jvm_args = "-Dspring.profiles.active=dbcp " + args.java_opts
+
+    # If IMPORTER_PROPERTIES_FILEPATH is set, add it as spring config location
+    importer_properties_filepath = os.environ.get('IMPORTER_PROPERTIES_FILEPATH')
+    if importer_properties_filepath:
+        jvm_args += f" --spring.config.location=file:{importer_properties_filepath}"
 
     # check if DB version and application version are in sync
     check_version(jvm_args)

--- a/scripts/importer/derive_tables.py
+++ b/scripts/importer/derive_tables.py
@@ -1,148 +1,36 @@
-#!/usr/bin/env python3
-"""Derived ClickHouse table construction for cBioPortal.
 
-Reads ClickHouse connection info from application.properties,
-downloads derived table SQL files from GitHub (or reads from a local dir),
-and executes each SQL statement via ClickHouse's HTTP interface.
-
-No shell scripts, no clickhouse CLI dependency, no environment variables
-for connection properties — everything comes from application.properties.
-"""
-
-import sys
 import os
 import re
-import urllib.request
-import urllib.parse
-import json
-import logging
 
-LOGGER = logging.getLogger(__name__)
-
-# GitHub source for derived table SQL
-GITHUB_API_BASE = "https://api.github.com/repos/cBioPortal/cbioportal/contents"
-SQL_PATH = "src/main/resources/db-scripts/clickhouse"
-DEFAULT_BRANCH = "master"
+import urllib
 
 
-def parse_clickhouse_properties(properties_filepath):
-    """Parse ClickHouse connection info from application.properties.
-
-    Reads standard Spring Boot datasource properties:
-      spring.datasource.url
-      spring.datasource.username
-      spring.datasource.password
-
-    The URL is expected in format: jdbc:ch://host:port/database
-    or jdbc:clickhouse://host:port/database
-
-    Returns dict with keys: host, port, user, password, database
+def rebuild_derived_tables(derived_table_sql_filepath=None):
+    """Rebuild ClickHouse derived tables after a database-mutating operation.
     """
-    props = {}
-    with open(properties_filepath) as f:
-        for line in f:
-            line = line.strip()
-            if line.startswith('#') or '=' not in line:
-                continue
-            key, _, value = line.partition('=')
-            props[key.strip()] = value.strip()
+    if not derived_table_sql_filepath:
+        portal_home = os.environ.get('PORTAL_HOME', '')
+        if portal_home == '':
+            raise RuntimeError("PORTAL_HOME not set, could not locate derived table script")
+        derived_table_sql_filepath = os.path.join(portal_home, 'clickhouse.sql')
+        if not os.path.exists(derived_table_sql_filepath):
+            raise RuntimeError(f"Could not find derived table script at {derived_table_sql_filepath}")
 
-    url = props.get('spring.datasource.url', '')
-    if not url:
-        raise ValueError(
-            f"spring.datasource.url not found in {properties_filepath}")
-
-    # Parse jdbc:ch://host:port/database or jdbc:clickhouse://host:port/database
-    match = re.match(r'jdbc:(?:ch|clickhouse)://([^:/]+)(?::(\d+))?/([^?;]+)',
-                     url)
-    if not match:
-        raise ValueError(f"Cannot parse ClickHouse URL: {url}")
-
-    host = match.group(1)
-    port = match.group(2) or '8123'
-    database = match.group(3)
-    user = props.get('spring.datasource.username', 'default')
-    password = props.get('spring.datasource.password', '')
-
-    return {
-        'host': host,
-        'port': port,
-        'user': user,
-        'password': password,
-        'database': database,
+    ch_props = {
+        'conn_str':  os.environ.get('CLICKHOUSE_CONNECTION_STRING'),
+        'host': os.environ.get('CLICKHOUSE_HOST'),
+        'port': os.environ.get('CLICKHOUSE_PORT'),
+        'user': os.environ.get('CLICKHOUSE_USER'),
+        'password': os.environ.get('CLICKHOUSE_PASSWORD'),
+        'database': os.environ.get('CLICKHOUSE_DATABASE'),
     }
 
+    with open(derived_table_sql_filepath, encoding='utf8') as f:
+        sql_content = f.read()
 
-def download_sql_files_from_github(branch=DEFAULT_BRANCH, dest_dir=None):
-    """Download all .sql files from the cBioPortal GitHub repo.
+    execute_clickhouse_sql_via_http(sql_content, ch_props)
 
-    Returns list of (filename, sql_content) tuples.
-    """
-    import http.client
-    import time
-
-    api_path = (f"/repos/cBioPortal/cbioportal/contents/{SQL_PATH}"
-                f"?ref={branch}")
-
-    conn = http.client.HTTPSConnection("api.github.com", timeout=60)
-    conn.request("GET", api_path, headers={
-        "User-Agent": "cbioportal-metaimport",
-        "Accept": "application/vnd.github+json",
-    })
-    response = conn.getresponse()
-    if response.status != 200:
-        raise RuntimeError(
-            f"Failed to list SQL files from GitHub: HTTP {response.status}\n"
-            f"URL: https://api.github.com{api_path}")
-
-    directory_content = json.loads(response.read().decode())
-    sql_files = []
-
-    for item in directory_content:
-        name = item.get("name", "")
-        if not name.casefold().endswith(".sql"):
-            continue
-
-        file_url = item["url"]
-        conn2 = http.client.HTTPSConnection("api.github.com", timeout=60)
-        conn2.request("GET", file_url, headers={
-            "User-Agent": "cbioportal-metaimport",
-            "Accept": "application/vnd.github+json",
-        })
-        file_resp = conn2.getresponse()
-        if file_resp.status != 200:
-            LOGGER.warning(
-                f"Failed to download {name}: HTTP {file_resp.status}")
-            continue
-
-        import base64
-        file_data = json.loads(file_resp.read().decode())
-        content = base64.b64decode(file_data["content"]).decode()
-        sql_files.append((name, content))
-
-        if dest_dir:
-            os.makedirs(dest_dir, exist_ok=True)
-            with open(os.path.join(dest_dir, name), "w") as f:
-                f.write(content)
-
-    return sql_files
-
-
-def read_sql_files_from_dir(sql_dir):
-    """Read all .sql files from a local directory.
-
-    Returns list of (filename, sql_content) tuples, sorted by filename.
-    """
-    sql_files = []
-    for filename in sorted(os.listdir(sql_dir)):
-        if filename.casefold().endswith(".sql"):
-            path = os.path.join(sql_dir, filename)
-            with open(path) as f:
-                sql_files.append((filename, f.read()))
-    return sql_files
-
-
-def execute_sql_via_http(ch_props, sql_content):
+def execute_clickhouse_sql_via_http(sql_content, ch_props):
     """Execute SQL statements via ClickHouse HTTP interface.
 
     Strips single-line and multi-line comments, splits on semicolons,
@@ -164,11 +52,8 @@ def execute_sql_via_http(ch_props, sql_content):
         f"database={urllib.parse.quote(database)}"
     )
 
-    # Strip single-line comments (-- to end of line)
     sql = re.sub(r'--[^\n]*', '', sql_content)
-    # Remove multi-line comments (/* ... */)
     sql = re.sub(r'/\*.*?\*/', '', sql, flags=re.DOTALL)
-    # Split on semicolons
     statements = [s.strip() for s in sql.split(';') if s.strip()]
 
     for stmt in statements:
@@ -176,7 +61,7 @@ def execute_sql_via_http(ch_props, sql_content):
         req = urllib.request.Request(base_url, data=data, method='POST')
         try:
             with urllib.request.urlopen(req, timeout=300) as resp:
-                pass  # success — ClickHouse returns 200 with result data
+                pass
         except urllib.error.HTTPError as e:
             body = e.read().decode(errors='replace')
             raise RuntimeError(
@@ -186,68 +71,3 @@ def execute_sql_via_http(ch_props, sql_content):
             )
 
     return len(statements)
-
-
-def derive_tables(ch_props, sql_files):
-    """Construct all derived tables from SQL files.
-
-    Args:
-        ch_props: dict from parse_clickhouse_properties()
-        sql_files: list of (name, content) tuples
-
-    Returns total number of statements executed.
-    Raises RuntimeError on any failure.
-    """
-    total = 0
-    for name, content in sql_files:
-        LOGGER.info(f"  Processing {name}...")
-        count = execute_sql_via_http(ch_props, content)
-        LOGGER.info(f"  {name}: executed {count} statements")
-        total += count
-    return total
-
-
-def main_derive(ch_props_filepath, github_branch=None, sql_dir=None):
-    """Main entry point for derived table construction.
-
-    Args:
-        ch_props_filepath: Path to application.properties
-        github_branch: GitHub branch name (overrides default)
-        sql_dir: Local directory with SQL files (overrides GitHub download)
-
-    Returns True on success, False on failure.
-    """
-    try:
-        print("Parsing ClickHouse connection properties from "
-              f"{ch_props_filepath}...")
-        ch_props = parse_clickhouse_properties(ch_props_filepath)
-        print(f"  Host: {ch_props['host']}:{ch_props['port']}, "
-              f"Database: {ch_props['database']}")
-
-        if sql_dir:
-            print(f"Reading SQL files from local directory: {sql_dir}")
-            sql_files = read_sql_files_from_dir(sql_dir)
-        else:
-            branch = github_branch or DEFAULT_BRANCH
-            print(f"Downloading SQL files from GitHub "
-                  f"(cBioPortal/cbioportal, branch: {branch})...")
-            sql_files = download_sql_files_from_github(branch)
-
-        if not sql_files:
-            print("ERROR: No SQL files found!", file=sys.stderr)
-            return False
-
-        print(f"Found {len(sql_files)} SQL file(s)")
-        total = derive_tables(ch_props, sql_files)
-        print(f"Derived tables rebuilt successfully "
-              f"({total} statements executed).")
-        return True
-
-    except RuntimeError as e:
-        print(f"ERROR: {e}", file=sys.stderr)
-        return False
-    except Exception as e:
-        print(f"ERROR: Unexpected error during derived table construction: "
-              f"{e}", file=sys.stderr)
-        LOGGER.exception("Unexpected error")
-        return False

--- a/scripts/importer/derive_tables.py
+++ b/scripts/importer/derive_tables.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Derived ClickHouse table construction for cBioPortal.
+
+Reads ClickHouse connection info from application.properties,
+downloads derived table SQL files from GitHub (or reads from a local dir),
+and executes each SQL statement via ClickHouse's HTTP interface.
+
+No shell scripts, no clickhouse CLI dependency, no environment variables
+for connection properties — everything comes from application.properties.
+"""
+
+import sys
+import os
+import re
+import urllib.request
+import urllib.parse
+import json
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
+# GitHub source for derived table SQL
+GITHUB_API_BASE = "https://api.github.com/repos/cBioPortal/cbioportal/contents"
+SQL_PATH = "src/main/resources/db-scripts/clickhouse"
+DEFAULT_BRANCH = "master"
+
+
+def parse_clickhouse_properties(properties_filepath):
+    """Parse ClickHouse connection info from application.properties.
+
+    Reads standard Spring Boot datasource properties:
+      spring.datasource.url
+      spring.datasource.username
+      spring.datasource.password
+
+    The URL is expected in format: jdbc:ch://host:port/database
+    or jdbc:clickhouse://host:port/database
+
+    Returns dict with keys: host, port, user, password, database
+    """
+    props = {}
+    with open(properties_filepath) as f:
+        for line in f:
+            line = line.strip()
+            if line.startswith('#') or '=' not in line:
+                continue
+            key, _, value = line.partition('=')
+            props[key.strip()] = value.strip()
+
+    url = props.get('spring.datasource.url', '')
+    if not url:
+        raise ValueError(
+            f"spring.datasource.url not found in {properties_filepath}")
+
+    # Parse jdbc:ch://host:port/database or jdbc:clickhouse://host:port/database
+    match = re.match(r'jdbc:(?:ch|clickhouse)://([^:/]+)(?::(\d+))?/([^?;]+)',
+                     url)
+    if not match:
+        raise ValueError(f"Cannot parse ClickHouse URL: {url}")
+
+    host = match.group(1)
+    port = match.group(2) or '8123'
+    database = match.group(3)
+    user = props.get('spring.datasource.username', 'default')
+    password = props.get('spring.datasource.password', '')
+
+    return {
+        'host': host,
+        'port': port,
+        'user': user,
+        'password': password,
+        'database': database,
+    }
+
+
+def download_sql_files_from_github(branch=DEFAULT_BRANCH, dest_dir=None):
+    """Download all .sql files from the cBioPortal GitHub repo.
+
+    Returns list of (filename, sql_content) tuples.
+    """
+    import http.client
+    import time
+
+    api_path = (f"/repos/cBioPortal/cbioportal/contents/{SQL_PATH}"
+                f"?ref={branch}")
+
+    conn = http.client.HTTPSConnection("api.github.com", timeout=60)
+    conn.request("GET", api_path, headers={
+        "User-Agent": "cbioportal-metaimport",
+        "Accept": "application/vnd.github+json",
+    })
+    response = conn.getresponse()
+    if response.status != 200:
+        raise RuntimeError(
+            f"Failed to list SQL files from GitHub: HTTP {response.status}\n"
+            f"URL: https://api.github.com{api_path}")
+
+    directory_content = json.loads(response.read().decode())
+    sql_files = []
+
+    for item in directory_content:
+        name = item.get("name", "")
+        if not name.casefold().endswith(".sql"):
+            continue
+
+        file_url = item["url"]
+        conn2 = http.client.HTTPSConnection("api.github.com", timeout=60)
+        conn2.request("GET", file_url, headers={
+            "User-Agent": "cbioportal-metaimport",
+            "Accept": "application/vnd.github+json",
+        })
+        file_resp = conn2.getresponse()
+        if file_resp.status != 200:
+            LOGGER.warning(
+                f"Failed to download {name}: HTTP {file_resp.status}")
+            continue
+
+        import base64
+        file_data = json.loads(file_resp.read().decode())
+        content = base64.b64decode(file_data["content"]).decode()
+        sql_files.append((name, content))
+
+        if dest_dir:
+            os.makedirs(dest_dir, exist_ok=True)
+            with open(os.path.join(dest_dir, name), "w") as f:
+                f.write(content)
+
+    return sql_files
+
+
+def read_sql_files_from_dir(sql_dir):
+    """Read all .sql files from a local directory.
+
+    Returns list of (filename, sql_content) tuples, sorted by filename.
+    """
+    sql_files = []
+    for filename in sorted(os.listdir(sql_dir)):
+        if filename.casefold().endswith(".sql"):
+            path = os.path.join(sql_dir, filename)
+            with open(path) as f:
+                sql_files.append((filename, f.read()))
+    return sql_files
+
+
+def execute_sql_via_http(ch_props, sql_content):
+    """Execute SQL statements via ClickHouse HTTP interface.
+
+    Strips single-line and multi-line comments, splits on semicolons,
+    and POSTs each statement individually to ClickHouse.
+
+    Returns number of statements executed.
+    Raises RuntimeError on failure.
+    """
+    host = ch_props['host']
+    port = ch_props['port']
+    user = ch_props['user']
+    password = ch_props['password']
+    database = ch_props['database']
+
+    base_url = (
+        f"http://{host}:{port}/?"
+        f"user={urllib.parse.quote(user)}&"
+        f"password={urllib.parse.quote(password)}&"
+        f"database={urllib.parse.quote(database)}"
+    )
+
+    # Strip single-line comments (-- to end of line)
+    sql = re.sub(r'--[^\n]*', '', sql_content)
+    # Remove multi-line comments (/* ... */)
+    sql = re.sub(r'/\*.*?\*/', '', sql, flags=re.DOTALL)
+    # Split on semicolons
+    statements = [s.strip() for s in sql.split(';') if s.strip()]
+
+    for stmt in statements:
+        data = stmt.encode()
+        req = urllib.request.Request(base_url, data=data, method='POST')
+        try:
+            with urllib.request.urlopen(req, timeout=300) as resp:
+                pass  # success — ClickHouse returns 200 with result data
+        except urllib.error.HTTPError as e:
+            body = e.read().decode(errors='replace')
+            raise RuntimeError(
+                f"ClickHouse HTTP error {e.code}:\n"
+                f"  Statement (first 300 chars): {stmt[:300]}...\n"
+                f"  Response: {body[:500]}"
+            )
+
+    return len(statements)
+
+
+def derive_tables(ch_props, sql_files):
+    """Construct all derived tables from SQL files.
+
+    Args:
+        ch_props: dict from parse_clickhouse_properties()
+        sql_files: list of (name, content) tuples
+
+    Returns total number of statements executed.
+    Raises RuntimeError on any failure.
+    """
+    total = 0
+    for name, content in sql_files:
+        LOGGER.info(f"  Processing {name}...")
+        count = execute_sql_via_http(ch_props, content)
+        LOGGER.info(f"  {name}: executed {count} statements")
+        total += count
+    return total
+
+
+def main_derive(ch_props_filepath, github_branch=None, sql_dir=None):
+    """Main entry point for derived table construction.
+
+    Args:
+        ch_props_filepath: Path to application.properties
+        github_branch: GitHub branch name (overrides default)
+        sql_dir: Local directory with SQL files (overrides GitHub download)
+
+    Returns True on success, False on failure.
+    """
+    try:
+        print("Parsing ClickHouse connection properties from "
+              f"{ch_props_filepath}...")
+        ch_props = parse_clickhouse_properties(ch_props_filepath)
+        print(f"  Host: {ch_props['host']}:{ch_props['port']}, "
+              f"Database: {ch_props['database']}")
+
+        if sql_dir:
+            print(f"Reading SQL files from local directory: {sql_dir}")
+            sql_files = read_sql_files_from_dir(sql_dir)
+        else:
+            branch = github_branch or DEFAULT_BRANCH
+            print(f"Downloading SQL files from GitHub "
+                  f"(cBioPortal/cbioportal, branch: {branch})...")
+            sql_files = download_sql_files_from_github(branch)
+
+        if not sql_files:
+            print("ERROR: No SQL files found!", file=sys.stderr)
+            return False
+
+        print(f"Found {len(sql_files)} SQL file(s)")
+        total = derive_tables(ch_props, sql_files)
+        print(f"Derived tables rebuilt successfully "
+              f"({total} statements executed).")
+        return True
+
+    except RuntimeError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return False
+    except Exception as e:
+        print(f"ERROR: Unexpected error during derived table construction: "
+              f"{e}", file=sys.stderr)
+        LOGGER.exception("Unexpected error")
+        return False

--- a/scripts/importer/derive_tables.py
+++ b/scripts/importer/derive_tables.py
@@ -22,13 +22,23 @@ def rebuild_derived_tables(derived_table_sql_filepath=None):
             if not os.path.exists(derived_table_sql_filepath):
                 raise RuntimeError(f"Could not find derived table script at {derived_table_sql_filepath}")
 
-        ch_props = {
-            'host': os.environ.get('CLICKHOUSE_HOST'),
-            'port': os.environ.get('CLICKHOUSE_PORT'),
-            'user': os.environ.get('CLICKHOUSE_USER'),
-            'password': os.environ.get('CLICKHOUSE_PASSWORD'),
-            'database': os.environ.get('CLICKHOUSE_DATABASE'),
+        required_props = {
+            'host': 'CLICKHOUSE_HOST',
+            'port': 'CLICKHOUSE_PORT',
+            'user': 'CLICKHOUSE_USER',
+            'password': 'CLICKHOUSE_PASSWORD',
+            'database': 'CLICKHOUSE_DATABASE',
         }
+        missing = []
+        ch_props = {}
+        for key, env_var in required_props.items():
+            value = os.environ.get(env_var)
+            if not value:
+                missing.append(env_var)
+            ch_props[key] = value
+        if missing:
+            raise RuntimeError(
+                f"ClickHouse properties not set: {', '.join(missing)}")
 
         with open(derived_table_sql_filepath, encoding='utf8') as f:
             sql_content = f.read()

--- a/scripts/importer/derive_tables.py
+++ b/scripts/importer/derive_tables.py
@@ -1,34 +1,43 @@
 
 import os
 import re
-
-import urllib
+import sys
+import urllib.request
+import urllib.parse
 
 
 def rebuild_derived_tables(derived_table_sql_filepath=None):
     """Rebuild ClickHouse derived tables after a database-mutating operation.
+
+    Returns True on success, False on failure.
     """
-    if not derived_table_sql_filepath:
-        portal_home = os.environ.get('PORTAL_HOME', '')
-        if portal_home == '':
-            raise RuntimeError("PORTAL_HOME not set, could not locate derived table script")
-        derived_table_sql_filepath = os.path.join(portal_home, 'clickhouse.sql')
-        if not os.path.exists(derived_table_sql_filepath):
-            raise RuntimeError(f"Could not find derived table script at {derived_table_sql_filepath}")
+    RED = '\033[91m'
+    END = '\033[0m'
+    try:
+        if not derived_table_sql_filepath:
+            portal_home = os.environ.get('PORTAL_HOME', '')
+            if not portal_home:
+                raise RuntimeError("PORTAL_HOME not set, could not locate derived table script")
+            derived_table_sql_filepath = os.path.join(portal_home, 'clickhouse.sql')
+            if not os.path.exists(derived_table_sql_filepath):
+                raise RuntimeError(f"Could not find derived table script at {derived_table_sql_filepath}")
 
-    ch_props = {
-        'conn_str':  os.environ.get('CLICKHOUSE_CONNECTION_STRING'),
-        'host': os.environ.get('CLICKHOUSE_HOST'),
-        'port': os.environ.get('CLICKHOUSE_PORT'),
-        'user': os.environ.get('CLICKHOUSE_USER'),
-        'password': os.environ.get('CLICKHOUSE_PASSWORD'),
-        'database': os.environ.get('CLICKHOUSE_DATABASE'),
-    }
+        ch_props = {
+            'host': os.environ.get('CLICKHOUSE_HOST'),
+            'port': os.environ.get('CLICKHOUSE_PORT'),
+            'user': os.environ.get('CLICKHOUSE_USER'),
+            'password': os.environ.get('CLICKHOUSE_PASSWORD'),
+            'database': os.environ.get('CLICKHOUSE_DATABASE'),
+        }
 
-    with open(derived_table_sql_filepath, encoding='utf8') as f:
-        sql_content = f.read()
+        with open(derived_table_sql_filepath, encoding='utf8') as f:
+            sql_content = f.read()
 
-    execute_clickhouse_sql_via_http(sql_content, ch_props)
+        execute_clickhouse_sql_via_http(sql_content, ch_props)
+        return True
+    except Exception as e:
+        print(RED + f"Derived table construction failed: {e}" + END, file=sys.stderr)
+        return False
 
 def execute_clickhouse_sql_via_http(sql_content, ch_props):
     """Execute SQL statements via ClickHouse HTTP interface.

--- a/scripts/importer/metaImport.py
+++ b/scripts/importer/metaImport.py
@@ -12,7 +12,10 @@ import os
 import importlib
 import argparse
 import logging
+import urllib.parse
 from pathlib import Path
+
+from scripts.importer import derive_tables
 
 # configure relative imports if running as a script; see PEP 366
 # it might passed as empty string by certain tooling to mark a top level module
@@ -31,7 +34,6 @@ from . import cbioportalImporter
 from . import importOncokbMutation
 from . import importOncokbDiscreteCNA
 from . import libImportOncokb
-from . import derive_tables
 
 
 # ----------------------------------------------------------------------------
@@ -107,17 +109,6 @@ def interface():
                         help='Perform validation and OncoKB download but do not import study into database.')
     parser.add_argument('--no-derive-tables', action='store_true',
                         help='Skip derived table construction after import.')
-    parser.add_argument('--ch-props', type=str,
-                        help='Path to ClickHouse application.properties '
-                             '(for derived table construction). '
-                             'Default: $IMPORTER_PROPERTIES_FILEPATH or '
-                             '/cbioportal/application.properties')
-    parser.add_argument('--sql-dir', type=str,
-                        help='Local directory with derived table SQL files '
-                             '(default: download from GitHub).')
-    parser.add_argument('--github-branch', type=str,
-                        help='GitHub branch for derived table SQL '
-                             '(default: master).')
     parser = parser.parse_args()
     return parser
 
@@ -125,40 +116,6 @@ def interface():
 # ----------------------------------------------------------------------------
 # Main
 # ----------------------------------------------------------------------------
-
-def _resolve_ch_props_path(args):
-    """Resolve the path to ClickHouse application.properties.
-
-    Priority:
-    1. --ch-props CLI argument
-    2. $IMPORTER_PROPERTIES_FILEPATH environment variable
-    3. /cbioportal/application.properties (Docker convention)
-    """
-    if hasattr(args, 'ch_props') and args.ch_props:
-        return args.ch_props
-    env_path = os.environ.get('IMPORTER_PROPERTIES_FILEPATH')
-    if env_path:
-        return env_path
-    return '/cbioportal/application.properties'
-
-
-def _rebuild_derived_tables(args):
-    """Rebuild ClickHouse derived tables after a database-mutating operation.
-
-    Returns True on success, False on failure.
-    """
-    ch_props_path = _resolve_ch_props_path(args)
-    sql_dir = getattr(args, 'sql_dir', None)
-    github_branch = getattr(args, 'github_branch', None)
-    try:
-        return derive_tables.main_derive(
-            ch_props_path, github_branch=github_branch, sql_dir=sql_dir)
-    except Exception as e:
-        print(Color.RED +
-              f"Derived table construction failed: {e}" +
-              Color.END, file=sys.stderr)
-        return False
-
 
 if __name__ == '__main__':
     # Check for derive-tables subcommand before normal parsing
@@ -172,7 +129,7 @@ if __name__ == '__main__':
 
     # Handle derive-tables subcommand (no validation, no import)
     if derive_tables_only:
-        success = _rebuild_derived_tables(args)
+        success = derive_tables.rebuild_derived_tables()
         sys.exit(0 if success else 1)
     # supply parameters that the validation script expects to have parsed
     args.error_file = False
@@ -272,7 +229,7 @@ if __name__ == '__main__':
                     print(Color.BOLD +
                           "Rebuilding ClickHouse derived tables..." +
                           Color.END, file=sys.stderr)
-                    if not _rebuild_derived_tables(args):
+                    if not derive_tables.rebuild_derived_tables():
                         print(Color.RED +
                               "Derived table construction failed. "
                               "The database may be in an inconsistent state." +
@@ -292,7 +249,7 @@ if __name__ == '__main__':
                 print(Color.BOLD +
                       "Rebuilding ClickHouse derived tables..." +
                       Color.END, file=sys.stderr)
-                if not _rebuild_derived_tables(args):
+                if not derive_tables.rebuild_derived_tables():
                     print(Color.RED +
                           "Derived table construction failed. "
                           "The database may be in an inconsistent state." +

--- a/scripts/importer/metaImport.py
+++ b/scripts/importer/metaImport.py
@@ -105,8 +105,11 @@ def interface():
                         help='Set as True to download OncoKB annotations for Mutations and CNA and load as custom driver annotations')
     parser.add_argument('-skipimport', '--skip_db_import', action='store_true',
                         help='Perform validation and OncoKB download but do not import study into database.')
-    parser.add_argument('--no-derive-tables', action='store_true',
+    derive_tables_group = parser.add_mutually_exclusive_group()
+    derive_tables_group.add_argument('--no-derive-tables', action='store_true',
                         help='Skip derived table construction after import.')
+    derive_tables_group.add_argument('--derived-table-sql', type=str, metavar='PATH',
+                        help='Path to SQL file used for derived table construction.')
     parser = parser.parse_args()
     return parser
 
@@ -127,11 +130,15 @@ def _print_need_to_update_derived_tables_warning():
     )
 
 if __name__ == '__main__':
-    if len(sys.argv) > 1 and sys.argv[1] == 'derive-tables':
-        sys.exit(0 if derive_tables.rebuild_derived_tables() else 1)
+    derive_tables_only = len(sys.argv) > 1 and sys.argv[1] == 'derive-tables'
+    if derive_tables_only:
+        sys.argv.pop(1)
 
     # Parse user input
     args = interface()
+
+    if derive_tables_only:
+        sys.exit(0 if derive_tables.rebuild_derived_tables(args.derived_table_sql) else 1)
     # supply parameters that the validation script expects to have parsed
     args.error_file = False
 
@@ -230,7 +237,7 @@ if __name__ == '__main__':
                     print(Color.BOLD +
                           "Rebuilding ClickHouse derived tables..." +
                           Color.END, file=sys.stderr)
-                    if not derive_tables.rebuild_derived_tables():
+                    if not derive_tables.rebuild_derived_tables(args.derived_table_sql):
                         print(Color.RED +
                               "Derived table construction failed. "
                               "The database may be in an inconsistent state." +
@@ -252,7 +259,7 @@ if __name__ == '__main__':
                 print(Color.BOLD +
                       "Rebuilding ClickHouse derived tables..." +
                       Color.END, file=sys.stderr)
-                if not derive_tables.rebuild_derived_tables():
+                if not derive_tables.rebuild_derived_tables(args.derived_table_sql):
                     print(Color.RED +
                           "Derived table construction failed. "
                           "The database may be in an inconsistent state." +

--- a/scripts/importer/metaImport.py
+++ b/scripts/importer/metaImport.py
@@ -12,10 +12,7 @@ import os
 import importlib
 import argparse
 import logging
-import urllib.parse
 from pathlib import Path
-
-from scripts.importer import derive_tables
 
 # configure relative imports if running as a script; see PEP 366
 # it might passed as empty string by certain tooling to mark a top level module
@@ -34,6 +31,7 @@ from . import cbioportalImporter
 from . import importOncokbMutation
 from . import importOncokbDiscreteCNA
 from . import libImportOncokb
+from . import derive_tables
 
 
 # ----------------------------------------------------------------------------
@@ -117,20 +115,23 @@ def interface():
 # Main
 # ----------------------------------------------------------------------------
 
+def _print_need_to_update_derived_tables_warning():
+    print(
+        Color.BOLD +
+        'The database has been altered. It is now necessary to reconstitute\n'
+        'the derived tables before using the database with the cBioPortal\n'
+        'web application. Run:\n'
+        '    metaImport.py derive-tables\n' +
+        Color.END,
+        file=sys.stderr,
+    )
+
 if __name__ == '__main__':
-    # Check for derive-tables subcommand before normal parsing
-    derive_tables_only = False
     if len(sys.argv) > 1 and sys.argv[1] == 'derive-tables':
-        derive_tables_only = True
-        sys.argv.pop(1)  # remove 'derive-tables' from args
+        sys.exit(0 if derive_tables.rebuild_derived_tables() else 1)
 
     # Parse user input
     args = interface()
-
-    # Handle derive-tables subcommand (no validation, no import)
-    if derive_tables_only:
-        success = derive_tables.rebuild_derived_tables()
-        sys.exit(0 if success else 1)
     # supply parameters that the validation script expects to have parsed
     args.error_file = False
 
@@ -236,7 +237,7 @@ if __name__ == '__main__':
                               Color.END, file=sys.stderr)
                         exitcode = 1
                 else:
-                    cbioportalImporter.print_need_to_update_derived_tables_warning()
+                    _print_need_to_update_derived_tables_warning()
             else:
                 print(Color.BOLD + "Warnings. Please fix your files or import with override warning option" + Color.END, file=sys.stderr)
                 print("#" * 71, file=sys.stderr)
@@ -258,7 +259,7 @@ if __name__ == '__main__':
                           Color.END, file=sys.stderr)
                     exitcode = 1
             else:
-                cbioportalImporter.print_need_to_update_derived_tables_warning()
+                _print_need_to_update_derived_tables_warning()
     except KeyboardInterrupt:
         print(Color.BOLD + "\nProcess interrupted. You will have to run this again to make sure study is completely loaded." + Color.END, file=sys.stderr)
         print("#" * 71, file=sys.stderr)

--- a/scripts/importer/metaImport.py
+++ b/scripts/importer/metaImport.py
@@ -31,6 +31,7 @@ from . import cbioportalImporter
 from . import importOncokbMutation
 from . import importOncokbDiscreteCNA
 from . import libImportOncokb
+from . import derive_tables
 
 
 # ----------------------------------------------------------------------------
@@ -104,6 +105,19 @@ def interface():
                         help='Set as True to download OncoKB annotations for Mutations and CNA and load as custom driver annotations')
     parser.add_argument('-skipimport', '--skip_db_import', action='store_true',
                         help='Perform validation and OncoKB download but do not import study into database.')
+    parser.add_argument('--no-derive-tables', action='store_true',
+                        help='Skip derived table construction after import.')
+    parser.add_argument('--ch-props', type=str,
+                        help='Path to ClickHouse application.properties '
+                             '(for derived table construction). '
+                             'Default: $IMPORTER_PROPERTIES_FILEPATH or '
+                             '/cbioportal/application.properties')
+    parser.add_argument('--sql-dir', type=str,
+                        help='Local directory with derived table SQL files '
+                             '(default: download from GitHub).')
+    parser.add_argument('--github-branch', type=str,
+                        help='GitHub branch for derived table SQL '
+                             '(default: master).')
     parser = parser.parse_args()
     return parser
 
@@ -112,9 +126,54 @@ def interface():
 # Main
 # ----------------------------------------------------------------------------
 
+def _resolve_ch_props_path(args):
+    """Resolve the path to ClickHouse application.properties.
+
+    Priority:
+    1. --ch-props CLI argument
+    2. $IMPORTER_PROPERTIES_FILEPATH environment variable
+    3. /cbioportal/application.properties (Docker convention)
+    """
+    if hasattr(args, 'ch_props') and args.ch_props:
+        return args.ch_props
+    env_path = os.environ.get('IMPORTER_PROPERTIES_FILEPATH')
+    if env_path:
+        return env_path
+    return '/cbioportal/application.properties'
+
+
+def _rebuild_derived_tables(args):
+    """Rebuild ClickHouse derived tables after a database-mutating operation.
+
+    Returns True on success, False on failure.
+    """
+    ch_props_path = _resolve_ch_props_path(args)
+    sql_dir = getattr(args, 'sql_dir', None)
+    github_branch = getattr(args, 'github_branch', None)
+    try:
+        return derive_tables.main_derive(
+            ch_props_path, github_branch=github_branch, sql_dir=sql_dir)
+    except Exception as e:
+        print(Color.RED +
+              f"Derived table construction failed: {e}" +
+              Color.END, file=sys.stderr)
+        return False
+
+
 if __name__ == '__main__':
+    # Check for derive-tables subcommand before normal parsing
+    derive_tables_only = False
+    if len(sys.argv) > 1 and sys.argv[1] == 'derive-tables':
+        derive_tables_only = True
+        sys.argv.pop(1)  # remove 'derive-tables' from args
+
     # Parse user input
     args = interface()
+
+    # Handle derive-tables subcommand (no validation, no import)
+    if derive_tables_only:
+        success = _rebuild_derived_tables(args)
+        sys.exit(0 if success else 1)
     # supply parameters that the validation script expects to have parsed
     args.error_file = False
 
@@ -206,6 +265,19 @@ if __name__ == '__main__':
                 print("#" * 71 + "\n", file=sys.stderr)
                 cbioportalImporter.main(args)
                 exitcode = 0
+                # Rebuild derived tables after database-mutating operation
+                if not getattr(args, 'no_derive_tables', False):
+                    print("\n")
+                    print("#" * 71, file=sys.stderr)
+                    print(Color.BOLD +
+                          "Rebuilding ClickHouse derived tables..." +
+                          Color.END, file=sys.stderr)
+                    if not _rebuild_derived_tables(args):
+                        print(Color.RED +
+                              "Derived table construction failed. "
+                              "The database may be in an inconsistent state." +
+                              Color.END, file=sys.stderr)
+                        exitcode = 1
             else:
                 print(Color.BOLD + "Warnings. Please fix your files or import with override warning option" + Color.END, file=sys.stderr)
                 print("#" * 71, file=sys.stderr)
@@ -213,6 +285,19 @@ if __name__ == '__main__':
             print(Color.BOLD + "Everything looks good. Importing study now" + Color.END, file=sys.stderr)
             print("#" * 71 + "\n", file=sys.stderr)
             cbioportalImporter.main(args)
+            # Rebuild derived tables after database-mutating operation
+            if not getattr(args, 'no_derive_tables', False):
+                print("\n")
+                print("#" * 71, file=sys.stderr)
+                print(Color.BOLD +
+                      "Rebuilding ClickHouse derived tables..." +
+                      Color.END, file=sys.stderr)
+                if not _rebuild_derived_tables(args):
+                    print(Color.RED +
+                          "Derived table construction failed. "
+                          "The database may be in an inconsistent state." +
+                          Color.END, file=sys.stderr)
+                    exitcode = 1
     except KeyboardInterrupt:
         print(Color.BOLD + "\nProcess interrupted. You will have to run this again to make sure study is completely loaded." + Color.END, file=sys.stderr)
         print("#" * 71, file=sys.stderr)

--- a/scripts/importer/metaImport.py
+++ b/scripts/importer/metaImport.py
@@ -235,6 +235,8 @@ if __name__ == '__main__':
                               "The database may be in an inconsistent state." +
                               Color.END, file=sys.stderr)
                         exitcode = 1
+                else:
+                    cbioportalImporter.print_need_to_update_derived_tables_warning()
             else:
                 print(Color.BOLD + "Warnings. Please fix your files or import with override warning option" + Color.END, file=sys.stderr)
                 print("#" * 71, file=sys.stderr)
@@ -255,6 +257,8 @@ if __name__ == '__main__':
                           "The database may be in an inconsistent state." +
                           Color.END, file=sys.stderr)
                     exitcode = 1
+            else:
+                cbioportalImporter.print_need_to_update_derived_tables_warning()
     except KeyboardInterrupt:
         print(Color.BOLD + "\nProcess interrupted. You will have to run this again to make sure study is completely loaded." + Color.END, file=sys.stderr)
         print("#" * 71, file=sys.stderr)


### PR DESCRIPTION
- Default behavior is now to derive tables for anything that could mutate the study: reg import, incremental update, incremental delete
- Standalone `metaImport derive-tables` command
- `--no-derive` flag to preserve old behavior
- `--derived-table-sql` lets you pass in a custom file path, otherwise defaults to `$PORTAL_HOME/clickhouse.sql`