### PR TITLE
perf(import): bulk-load tab-delim matrix + genetic_entity inserts

### DIFF
--- a/src/main/java/org/mskcc/cbio/portal/dao/DaoGeneticEntity.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/DaoGeneticEntity.java
@@ -30,18 +30,27 @@ public class DaoGeneticEntity {
 
     public static GeneticEntity addNewGeneticEntity(GeneticEntity geneticEntity) throws DaoException {
 
+        long entityId = ClickHouseAutoIncrement.nextId("seq_genetic_entity");
+        geneticEntity.setId((int) entityId);
+
+        if (ClickHouseBulkLoader.isBulkLoad()) {
+            ClickHouseBulkLoader.getClickHouseBulkLoader("genetic_entity").insertRecord(
+                Long.toString(entityId),
+                geneticEntity.getEntityType(),
+                geneticEntity.getStableId());
+            return geneticEntity;
+        }
+
         Connection con = null;
         PreparedStatement pstmt = null;
         try {
             con = JdbcUtil.getDbConnection(DaoGeneticEntity.class);
-            long entityId = ClickHouseAutoIncrement.nextId("seq_genetic_entity");
             pstmt = con.prepareStatement("INSERT INTO genetic_entity (`id`, `entity_type`, `stable_id`) "
                     + "VALUES(?,?,?)");
             pstmt.setLong(1, entityId);
             pstmt.setString(2, geneticEntity.getEntityType());
             pstmt.setString(3, geneticEntity.getStableId());
             pstmt.executeUpdate();
-            geneticEntity.setId((int) entityId);
         } catch (SQLException e) {
             throw new DaoException(e);
         } finally {

--- a/src/main/java/org/mskcc/cbio/portal/scripts/ImportGenericAssayEntity.java
+++ b/src/main/java/org/mskcc/cbio/portal/scripts/ImportGenericAssayEntity.java
@@ -253,8 +253,11 @@ public class ImportGenericAssayEntity extends ConsoleRunnable {
         // (e.g. GenericAssayMetaUtils.buildGenericAssayStableIdToEntityIdMap)
         // in the same JVM sees them. ImportProfileData runs this method
         // immediately before ImportTabDelimData for GENERIC_ASSAY profiles.
+        // bulkLoadOff() restores the global flag — ImportTabDelimData will
+        // turn it back on for the matrix import.
         if (ClickHouseBulkLoader.isBulkLoad()) {
             ClickHouseBulkLoader.flushAll();
+            ClickHouseBulkLoader.bulkLoadOff();
         }
 
         ProgressMonitor.setCurrentMessage("Finished loading generic assay.\n");

--- a/src/main/java/org/mskcc/cbio/portal/scripts/ImportGenericAssayEntity.java
+++ b/src/main/java/org/mskcc/cbio/portal/scripts/ImportGenericAssayEntity.java
@@ -41,6 +41,7 @@ import java.util.*;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
+import org.mskcc.cbio.portal.dao.ClickHouseBulkLoader;
 import org.mskcc.cbio.portal.dao.DaoGenericAssay;
 import org.mskcc.cbio.portal.dao.DaoGeneticEntity;
 import org.mskcc.cbio.portal.model.shared.EntityType;
@@ -247,7 +248,15 @@ public class ImportGenericAssayEntity extends ConsoleRunnable {
         }
         
         reader.close();
-        
+
+        // Flush any buffered genetic_entity inserts so that a subsequent SELECT
+        // (e.g. GenericAssayMetaUtils.buildGenericAssayStableIdToEntityIdMap)
+        // in the same JVM sees them. ImportProfileData runs this method
+        // immediately before ImportTabDelimData for GENERIC_ASSAY profiles.
+        if (ClickHouseBulkLoader.isBulkLoad()) {
+            ClickHouseBulkLoader.flushAll();
+        }
+
         ProgressMonitor.setCurrentMessage("Finished loading generic assay.\n");
     }
     

--- a/src/main/java/org/mskcc/cbio/portal/scripts/ImportTabDelimData.java
+++ b/src/main/java/org/mskcc/cbio/portal/scripts/ImportTabDelimData.java
@@ -280,11 +280,15 @@ public class ImportTabDelimData {
 
             geneticAlterationImporter.initialize();
 
+            // Bulk-load matrix data via ClickHouseBulkLoader's
+            // INSERT ... FORMAT TSVWithNames path — one round-trip per profile
+            // instead of one JDBC INSERT per gene.
+            ClickHouseBulkLoader.bulkLoadOn();
+
             //cache for data found in  cna_event' table:
             Set<CnaEvent.Event> existingCnaEvents = new HashSet<>();
             if (isDiscretizedCnaProfile) {
                 existingCnaEvents.addAll(DaoCnaEvent.getAllCnaEvents());
-                ClickHouseBulkLoader.bulkLoadOn();
             }
 
             // load entities map from database

--- a/src/main/java/org/mskcc/cbio/portal/scripts/ImportTabDelimData.java
+++ b/src/main/java/org/mskcc/cbio/portal/scripts/ImportTabDelimData.java
@@ -372,6 +372,7 @@ public class ImportTabDelimData {
             DaoSampleProfile.upsertSampleToProfileMapping(orderedSampleList, geneticProfileId, genePanelId);
             if (ClickHouseBulkLoader.isBulkLoad()) {
                 ClickHouseBulkLoader.flushAll();
+                ClickHouseBulkLoader.bulkLoadOff();
             }
             geneticAlterationImporter.complete();
 


### PR DESCRIPTION
## Summary

Two bulk-load fixes for v7 tab-delim matrix imports:

1. **Enable `ClickHouseBulkLoader` for every tab-delim matrix import** in `ImportTabDelimData` (mRNA + z-scores, methylation, RPPA + z-scores, log2 CNA, generic assay, …). Previously only the discretized CNA profile got the bulk path.
2. **Bulk-load `genetic_entity` inserts** in `DaoGeneticEntity.addNewGeneticEntity`, plus an explicit `ClickHouseBulkLoader.flushAll()` in `ImportGenericAssayEntity.importData()` so that buffered entities are visible to the SELECT inside `ImportTabDelimData` (both run in the same JVM for GENERIC_ASSAY profiles).

## Measured impact

Full import of TCGA Pancan ACC (~92 samples, 17 data files including methylation_hm450 with ~400K rows) against an in-cluster ClickHouse:

| Path | Wall time |
|---|---|
| Before: per-row JDBC inserts everywhere | 25+ min, multiple files silent 5–10 min each |
| After: bulk loader for both genetic_alteration + genetic_entity | **1m52s** end-to-end |

Representative per-file times after the fix: `data_log2_cna.txt` 1.5s, `data_methylation_hm27_hm450_merged.txt` 2.8s, `data_methylation_hm450.txt` ~5s, mRNA z-score files 1.5s each.

See related stats here also: https://github.com/cBioPortal/datahub/pull/2326#issuecomment-4594022844

## Heap requirement

The bulk loader buffers `pendingRecords` plus a TSV byte[] in memory. For TCGA Pancan-scale matrices the peak is ~2–4 GB; the default container-aware JVM heap (~25% of container limit) OOMs on methylation_hm450. Importer Jobs should set `-Xmx6g` (we use `JAVA_OPTS=-Xmx6g` + an 8 GB container memory limit).

## Safety

- `flushAll()` at the end of `ImportTabDelimData.importDataInternal` is already gated on `isBulkLoad()`; flipping the loader on unconditionally also auto-flushes at the end.
- `DaoGeneticEntity.addNewGeneticEntity` reserves the ID via `ClickHouseAutoIncrement.nextId()` before buffering, so callers downstream get a valid id immediately.
- `flushAll()` iterates loaders in insertion order; `genetic_entity` is always touched before `genetic_alteration` for a given gene, so the flush order matches the dependency.
- The discretized CNA `existingCnaEvents` population is untouched.

## Test plan

- [ ] CI integration tests pass
- [ ] Manual import of a non-discrete matrix profile (mRNA) verifies rows land in `genetic_alteration`
- [ ] Manual import of a generic-assay profile (e.g. methylation_hm450) verifies rows in `genetic_alteration` + entities in `genetic_entity`