### PR TITLE
[RFC100] FIX -- incremental import fails during validation when trying to process a meta_study.txt file

### DIFF
--- a/scripts/importer/cbioportalImporter.py
+++ b/scripts/importer/cbioportalImporter.py
@@ -543,6 +543,9 @@ def process_data_directory(jvm_args, data_directory, update_generic_assay_entity
 
     meta_file_type_to_meta_files = get_meta_filenames_by_type(data_directory)
 
+    # meta_study is not meaningful for incremental upload (study must already exist); skip it silently
+    meta_file_type_to_meta_files.pop(MetaFileTypes.STUDY, None)
+
     not_supported_meta_types = meta_file_type_to_meta_files.keys() - INCREMENTAL_UPLOAD_SUPPORTED_META_TYPES
     if not_supported_meta_types:
         raise NotImplementedError("These types do not support incremental upload: {}".format(", ".join(not_supported_meta_types)))

--- a/scripts/importer/validateData.py
+++ b/scripts/importer/validateData.py
@@ -5616,6 +5616,8 @@ def validate_data_dir(data_dir, portal_instance, logger, relaxed_mode, strict_ma
             continue
         logger.info("Validating %s", meta_file_type)
         for validator in validators:
+            if validator is None:
+                continue
             validator.validate()
     logger.info('Validation complete')
 


### PR DESCRIPTION
Running this simple command from the docs fails:

```
docker compose exec cbioportal metaImport.py -d /study/lgg_ucsf_2014 -o
```

**Cause:** This triggers a different branch of the validator than a regular study import. This assumes that all meta files in the study are linked to a data file. However, the `meta_study.txt` is not associated with any data file and causes it to fail

**Fix:** We exclude `meta_study.txt` meta file from being processed during validation