### PR TITLE
fix: only relabel whitelisted 5'Flank mutations as "Promoter" with custom filters (#65)

### DIFF
--- a/src/main/java/org/mskcc/cbio/portal/scripts/MutationFilter.java
+++ b/src/main/java/org/mskcc/cbio/portal/scripts/MutationFilter.java
@@ -125,7 +125,12 @@ public class MutationFilter {
               addRejectedVariant(rejectionMap, mutation.getMutationType());
               return false;
           } else {
-              if( safeStringTest( mutation.getMutationType(), "5'Flank" ) ) {
+              // Only relabel 5'Flank mutations as "Promoter" for whitelisted genes
+              // (e.g. TERT), consistent with the default-filter branch below. A
+              // custom filtered-mutations list controls which types are excluded;
+              // it must not turn every 5'Flank mutation into a promoter mutation.
+              if( safeStringTest( mutation.getMutationType(), "5'Flank" )
+                      && whiteListGenesForPromoterMutations.contains(mutation.getEntrezGeneId()) ) {
                   mutation.setProteinChange("Promoter");
               }
               return true;

--- a/src/test/java/org/mskcc/cbio/portal/scripts/TestMutationFilterPromoter.java
+++ b/src/test/java/org/mskcc/cbio/portal/scripts/TestMutationFilterPromoter.java
@@ -1,0 +1,102 @@
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.mskcc.cbio.portal.scripts;
+
+import org.junit.Test;
+import org.mskcc.cbio.portal.model.CanonicalGene;
+import org.mskcc.cbio.portal.model.ExtendedMutation;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests covering the handling of {@code 5'Flank} (promoter) mutations by
+ * {@link MutationFilter}, both with the default filter and with a custom list of
+ * filtered mutation types.
+ *
+ * <p>The "Promoter" protein-change relabeling is reserved for genes on the
+ * promoter whitelist (currently only TERT, Entrez 7015). This must hold
+ * regardless of whether a custom filtered-mutations list is supplied.
+ */
+public class TestMutationFilterPromoter {
+
+    private static final long TERT_ENTREZ_ID = 7015L;
+    private static final long NON_WHITELISTED_ENTREZ_ID = 207L; // AKT1
+
+    private ExtendedMutation fivePrimeFlankMutation(long entrezGeneId) {
+        CanonicalGene gene = new CanonicalGene(entrezGeneId, "GENE" + entrezGeneId);
+        return new ExtendedMutation(gene, "Valid", "Somatic", "5'Flank");
+    }
+
+    @Test
+    public void defaultFilterLabelsWhitelistedFlankMutationAsPromoter() {
+        MutationFilter filter = new MutationFilter();
+        ExtendedMutation mutation = fivePrimeFlankMutation(TERT_ENTREZ_ID);
+
+        assertTrue(filter.acceptMutation(mutation, null));
+        assertEquals("Promoter", mutation.getProteinChange());
+    }
+
+    @Test
+    public void defaultFilterRejectsNonWhitelistedFlankMutation() {
+        MutationFilter filter = new MutationFilter();
+        ExtendedMutation mutation = fivePrimeFlankMutation(NON_WHITELISTED_ENTREZ_ID);
+
+        assertFalse(filter.acceptMutation(mutation, null));
+    }
+
+    @Test
+    public void customFilterLabelsWhitelistedFlankMutationAsPromoter() {
+        MutationFilter filter = new MutationFilter();
+        Set<String> filteredMutations = Collections.singleton("Silent");
+        ExtendedMutation mutation = fivePrimeFlankMutation(TERT_ENTREZ_ID);
+
+        assertTrue(filter.acceptMutation(mutation, filteredMutations));
+        assertEquals("Promoter", mutation.getProteinChange());
+    }
+
+    @Test
+    public void customFilterKeepsNonWhitelistedFlankMutationWithoutPromoterLabel() {
+        MutationFilter filter = new MutationFilter();
+        Set<String> filteredMutations = Collections.singleton("Silent");
+        ExtendedMutation mutation = fivePrimeFlankMutation(NON_WHITELISTED_ENTREZ_ID);
+        mutation.setProteinChange("p.E17K");
+
+        // A custom filtered-mutations list only excludes the listed types, so a
+        // 5'Flank mutation that is not listed must still be accepted ...
+        assertTrue(filter.acceptMutation(mutation, filteredMutations));
+        // ... but it must not be relabeled as a promoter mutation, since the
+        // gene is not on the promoter whitelist.
+        assertNotEquals("Promoter", mutation.getProteinChange());
+        assertEquals("p.E17K", mutation.getProteinChange());
+    }
+
+    @Test
+    public void customFilterRejectsListedMutationType() {
+        MutationFilter filter = new MutationFilter();
+        Set<String> filteredMutations = Collections.singleton("5'Flank");
+        ExtendedMutation mutation = fivePrimeFlankMutation(TERT_ENTREZ_ID);
+
+        assertFalse(filter.acceptMutation(mutation, filteredMutations));
+    }
+}


### PR DESCRIPTION
## Summary

`MutationFilter.acceptMutation()` relabels `5'Flank` mutations' protein change to `"Promoter"` inconsistently, depending on whether a custom filtered-mutations list (`sequenced_samples`/`variant_classification_filter` in the meta file) is supplied:

| Path | Whitelisted gene (e.g. TERT) | Other gene |
| --- | --- | --- |
| **Default filter** (no custom list) | relabeled `"Promoter"`, accepted | rejected |
| **Custom filter** (before this PR) | relabeled `"Promoter"`, accepted | **relabeled `"Promoter"`**, accepted |

So the exact same `5'Flank` mutation on a non-whitelisted gene is labeled `"Promoter"` or not purely based on the filter configuration. The `"Promoter"` convention is specific to whitelisted promoter genes (currently only TERT, Entrez `7015`), so labeling arbitrary genes' `5'Flank` mutations as promoter mutations misrepresents them. This was reported in #65 as an unintended asymmetry.

## Changes

`src/main/java/org/mskcc/cbio/portal/scripts/MutationFilter.java`: in the custom-filter branch, gate the `"Promoter"` relabeling by the promoter whitelist, exactly as the default-filter branch already does:

```java
if (safeStringTest(mutation.getMutationType(), "5'Flank")
        && whiteListGenesForPromoterMutations.contains(mutation.getEntrezGeneId())) {
    mutation.setProteinChange("Promoter");
}
```

The accept/reject contract of custom filters is intentionally **unchanged**: a `5'Flank` type that is not in the custom list is still accepted (a custom list only excludes the types it names); it is simply no longer relabeled `"Promoter"` unless its gene is whitelisted.

## Tests

Added `TestMutationFilterPromoter`, a focused unit test (the filtering logic is self-contained and does not touch the database) covering both filter modes for whitelisted (TERT) and non-whitelisted genes:

```
mvn -Dtest=TestMutationFilterPromoter test
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

The existing `TestMutationFilter` only exercises the default filter path and is unaffected.

Fixes #65
