### PR TITLE
fix: stop warning for missing or NA Entrez_Gene_Id in CNA files (#4)

### DIFF
--- a/src/main/java/org/mskcc/cbio/portal/util/CnaUtil.java
+++ b/src/main/java/org/mskcc/cbio/portal/util/CnaUtil.java
@@ -87,7 +87,12 @@ public class CnaUtil {
     
     public long getEntrezSymbol(String[] parts) {
         String entrezAsString = TabDelimitedFileUtil.getPartString(getColumnIndex(CnaUtil.ENTREZ_GENE_ID), parts);
-        if (entrezAsString.isEmpty()) {
+        // TabDelimitedFileUtil.getPartString() returns "NA" when the Entrez_Gene_Id column is absent
+        // (column index -1), when the cell is empty, or when it literally contains "NA". In all of these
+        // cases an Entrez ID is simply not provided, which is allowed as long as a Hugo_Symbol is present
+        // (see https://docs.cbioportal.org/file-formats/#discrete-copy-number-data). Treat it as "no Entrez
+        // ID" and let the caller fall back to the Hugo symbol, without emitting a spurious warning per line.
+        if (entrezAsString.isEmpty() || entrezAsString.equals(TabDelimitedFileUtil.NA_STRING)) {
             return 0;
         } else if (!entrezAsString.matches("^\\d+$")) {
             ProgressMonitor.logWarning("Ignoring line with invalid Entrez_Id " + entrezAsString);

--- a/src/test/java/org/mskcc/cbio/portal/util/TestCnaUtil.java
+++ b/src/test/java/org/mskcc/cbio/portal/util/TestCnaUtil.java
@@ -1,0 +1,96 @@
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.mskcc.cbio.portal.util;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link CnaUtil}, focusing on the resolution of the
+ * Entrez_Gene_Id column. The Entrez ID is optional as long as a Hugo_Symbol is
+ * provided, so a missing or "NA" value must not raise a warning.
+ *
+ * @see <a href="https://docs.cbioportal.org/file-formats/#discrete-copy-number-data">file format docs</a>
+ */
+public class TestCnaUtil {
+
+    @Before
+    public void setUp() {
+        ProgressMonitor.resetWarnings();
+    }
+
+    private CnaUtil cnaUtil(String[] header) {
+        return new CnaUtil(header, Collections.emptySet());
+    }
+
+    private boolean hasInvalidEntrezWarning() {
+        return ProgressMonitor.getWarnings().stream()
+                .anyMatch(w -> w.contains("Ignoring line with invalid Entrez_Id"));
+    }
+
+    @Test
+    public void getEntrezSymbolReturnsZeroWithoutWarningWhenEntrezColumnAbsent() {
+        // No Entrez_Gene_Id column at all (only Hugo_Symbol provided).
+        CnaUtil cnaUtil = cnaUtil(new String[]{"Hugo_Symbol", "Sample_Id", "Value"});
+        long entrez = cnaUtil.getEntrezSymbol(new String[]{"KIAA1549", "TCGA-A1-A0SB-11", "2"});
+        assertEquals(0L, entrez);
+        assertFalse("No warning expected when the Entrez_Gene_Id column is absent",
+                hasInvalidEntrezWarning());
+    }
+
+    @Test
+    public void getEntrezSymbolReturnsZeroWithoutWarningWhenValueIsNa() {
+        CnaUtil cnaUtil = cnaUtil(new String[]{"Hugo_Symbol", "Entrez_Gene_Id", "Sample_Id", "Value"});
+        long entrez = cnaUtil.getEntrezSymbol(new String[]{"KIAA1549", "NA", "TCGA-A1-A0SB-11", "2"});
+        assertEquals(0L, entrez);
+        assertFalse("No warning expected when the Entrez_Gene_Id value is NA",
+                hasInvalidEntrezWarning());
+    }
+
+    @Test
+    public void getEntrezSymbolReturnsZeroWithoutWarningWhenValueIsEmpty() {
+        CnaUtil cnaUtil = cnaUtil(new String[]{"Hugo_Symbol", "Entrez_Gene_Id", "Sample_Id", "Value"});
+        long entrez = cnaUtil.getEntrezSymbol(new String[]{"KIAA1549", "", "TCGA-A1-A0SB-11", "2"});
+        assertEquals(0L, entrez);
+        assertFalse("No warning expected when the Entrez_Gene_Id value is empty",
+                hasInvalidEntrezWarning());
+    }
+
+    @Test
+    public void getEntrezSymbolReturnsParsedValueForValidEntrezId() {
+        CnaUtil cnaUtil = cnaUtil(new String[]{"Hugo_Symbol", "Entrez_Gene_Id", "Sample_Id", "Value"});
+        long entrez = cnaUtil.getEntrezSymbol(new String[]{"KIAA1549", "57670", "TCGA-A1-A0SB-11", "2"});
+        assertEquals(57670L, entrez);
+        assertFalse("No warning expected for a valid Entrez ID", hasInvalidEntrezWarning());
+    }
+
+    @Test
+    public void getEntrezSymbolWarnsForGenuinelyInvalidEntrezId() {
+        CnaUtil cnaUtil = cnaUtil(new String[]{"Hugo_Symbol", "Entrez_Gene_Id", "Sample_Id", "Value"});
+        long entrez = cnaUtil.getEntrezSymbol(new String[]{"KIAA1549", "not-a-number", "TCGA-A1-A0SB-11", "2"});
+        assertEquals(0L, entrez);
+        assertTrue("A non-numeric, non-NA Entrez ID should still produce a warning",
+                hasInvalidEntrezWarning());
+    }
+}


### PR DESCRIPTION
## Summary

Loading a discrete copy-number (`CNA`) file that has no `Entrez_Gene_Id` column (or rows where it is empty / `NA`) prints a misleading warning for **every** data row:

```
Warnings / Errors:
-------------------
0.  Ignoring line with invalid Entrez_Id NA; 20x
```

despite the rows being loaded correctly. The [file-format docs](https://docs.cbioportal.org/file-formats/#discrete-copy-number-data) state that one or both of `Hugo_Symbol` / `Entrez_Gene_Id` may be specified, so a missing Entrez ID is valid as long as a `Hugo_Symbol` is present.

## Root cause

`TabDelimitedFileUtil.getPartString()` returns the literal string `"NA"` when a column is absent (index `-1`) or the cell is empty — it never returns an empty string. As a result the existing guard in `CnaUtil.getEntrezSymbol()`:

```java
if (entrezAsString.isEmpty()) {   // never true: getPartString returns "NA", not ""
    return 0;
} else if (!entrezAsString.matches("^\\d+$")) {
    ProgressMonitor.logWarning("Ignoring line with invalid Entrez_Id " + entrezAsString);
    return 0;
}
```

was dead code, so execution always fell through to the warning branch for missing/`NA` Entrez IDs.

## Changes

- **`CnaUtil.getEntrezSymbol()`**: treat an empty or `"NA"` Entrez value as "not provided" and return `0` silently so the caller falls back to the `Hugo_Symbol`. Genuinely malformed (non-numeric, non-`NA`) Entrez IDs still produce the warning.
- **`TestCnaUtil`** (new): unit tests covering the absent-column, `NA`, empty, valid, and malformed cases.

There is no functional change to which rows are loaded — only the spurious per-row warning is removed.

## Test plan

```
mvn -Dtest=TestCnaUtil test
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Fixes #4
