### PR TITLE
gsoc/embedding-ingestion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ __pycache__/
 
 # ignore maven properties
 maven.properties
+core.iml
+venv

--- a/scripts/importer/cbioportal_common.py
+++ b/scripts/importer/cbioportal_common.py
@@ -372,11 +372,11 @@ META_FIELD_MAP = {
     },
     MetaFileTypes.EMBEDDING_DEFINITION: {
         'cancer_study_identifier': False,
-        'embedding_type': True,
+        'embedding_type': True, # Included to help the importer distinguish between definition and data file
         'data_filename': True
     },
     MetaFileTypes.EMBEDDING: {
-        'embedding_type': True,
+        'embedding_type': True, # Included to help the importer distinguish between definition and data file
         'data_filename': True
     },
 }
@@ -433,8 +433,8 @@ IMPORTER_CLASSNAME_BY_META_TYPE = {
     MetaFileTypes.PATIENT_RESOURCES: "org.mskcc.cbio.portal.scripts.ImportResourceData",
     MetaFileTypes.STUDY_RESOURCES: "org.mskcc.cbio.portal.scripts.ImportResourceData",
     MetaFileTypes.RESOURCES_DEFINITION: "org.mskcc.cbio.portal.scripts.ImportResourceDefinition",
-    # TODO create the embedding java class and also would it need the meta data
-    # MetaFileTypes.EMBEDDING:
+    MetaFileTypes.EMBEDDING_DEFINITION: "org.mskcc.cbio.portal.scripts.ImportEmbeddingDefinition",
+    MetaFileTypes.EMBEDDING: "org.mskcc.cbio.portal.scripts.ImportEmbeddingData",
 }
 
 IMPORTER_REQUIRES_METADATA = {
@@ -446,7 +446,9 @@ IMPORTER_REQUIRES_METADATA = {
     "org.mskcc.cbio.portal.scripts.ImportTimelineData" : True,
     "org.mskcc.cbio.portal.scripts.ImportGenePanelProfileMap" : False,
     "org.mskcc.cbio.portal.scripts.ImportResourceData" : True,
-    "org.mskcc.cbio.portal.scripts.ImportResourceDefinition" : True
+    "org.mskcc.cbio.portal.scripts.ImportResourceDefinition" : True,
+    "org.mskcc.cbio.portal.scripts.ImportEmbeddingData" : True,
+    "org.mskcc.cbio.portal.scripts.ImportEmbeddingDefinition": False
 }
 
 # ------------------------------------------------------------------------------

--- a/scripts/importer/cbioportal_common.py
+++ b/scripts/importer/cbioportal_common.py
@@ -371,11 +371,11 @@ META_FIELD_MAP = {
         'data_filename': True
     },
     MetaFileTypes.EMBEDDING_DEFINITION: {
-        'cancer_study_identifier': False,
         'embedding_type': True, # Included to help the importer distinguish between definition and data file
         'data_filename': True
     },
     MetaFileTypes.EMBEDDING: {
+        'cancer_study_identifier': True,
         'embedding_type': True, # Included to help the importer distinguish between definition and data file
         'data_filename': True
     },

--- a/scripts/importer/cbioportal_common.py
+++ b/scripts/importer/cbioportal_common.py
@@ -83,6 +83,8 @@ class MetaFileTypes(object):
     PATIENT_RESOURCES = 'meta_resource_patient'
     STUDY_RESOURCES = 'meta_resource_study'
     RESOURCES_DEFINITION = 'meta_resource_definition'
+    EMBEDDING = 'meta_embedding'
+    EMBEDDING_DEFINITION = 'meta_embedding_definition'
 
 # class to hold information about a failed java process execution
 class JavaRunException(Exception):
@@ -368,6 +370,15 @@ META_FIELD_MAP = {
         'resource_type': True,
         'data_filename': True
     },
+    MetaFileTypes.EMBEDDING_DEFINITION: {
+        'cancer_study_identifier': False,
+        'embedding_type': True,
+        'data_filename': True
+    },
+    MetaFileTypes.EMBEDDING: {
+        'embedding_type': True,
+        'data_filename': True
+    },
 }
 
 # order is important! This is the order in which they should be loaded:
@@ -422,6 +433,8 @@ IMPORTER_CLASSNAME_BY_META_TYPE = {
     MetaFileTypes.PATIENT_RESOURCES: "org.mskcc.cbio.portal.scripts.ImportResourceData",
     MetaFileTypes.STUDY_RESOURCES: "org.mskcc.cbio.portal.scripts.ImportResourceData",
     MetaFileTypes.RESOURCES_DEFINITION: "org.mskcc.cbio.portal.scripts.ImportResourceDefinition",
+    # TODO create the embedding java class and also would it need the meta data
+    # MetaFileTypes.EMBEDDING:
 }
 
 IMPORTER_REQUIRES_METADATA = {
@@ -723,6 +736,17 @@ def get_meta_file_type(meta_dictionary, logger, filename):
             result = MetaFileTypes.STUDY_RESOURCES
         elif meta_dictionary['resource_type'] == 'DEFINITION':
             result = MetaFileTypes.RESOURCES_DEFINITION
+    elif 'embedding_type' in meta_dictionary:
+        embedding_type = meta_dictionary['embedding_type'].strip().upper()
+        if embedding_type == 'DATA':
+            result = MetaFileTypes.EMBEDDING
+        elif embedding_type == 'DEFINITION':
+            result = MetaFileTypes.EMBEDDING_DEFINITION
+        else:
+            logger.error(
+                'Invalid embedding_type. Expected DEFINITION or DATA.',
+                extra={'filename_': filename,
+                       'cause': 'embedding_type: %s' % meta_dictionary['embedding_type']})
     else:
         logger.error('Could not determine the file type. Did not find expected meta file fields. Please check your meta files for correct configuration.',
                          extra={'filename_': filename})

--- a/scripts/importer/validateData.py
+++ b/scripts/importer/validateData.py
@@ -128,7 +128,7 @@ VALIDATOR_IDS = {
     cbioportal_common.MetaFileTypes.STUDY_RESOURCES:'StudyResourceValidator',
     cbioportal_common.MetaFileTypes.RESOURCES_DEFINITION:'ResourceDefinitionValidator',
     cbioportal_common.MetaFileTypes.EMBEDDING_DEFINITION:'EmbeddingDefinitionValidator',
-    cbioportal_common.MetaFileTypes.EMBEDDING:'EmbeddingValidator',
+    cbioportal_common.MetaFileTypes.EMBEDDING:'EmbeddingDataValidator',
 }
 
 
@@ -3702,7 +3702,7 @@ class EmbeddingDefinitionValidator(Validator):
 
     REQUIRE_COLUMN_ORDER = False
     REQUIRED_HEADERS = ['EMBEDDING_ID', 'SHORT_NAME', 'DESCRIPTION',
-                        'ENTITY_TYPE', 'REDUCTION_TECHNIQUE']
+                        'ENTITY_TYPE', 'REDUCTION_TECHNIQUE', 'NAME']
     UNIQUE_COLUMNS = ['EMBEDDING_ID']
 
 
@@ -3718,18 +3718,18 @@ class EmbeddingDefinitionValidator(Validator):
                        'cause': entity_type})
 
 
-class EmbeddingValidator(Validator):
+class EmbeddingDataValidator(Validator):
     """Validator for Embeddings data files."""
     REQUIRED_HEADERS = ['EMBEDDING_ID', 'PATIENT_ID', 'SAMPLE_ID', 'X', 'Y', 'CUSTOM_ATTRIBUTES']
     REQUIRE_COLUMN_ORDER = True
     ALLOW_BLANKS = True
 
     def __init__(self, *args, **kwargs):
-        super(EmbeddingValidator, self).__init__(*args, **kwargs)
+        super(EmbeddingDataValidator, self).__init__(*args, **kwargs)
         self.seen_pairs = set()
 
     def checkLine(self, data):
-        super(EmbeddingValidator,self).checkLine(data)
+        super(EmbeddingDataValidator, self).checkLine(data)
 
 
         embedding_id = data[self.cols.index('EMBEDDING_ID')].strip()
@@ -3749,6 +3749,7 @@ class EmbeddingValidator(Validator):
         # sample embedding
         if sample_id:
             self.checkSampleId(sample_id, self.cols.index('SAMPLE_ID') + 1)
+            self.checkPatientId(patient_id, self.cols.index('PATIENT_ID') + 1)
             pair = (embedding_id, sample_id)
         # patient embedding
         else:

--- a/scripts/importer/validateData.py
+++ b/scripts/importer/validateData.py
@@ -3700,31 +3700,67 @@ class CancerTypeValidator(Validator):
 class EmbeddingDefinitionValidator(Validator):
     """Validator for tab-Embeddings definition files."""
 
-    REQUIRED_HEADERS = ['embedding_id', 'short_name', 'name',
-                        'entity_type', 'reduction_technique']
     REQUIRE_COLUMN_ORDER = False
-    ALLOW_BLANKS = False
+    REQUIRED_HEADERS = ['EMBEDDING_ID', 'SHORT_NAME', 'DESCRIPTION',
+                        'ENTITY_TYPE', 'REDUCTION_TECHNIQUE']
+    UNIQUE_COLUMNS = ['EMBEDDING_ID']
 
-    # def __init__(self, *args, **kwargs):
-    #     super(EmbeddingDefinitionValidator, self).__init__(*args, **kwargs)
-    #
-    # def checkLine(self, data):
 
-    pass
+    def checkLine(self, data):
+        super(EmbeddingDefinitionValidator, self).checkLine(data)
+
+        #Gets the index of where entity tyoes are stored
+        entity_type = data[self.cols.index('ENTITY_TYPE')].strip().lower()
+        if entity_type not in ('patient','sample'):
+            self.logger.error(
+                'Invalid entity_type, must be PATIENT or SAMPLE',
+                extra={'line_number': self.line_number,
+                       'cause': entity_type})
+
 
 class EmbeddingValidator(Validator):
     """Validator for Embeddings data files."""
-    REQUIRED_HEADERS = [ 'PATIENT_ID', 'SAMPLE_ID', 'EMBEDDING_ID', 'X', 'Y']
-    OPTIONAL_HEADERS = ['CUSTOM_ATTRIBUTES']
-    NULL_VALUES = [""]
+    REQUIRED_HEADERS = ['EMBEDDING_ID', 'PATIENT_ID', 'SAMPLE_ID', 'X', 'Y', 'CUSTOM_ATTRIBUTES']
+    REQUIRE_COLUMN_ORDER = True
+    ALLOW_BLANKS = True
 
     def __init__(self, *args, **kwargs):
         super(EmbeddingValidator, self).__init__(*args, **kwargs)
+        self.seen_pairs = set()
 
     def checkLine(self, data):
+        super(EmbeddingValidator,self).checkLine(data)
 
 
-    pass
+        embedding_id = data[self.cols.index('EMBEDDING_ID')].strip()
+        patient_id = data[self.cols.index('PATIENT_ID')].strip()
+        sample_id = data[self.cols.index('SAMPLE_ID')].strip()
+        x = data[self.cols.index('X')].strip()
+        y = data[self.cols.index('Y')].strip()
+
+        # check x and y are floats
+        if not self.checkFloat(x):
+            self.logger.error('X coordinate is not a number',
+                              extra={'line_number': self.line_number, 'cause': x})
+        if not self.checkFloat(y):
+            self.logger.error('Y coordinate is not a number',
+                              extra={'line_number': self.line_number, 'cause': y})
+
+        # sample embedding
+        if sample_id:
+            self.checkSampleId(sample_id, self.cols.index('SAMPLE_ID') + 1)
+            pair = (embedding_id, sample_id)
+        # patient embedding
+        else:
+            self.checkPatientId(patient_id, self.cols.index('PATIENT_ID') + 1)
+            pair = (embedding_id, patient_id)
+
+        # track duplicates
+        if pair in self.seen_pairs:
+            self.logger.error('Duplicate entry',
+                              extra={'line_number': self.line_number, 'cause': str(pair)})
+        else:
+            self.seen_pairs.add(pair)
 
 class ResourceDefinitionValidator(Validator):
     # 'RESOURCE_ID', 'RESOURCE_TYPE', 'DISPLAY_NAME' are required

--- a/scripts/importer/validateData.py
+++ b/scripts/importer/validateData.py
@@ -127,6 +127,8 @@ VALIDATOR_IDS = {
     cbioportal_common.MetaFileTypes.PATIENT_RESOURCES:'PatientResourceValidator',
     cbioportal_common.MetaFileTypes.STUDY_RESOURCES:'StudyResourceValidator',
     cbioportal_common.MetaFileTypes.RESOURCES_DEFINITION:'ResourceDefinitionValidator',
+    cbioportal_common.MetaFileTypes.EMBEDDING_DEFINITION:'EmbeddingDefinitionValidator',
+    cbioportal_common.MetaFileTypes.EMBEDDING:'EmbeddingValidator',
 }
 
 
@@ -3694,6 +3696,35 @@ class CancerTypeValidator(Validator):
                 self.defined_cancer_types.append(line_cancer_type)
         finally:
             self.logger.logger.removeHandler(tracking_handler)
+
+class EmbeddingDefinitionValidator(Validator):
+    """Validator for tab-Embeddings definition files."""
+
+    REQUIRED_HEADERS = ['embedding_id', 'short_name', 'name',
+                        'entity_type', 'reduction_technique']
+    REQUIRE_COLUMN_ORDER = False
+    ALLOW_BLANKS = False
+
+    # def __init__(self, *args, **kwargs):
+    #     super(EmbeddingDefinitionValidator, self).__init__(*args, **kwargs)
+    #
+    # def checkLine(self, data):
+
+    pass
+
+class EmbeddingValidator(Validator):
+    """Validator for Embeddings data files."""
+    REQUIRED_HEADERS = [ 'PATIENT_ID', 'SAMPLE_ID', 'EMBEDDING_ID', 'X', 'Y']
+    OPTIONAL_HEADERS = ['CUSTOM_ATTRIBUTES']
+    NULL_VALUES = [""]
+
+    def __init__(self, *args, **kwargs):
+        super(EmbeddingValidator, self).__init__(*args, **kwargs)
+
+    def checkLine(self, data):
+
+
+    pass
 
 class ResourceDefinitionValidator(Validator):
     # 'RESOURCE_ID', 'RESOURCE_TYPE', 'DISPLAY_NAME' are required

--- a/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseAutoIncrement.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseAutoIncrement.java
@@ -90,6 +90,7 @@ public final class ClickHouseAutoIncrement {
         register("seq_copy_number_seg", "copy_number_seg", "seg_id");
         register("seq_copy_number_seg_file", "copy_number_seg_file", "seg_file_id");
         register("seq_clinical_event", "clinical_event", "clinical_event_id");
+        register("seq_embedding_definition", "embedding_definition", "internal_id"); // the registry need to change name
         registerShutdownHook();
     }
 

--- a/src/main/java/org/mskcc/cbio/portal/dao/DaoEmbeddingData.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/DaoEmbeddingData.java
@@ -1,0 +1,57 @@
+package org.mskcc.cbio.portal.dao;
+
+import org.mskcc.cbio.portal.model.EmbeddingData;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public final class DaoEmbeddingData {
+
+    public static final String TABLE = "embedding_data";
+
+    private DaoEmbeddingData(){}
+
+    public static int addDatum(String tableName, String InternalId, String sampleId,
+                               String patientId, String x, String y,String customAttribute, int CancerStudyId){
+
+        ClickHouseBulkLoader.getClickHouseBulkLoader(tableName).insertRecord(
+                InternalId, sampleId, patientId, x, y, customAttribute, Integer.toString(CancerStudyId)
+        );
+        return 1;
+    }
+
+    public static List<EmbeddingData> getEmbeddingDataByCancerStudy(int cancerStudyId) throws DaoException {
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        ResultSet rs = null;
+        List<EmbeddingData> result = new ArrayList<>();
+        try {
+            con = JdbcUtil.getDbConnection(DaoEmbeddingData.class);
+            pstmt = con.prepareStatement("SELECT * FROM " + TABLE +
+                    " WHERE study_id = ?");
+            pstmt.setInt(1, cancerStudyId);
+            rs = pstmt.executeQuery();
+            while (rs.next()) {
+                EmbeddingData datum = new EmbeddingData(
+                        rs.getInt("embedding_id"),
+                        rs.getString("sample_id"),
+                        rs.getString("patient_id"),
+                        rs.getFloat("x"),
+                        rs.getFloat("y"),
+                        rs.getString("custom_attribute"),
+                        rs.getInt("study_id")
+                );
+                result.add(datum);
+            }
+            return result;
+        } catch (SQLException e) {
+            throw new DaoException(e);
+        } finally {
+            JdbcUtil.closeAll(DaoEmbeddingData.class, con, pstmt, rs);
+        }
+    }
+}

--- a/src/main/java/org/mskcc/cbio/portal/dao/DaoEmbeddingData.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/DaoEmbeddingData.java
@@ -1,8 +1,6 @@
 package org.mskcc.cbio.portal.dao;
 
 import org.mskcc.cbio.portal.model.EmbeddingData;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,15 +15,15 @@ public final class DaoEmbeddingData {
 
     private DaoEmbeddingData(){}
 
-    public static void addEmbeddingData(String tableName, String InternalId, String sampleId,
-                                       String patientId, String x, String y, String customAttribute, int CancerStudyId)
+    public static void addEmbeddingData( String InternalId, String  patientId,
+                                       String sampleId, String x, String y, String customAttribute, int CancerStudyId)
     throws DaoException{
 
         if(!ClickHouseBulkLoader.isBulkLoad()){
             throw new DaoException("You have to turn on ClickHouseBulkLoader in order to insert embedding data");
         }else{
-            ClickHouseBulkLoader.getClickHouseBulkLoader(tableName).insertRecord(
-                    InternalId, sampleId, patientId, x, y, customAttribute, Integer.toString(CancerStudyId)
+            ClickHouseBulkLoader.getClickHouseBulkLoader(TABLE).insertRecord(
+                    InternalId, patientId, sampleId, x, y, customAttribute, Integer.toString(CancerStudyId)
             );
         }
     }
@@ -43,7 +41,7 @@ public final class DaoEmbeddingData {
             rs = pstmt.executeQuery();
             while (rs.next()) {
                 EmbeddingData datum = new EmbeddingData(
-                        rs.getInt("embedding_id"),
+                        rs.getInt("embedding_definition_id"),
                         rs.getString("sample_id"),
                         rs.getString("patient_id"),
                         rs.getFloat("x"),

--- a/src/main/java/org/mskcc/cbio/portal/dao/DaoEmbeddingData.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/DaoEmbeddingData.java
@@ -1,6 +1,8 @@
 package org.mskcc.cbio.portal.dao;
 
 import org.mskcc.cbio.portal.model.EmbeddingData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,13 +17,17 @@ public final class DaoEmbeddingData {
 
     private DaoEmbeddingData(){}
 
-    public static int addDatum(String tableName, String InternalId, String sampleId,
-                               String patientId, String x, String y,String customAttribute, int CancerStudyId){
+    public static void addEmbeddingData(String tableName, String InternalId, String sampleId,
+                                       String patientId, String x, String y, String customAttribute, int CancerStudyId)
+    throws DaoException{
 
-        ClickHouseBulkLoader.getClickHouseBulkLoader(tableName).insertRecord(
-                InternalId, sampleId, patientId, x, y, customAttribute, Integer.toString(CancerStudyId)
-        );
-        return 1;
+        if(!ClickHouseBulkLoader.isBulkLoad()){
+            throw new DaoException("You have to turn on ClickHouseBulkLoader in order to insert embedding data");
+        }else{
+            ClickHouseBulkLoader.getClickHouseBulkLoader(tableName).insertRecord(
+                    InternalId, sampleId, patientId, x, y, customAttribute, Integer.toString(CancerStudyId)
+            );
+        }
     }
 
     public static List<EmbeddingData> getEmbeddingDataByCancerStudy(int cancerStudyId) throws DaoException {

--- a/src/main/java/org/mskcc/cbio/portal/dao/DaoEmbeddingDefinition.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/DaoEmbeddingDefinition.java
@@ -22,9 +22,8 @@ public final class DaoEmbeddingDefinition {
         PreparedStatement pstmt = null;
         ResultSet rs = null;
 
-        //Check if it exists
         try{
-            long internalId = ClickHouseAutoIncrement.nextId(EMBEDDING_DEFINITION_SEQUENCE); // ClickHouseAutoIncrement.nextId(EMBEDDINGDEFINION_SEQUENCE)
+            long internalId = ClickHouseAutoIncrement.nextId(EMBEDDING_DEFINITION_SEQUENCE);
             con = JdbcUtil.getDbConnection(DaoEmbeddingDefinition.class);
             pstmt = con.prepareStatement("INSERT INTO " +TABLE +
                     " ( `internal_id`, `embedding_id`, `short_name`, `name`, `description`,`entity_type`,`reduction_technique`) " +

--- a/src/main/java/org/mskcc/cbio/portal/dao/DaoEmbeddingDefinition.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/DaoEmbeddingDefinition.java
@@ -1,0 +1,88 @@
+package org.mskcc.cbio.portal.dao;
+
+import org.mskcc.cbio.portal.model.EmbeddingDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public final class DaoEmbeddingDefinition {
+
+    private static final Logger log = LoggerFactory.getLogger(DaoEmbeddingDefinition.class);
+
+    private static final String EMBEDDING_DEFINITION_SEQUENCE = "seq_embedding_definition";
+    public static final String TABLE = "embedding_definition";
+
+    public static void addDatum(EmbeddingDefinition embeddingDefinition) throws DaoException
+    {
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        ResultSet rs = null;
+
+        //Check if it exists
+        try{
+            long internalId = ClickHouseAutoIncrement.nextId(EMBEDDING_DEFINITION_SEQUENCE); // ClickHouseAutoIncrement.nextId(EMBEDDINGDEFINION_SEQUENCE)
+            con = JdbcUtil.getDbConnection(DaoEmbeddingDefinition.class);
+            pstmt = con.prepareStatement("INSERT INTO " +TABLE +
+                    " ( `internal_id`, `embedding_id`, `short_name`, `name`,`entity_type`,`reduction_technique`) " +
+                    "VALUES (?,?,?,?,?,?)");
+            pstmt.setLong(1,internalId);
+            pstmt.setString(2,embeddingDefinition.getEmbeddingId());
+            pstmt.setString(3,embeddingDefinition.getShortName());
+            pstmt.setString(4,embeddingDefinition.getName());
+            pstmt.setString(5,embeddingDefinition.getEntityType());
+            pstmt.setString(6,embeddingDefinition.getReductionTechnique());
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            throw new DaoException(e);
+        }
+        finally {
+            JdbcUtil.closeAll(DaoEmbeddingDefinition.class, con, pstmt, null);
+        }
+    }
+
+    public static boolean checkDefinitionExists(String embeddingID) throws DaoException{
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        ResultSet rs = null;
+        try{
+            con = JdbcUtil.getDbConnection(DaoEmbeddingDefinition.class);
+            pstmt = con.prepareStatement("SELECT 1 FROM "+ TABLE +
+                    " WHERE embedding_id=?");
+            pstmt.setString(1,embeddingID);
+            rs = pstmt.executeQuery();
+            return rs.next();
+        } catch (SQLException e) {
+            throw new DaoException(e);
+        }
+        finally {
+            JdbcUtil.closeAll(DaoEmbeddingDefinition.class, con, pstmt, rs);
+        }
+    }
+
+    public static int getDefinitionId(String embeddingID) throws DaoException{
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        ResultSet rs = null;
+
+        try{
+            con = JdbcUtil.getDbConnection(DaoEmbeddingDefinition.class);
+            pstmt = con.prepareStatement("SELECT internal_id FROM "+ TABLE +
+                    " WHERE embedding_id=?");
+            pstmt.setString(1,embeddingID);
+            rs = pstmt.executeQuery();
+            if (rs.next()) {
+                return rs.getInt("internal_id");
+            }
+        } catch (SQLException e) {
+            throw new DaoException(e);
+        }
+        finally {
+            JdbcUtil.closeAll(DaoEmbeddingDefinition.class, con, pstmt, rs);
+        }
+        return -1;
+    }
+}

--- a/src/main/java/org/mskcc/cbio/portal/dao/DaoEmbeddingDefinition.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/DaoEmbeddingDefinition.java
@@ -27,14 +27,15 @@ public final class DaoEmbeddingDefinition {
             long internalId = ClickHouseAutoIncrement.nextId(EMBEDDING_DEFINITION_SEQUENCE); // ClickHouseAutoIncrement.nextId(EMBEDDINGDEFINION_SEQUENCE)
             con = JdbcUtil.getDbConnection(DaoEmbeddingDefinition.class);
             pstmt = con.prepareStatement("INSERT INTO " +TABLE +
-                    " ( `internal_id`, `embedding_id`, `short_name`, `name`,`entity_type`,`reduction_technique`) " +
-                    "VALUES (?,?,?,?,?,?)");
+                    " ( `internal_id`, `embedding_id`, `short_name`, `name`, `description`,`entity_type`,`reduction_technique`) " +
+                    "VALUES (?,?,?,?,?,?,?)");
             pstmt.setLong(1,internalId);
             pstmt.setString(2,embeddingDefinition.getEmbeddingId());
             pstmt.setString(3,embeddingDefinition.getShortName());
             pstmt.setString(4,embeddingDefinition.getName());
-            pstmt.setString(5,embeddingDefinition.getEntityType());
-            pstmt.setString(6,embeddingDefinition.getReductionTechnique());
+            pstmt.setString(5,embeddingDefinition.getDescription());
+            pstmt.setString(6,embeddingDefinition.getEntityType());
+            pstmt.setString(7,embeddingDefinition.getReductionTechnique());
             pstmt.executeUpdate();
         } catch (SQLException e) {
             throw new DaoException(e);

--- a/src/main/java/org/mskcc/cbio/portal/model/EmbeddingData.java
+++ b/src/main/java/org/mskcc/cbio/portal/model/EmbeddingData.java
@@ -1,16 +1,16 @@
 package org.mskcc.cbio.portal.model;
 
 public class EmbeddingData {
-    private int embeddingId;
+    private int embeddingDefinitionId;
     private String patientId;
     private String sampleId;
     private double x;
     private double y;
     private int cancerStudyId; // storing the id for the cancer study identifierand
     private String customAttribute;
-    public EmbeddingData(int embeddingId, String sampleId, String patientId,
-                         float x, float y, String customAttribute, Integer cancerStudyId) {
-        this.embeddingId = embeddingId;
+    public EmbeddingData(int embeddingDefinitionId, String sampleId, String patientId,
+                         double x, double y, String customAttribute, Integer cancerStudyId) {
+        this.embeddingDefinitionId = embeddingDefinitionId;
         this.sampleId = sampleId;
         this.patientId = patientId;
         this.x = x;
@@ -19,12 +19,12 @@ public class EmbeddingData {
         this.cancerStudyId = cancerStudyId;
     }
 
-    public int getEmbeddingId() {
-        return embeddingId;
+    public int getEmbeddingDefinitionId() {
+        return embeddingDefinitionId;
     }
 
-    public void setEmbeddingId(int embeddingId) {
-        this.embeddingId = embeddingId;
+    public void setEmbeddingDefinitionId(int embeddingDefinitionId) {
+        this.embeddingDefinitionId = embeddingDefinitionId;
     }
 
     public String getPatientId() {

--- a/src/main/java/org/mskcc/cbio/portal/model/EmbeddingData.java
+++ b/src/main/java/org/mskcc/cbio/portal/model/EmbeddingData.java
@@ -1,0 +1,79 @@
+package org.mskcc.cbio.portal.model;
+
+public class EmbeddingData {
+    private int embeddingId;
+    private String patientId;
+    private String sampleId;
+    private double x;
+    private double y;
+    private int cancerStudyId; // storing the id for the cancer study identifierand
+    private String customAttribute;
+    public EmbeddingData(int embeddingId, String sampleId, String patientId,
+                         float x, float y, String customAttribute, Integer cancerStudyId) {
+        this.embeddingId = embeddingId;
+        this.sampleId = sampleId;
+        this.patientId = patientId;
+        this.x = x;
+        this.y = y;
+        this.customAttribute =  customAttribute;
+        this.cancerStudyId = cancerStudyId;
+    }
+
+    public int getEmbeddingId() {
+        return embeddingId;
+    }
+
+    public void setEmbeddingId(int embeddingId) {
+        this.embeddingId = embeddingId;
+    }
+
+    public String getPatientId() {
+        return patientId;
+    }
+
+    public void setPatientId(String patientId) {
+        this.patientId = patientId;
+    }
+
+    public String getSampleId() {
+        return sampleId;
+    }
+
+    public void setSampleId(String sampleId) {
+        this.sampleId = sampleId;
+    }
+
+    public double getX() {
+        return x;
+    }
+
+    public void setX(double x) {
+        this.x = x;
+    }
+
+    public double getY() {
+        return y;
+    }
+
+    public void setY(double y) {
+        this.y = y;
+    }
+
+    public Integer getCancerStudyId() {
+        return cancerStudyId;
+    }
+
+    public void setCancerStudyId(Integer cancerStudyId) {
+        this.cancerStudyId = cancerStudyId;
+    }
+
+    public String getCustomAttribute() {
+        return customAttribute;
+    }
+
+    public void setCustomAttribute(String customAttribute) {
+        this.customAttribute = customAttribute;
+    }
+
+    //TODO need to add the equals/hascode method
+}

--- a/src/main/java/org/mskcc/cbio/portal/model/EmbeddingDefinition.java
+++ b/src/main/java/org/mskcc/cbio/portal/model/EmbeddingDefinition.java
@@ -1,0 +1,86 @@
+package org.mskcc.cbio.portal.model;
+
+import java.util.Objects;
+
+public class EmbeddingDefinition {
+
+    private String embeddingId;
+    private String internalId;
+    private String shortName;
+    private String name;
+    private String entityType;
+    private String reductionTechnique;
+
+
+    public EmbeddingDefinition(String embeddingId, String shortName, String name,
+                               String entityType, String reductionTechnique) {
+        this.embeddingId = embeddingId;
+        this.shortName = shortName;
+        this.name = name;
+        this.entityType = entityType;
+        this.reductionTechnique = reductionTechnique;
+    }
+
+    public void setEmbeddingId(String embeddingId) {
+        this.embeddingId = embeddingId;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setShortName(String shortName) {
+        this.shortName = shortName;
+    }
+
+    public void setEntityType(String entityType) {
+        this.entityType = entityType;
+    }
+
+    public void setReductionTechnique(String reductionTechnique) {
+        this.reductionTechnique = reductionTechnique;
+    }
+
+    public String getEntityType() {
+        return entityType;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getShortName() {
+        return shortName;
+    }
+
+    public String getEmbeddingId() {
+        return embeddingId;
+    }
+
+    public String getReductionTechnique() {
+        return reductionTechnique;
+    }
+
+    public String getInternalId() {
+        return internalId;
+    }
+
+    public void setInternalId(String internalId) {
+        this.internalId = internalId;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(embeddingId, reductionTechnique, entityType);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        EmbeddingDefinition other = (EmbeddingDefinition) obj;
+        return Objects.equals(embeddingId, other.embeddingId) &&
+                Objects.equals(reductionTechnique, other.reductionTechnique) &&
+                Objects.equals(entityType, other.entityType);
+    }
+}

--- a/src/main/java/org/mskcc/cbio/portal/model/EmbeddingDefinition.java
+++ b/src/main/java/org/mskcc/cbio/portal/model/EmbeddingDefinition.java
@@ -3,20 +3,21 @@ package org.mskcc.cbio.portal.model;
 import java.util.Objects;
 
 public class EmbeddingDefinition {
-
+    private Integer internalId;
     private String embeddingId;
-    private String internalId;
     private String shortName;
     private String name;
+    private String description;
     private String entityType;
     private String reductionTechnique;
 
 
     public EmbeddingDefinition(String embeddingId, String shortName, String name,
-                               String entityType, String reductionTechnique) {
+                               String description, String entityType, String reductionTechnique) {
         this.embeddingId = embeddingId;
         this.shortName = shortName;
         this.name = name;
+        this.description = description;
         this.entityType = entityType;
         this.reductionTechnique = reductionTechnique;
     }
@@ -61,12 +62,20 @@ public class EmbeddingDefinition {
         return reductionTechnique;
     }
 
-    public String getInternalId() {
+    public Integer getInternalId() {
         return internalId;
     }
 
-    public void setInternalId(String internalId) {
+    public void setInternalId(Integer internalId) {
         this.internalId = internalId;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
     }
 
     @Override

--- a/src/main/java/org/mskcc/cbio/portal/scripts/ImportEmbeddingData.java
+++ b/src/main/java/org/mskcc/cbio/portal/scripts/ImportEmbeddingData.java
@@ -290,7 +290,7 @@ public class ImportEmbeddingData extends ConsoleRunnable{
 
     public static void main(String[] args){
         ConsoleRunnable runner = new ImportEmbeddingData(args);
-        runner.run();
+        runner.runInConsole();
     }
 
 }

--- a/src/main/java/org/mskcc/cbio/portal/scripts/ImportEmbeddingData.java
+++ b/src/main/java/org/mskcc/cbio/portal/scripts/ImportEmbeddingData.java
@@ -37,7 +37,7 @@ public class ImportEmbeddingData extends ConsoleRunnable{
     public static final String X__COLUMN_NAME = "X";
     public static final String Y_COLUMN_NAME = "Y";
     private static Properties properties;
-    Map<String, Integer> seenEmbeddingIds = new HashMap<>();
+    Map<String, Integer> seenDefinitionIds = new HashMap<>();
     public static final String TABLE = "embedding_data";
 
     /**
@@ -91,26 +91,26 @@ public class ImportEmbeddingData extends ConsoleRunnable{
                 String x = fieldValues[xIndex].trim();
                 String y = fieldValues[yIndex].trim();
                 String customAttribute = fieldValues[customIndex].trim();
-                // check if we have gotten the embedding id before  by checking
+                // check if embedding definition already exists
                 // the hashMap else query for embedding definition for the internal id
-                Integer internalId = seenEmbeddingIds.get(embeddingId);
+                Integer embeddingDefinitionId = seenDefinitionIds.get(embeddingId);
                 if(sampleId.isEmpty()){
                     patientEmbedding+=1;
                 }else{
                     sampleEmbedding+=1;
                 }
 
-                if (internalId == null) {
-                    internalId = DaoEmbeddingDefinition.getDefinitionId(embeddingId);
+                if (embeddingDefinitionId == null) {
+                    embeddingDefinitionId = DaoEmbeddingDefinition.getDefinitionId(embeddingId);
 
-                    if (internalId <= 0) {
+                    if (embeddingDefinitionId <= 0) {
                         throw new IllegalArgumentException(
                                 "Embedding definition not found: " + embeddingId
                         );
                     }
-                    seenEmbeddingIds.put(embeddingId, internalId);
+                    seenDefinitionIds.put(embeddingId, embeddingDefinitionId);
                 }
-                DaoEmbeddingData.addEmbeddingData(TABLE,Integer.toString(internalId), patientId,
+                DaoEmbeddingData.addEmbeddingData(Integer.toString(embeddingDefinitionId), patientId,
                         sampleId,x,y,customAttribute, cancerStudyId);
                 recordCount+=1;
 

--- a/src/main/java/org/mskcc/cbio/portal/scripts/ImportEmbeddingData.java
+++ b/src/main/java/org/mskcc/cbio/portal/scripts/ImportEmbeddingData.java
@@ -28,7 +28,7 @@ public class ImportEmbeddingData extends ConsoleRunnable{
     public static final String SAMPLE_ID_COLUMN_NAME = "SAMPLE_ID";
     public static final String PATIENT_ID_COLUMN_NAME = "PATIENT_ID";
     public static final String EMBEDDING_ID_COLUMN_NAME = "EMBEDDING_ID";
-    public static final String CUSTOM_ATTRIBUTE_COLUMN_NAME = "CUSTOM_ATTRIBUTE";
+    public static final String CUSTOM_ATTRIBUTE_COLUMN_NAME = "CUSTOM_ATTRIBUTES";
     public static final String X__COLUMN_NAME = "X";
     public static final String Y_COLUMN_NAME = "Y";
     private static Properties properties;

--- a/src/main/java/org/mskcc/cbio/portal/scripts/ImportEmbeddingData.java
+++ b/src/main/java/org/mskcc/cbio/portal/scripts/ImportEmbeddingData.java
@@ -29,8 +29,8 @@ public class ImportEmbeddingData extends ConsoleRunnable{
     public static final String PATIENT_ID_COLUMN_NAME = "PATIENT_ID";
     public static final String EMBEDDING_ID_COLUMN_NAME = "EMBEDDING_ID";
     public static final String CUSTOM_ATTRIBUTE_COLUMN_NAME = "CUSTOM_ATTRIBUTE";
-    public static final String X__COLUMN_NAME = "CUSTOM_ATTRIBUTE";
-    public static final String Y_COLUMN_NAME = "CUSTOM_ATTRIBUTE";
+    public static final String X__COLUMN_NAME = "X";
+    public static final String Y_COLUMN_NAME = "Y";
     private static Properties properties;
     Map<String, Integer> seenEmbeddingIds = new HashMap<>();
     public static final String TABLE = "embedding_data";

--- a/src/main/java/org/mskcc/cbio/portal/scripts/ImportEmbeddingData.java
+++ b/src/main/java/org/mskcc/cbio/portal/scripts/ImportEmbeddingData.java
@@ -59,6 +59,7 @@ public class ImportEmbeddingData extends ConsoleRunnable{
     // need to pay attention to the order at which it is passed to the method  must be order
     //might delete test for adding embedding data  and the model
     // TODO Need to be able to count the number of sample and patient embedding added to display that into the progress message
+    //TODO Decide upon if there is a failure during the import process shpuld partial data be added or the whole data discarded
     public void importData()throws Exception{
         ClickHouseBulkLoader.bulkLoadOn();
         try(BufferedReader buff = new BufferedReader(new FileReader(embeddingDataFile))){
@@ -77,6 +78,8 @@ public class ImportEmbeddingData extends ConsoleRunnable{
             int customIndex = findCustomAttributeIndex(headerIndexMap);
             ProgressMonitor.setCurrentMessage("Loading embedding data into database...");
             int recordCount = 0;
+            int patientEmbedding = 0;
+            int sampleEmbedding = 0;
 
             while((line = buff.readLine())!=null){
                 String[] fieldValues = getFieldValues(line, headerIndexMap);
@@ -91,6 +94,11 @@ public class ImportEmbeddingData extends ConsoleRunnable{
                 // check if we have gotten the embedding id before  by checking
                 // the hashMap else query for embedding definition for the internal id
                 Integer internalId = seenEmbeddingIds.get(embeddingId);
+                if(sampleId.isEmpty()){
+                    patientEmbedding+=1;
+                }else{
+                    sampleEmbedding+=1;
+                }
 
                 if (internalId == null) {
                     internalId = DaoEmbeddingDefinition.getDefinitionId(embeddingId);
@@ -108,11 +116,9 @@ public class ImportEmbeddingData extends ConsoleRunnable{
 
 
             }
-            if (ClickHouseBulkLoader.isBulkLoad()) {
-                ClickHouseBulkLoader.flushAll();
-                ClickHouseBulkLoader.relaxedModeOff();
-            }
             ProgressMonitor.setCurrentMessage("--> records inserted into `" + TABLE + "` table: " + recordCount);
+            ProgressMonitor.setCurrentMessage("--> Patient embedding inserted into `" + TABLE + "` table: " + patientEmbedding);
+            ProgressMonitor.setCurrentMessage("--> Sample embedding inserted into `" + TABLE + "` table: " + sampleEmbedding);
         }finally {
             if (ClickHouseBulkLoader.isBulkLoad()) {
                 ClickHouseBulkLoader.flushAll();

--- a/src/main/java/org/mskcc/cbio/portal/scripts/ImportEmbeddingData.java
+++ b/src/main/java/org/mskcc/cbio/portal/scripts/ImportEmbeddingData.java
@@ -1,0 +1,230 @@
+package org.mskcc.cbio.portal.scripts;
+
+import joptsimple.OptionException;
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
+import org.mskcc.cbio.portal.dao.ClickHouseBulkLoader;
+import org.mskcc.cbio.portal.dao.DaoCancerStudy;
+import org.mskcc.cbio.portal.dao.DaoEmbeddingData;
+import org.mskcc.cbio.portal.dao.DaoEmbeddingDefinition;
+import org.mskcc.cbio.portal.model.CancerStudy;
+import org.mskcc.cbio.portal.util.ConsoleUtil;
+import org.mskcc.cbio.portal.util.ProgressMonitor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+public class ImportEmbeddingData extends ConsoleRunnable{
+    private static final Logger log = LoggerFactory.getLogger(ImportEmbeddingData.class);
+    private CancerStudy cancerStudy;
+    private File embeddingDataFile;
+    public static final String DELIMITER = "\t";
+    public static final String SAMPLE_ID_COLUMN_NAME = "SAMPLE_ID";
+    public static final String PATIENT_ID_COLUMN_NAME = "PATIENT_ID";
+    public static final String EMBEDDING_ID_COLUMN_NAME = "EMBEDDING_ID";
+    public static final String CUSTOM_ATTRIBUTE_COLUMN_NAME = "CUSTOM_ATTRIBUTE";
+    public static final String X__COLUMN_NAME = "CUSTOM_ATTRIBUTE";
+    public static final String Y_COLUMN_NAME = "CUSTOM_ATTRIBUTE";
+    private static Properties properties;
+    Map<String, Integer> seenEmbeddingIds = new HashMap<>();
+    public static final String TABLE = "embedding_data";
+    /**
+     * Instantiates a ConsoleRunnable to run with the given command line args.
+     *
+     * @param args the command line arguments to be used
+     * @see {@link #run()}
+     */
+    public ImportEmbeddingData(String[] args) {
+        super(args);
+    }
+
+    public void setFile(CancerStudy cancerStudy, File embeddingDataFile)
+    {
+        this.cancerStudy = cancerStudy;
+        this.embeddingDataFile = embeddingDataFile;
+    }
+
+    // need to pay attention to the order at which it is passed to the method  must be order
+    //might delete test for adding embedding data  and the model
+    public void importData()throws Exception{
+        ClickHouseBulkLoader.bulkLoadOn();
+        FileReader reader = new FileReader(embeddingDataFile);
+        BufferedReader buff = new BufferedReader(reader);
+        String line = buff.readLine();
+
+        // Get the headers to know which index belongs to which value
+        String[] headerNames = splitFields(line);
+        Map<String, Integer> headerIndexMap = makeHeaderIndexMap(headerNames);
+        // need to fix this to not be hardcoded and to be create a single point
+        // of entry a helper method to handle extracting this values
+        int embeddingIdIndex = headerIndexMap.get(EMBEDDING_ID_COLUMN_NAME);
+        int sampleIndex = headerIndexMap.get(SAMPLE_ID_COLUMN_NAME);
+        int patientIndex = headerIndexMap.get(PATIENT_ID_COLUMN_NAME);
+        int xIndex = headerIndexMap.get(X__COLUMN_NAME);
+        int yIndex = headerIndexMap.get(Y_COLUMN_NAME);
+        int customIndex = headerIndexMap.get(CUSTOM_ATTRIBUTE_COLUMN_NAME);
+
+        while((line = buff.readLine())!=null){
+            String[] fieldValues = getFieldValues(line, headerIndexMap);
+            String embeddingId = fieldValues[embeddingIdIndex];
+            int cancerStudyId =  cancerStudy.getInternalId();
+            String sampleId = fieldValues[sampleIndex];
+            String patientId = fieldValues[patientIndex];
+            String x = fieldValues[xIndex];
+            String y = fieldValues[yIndex];
+            String customAttribute = fieldValues[customIndex];
+            // check if we have gotten the embedding id before  by checking
+            // the hashMap else query for embedding definition for the internal id
+            Integer internalId = seenEmbeddingIds.get(embeddingId);
+
+            if (internalId == null) {
+                internalId = DaoEmbeddingDefinition.getDefinitionId(embeddingId);
+
+                if (internalId <= 0) {
+                    throw new IllegalArgumentException(
+                            "Embedding definition not found: " + embeddingId
+                    );
+                }
+                seenEmbeddingIds.put(embeddingId, internalId);
+            }
+            DaoEmbeddingData.addDatum(TABLE,Integer.toString(internalId), patientId,
+                    sampleId,x,y,customAttribute, cancerStudyId);
+
+        }
+        if (ClickHouseBulkLoader.isBulkLoad()) {
+            ClickHouseBulkLoader.flushAll();
+            ClickHouseBulkLoader.relaxedModeOff();
+        }
+    }
+
+    private String[] splitFields(String line) throws IOException {
+        return line.split(DELIMITER, -1);
+    }
+
+    private String[] getFieldValues(String line, Map<String, Integer> headerIndexMap) {
+        // split on delimiter:
+        String[] fieldValues = line.split(DELIMITER, -1);
+
+        // validate: if number of fields is incorrect, give exception
+        if (fieldValues.length != headerIndexMap.size()) {
+            throw new IllegalArgumentException("Number of columns in line is not as expected. Expected: "
+                    + headerIndexMap.size() + " columns, found: " + fieldValues.length + ", for line: " + line);
+        }
+
+        // now iterate over lines and trim each value:
+        for (int i = 0; i < fieldValues.length; i++) {
+            fieldValues[i] = fieldValues[i].trim();
+        }
+        return fieldValues;
+    }
+
+    private Map<String, Integer> makeHeaderIndexMap(String[] headerNames) {
+        Map<String, Integer> headerIndexMap = new HashMap<String, Integer>();
+        for (int i= 0; i < headerNames.length; i++) {
+            headerIndexMap.put(headerNames[i], i);
+        }
+        return headerIndexMap;
+    }
+
+
+    @Override
+    public void run() {
+        try{
+            String progName = "importEmbeddingData";
+            String description = "Import Embedding data files.";
+            // usage: --data <data_file.txt> --meta <meta_file.txt> --loadMode [directLoad|bulkLoad (default)] [--noprogress]
+
+            OptionParser parser = new OptionParser();
+            OptionSpec<String> data = parser.accepts( "data",
+                    "embedding data file" ).withRequiredArg().describedAs( "data_file.txt" ).ofType( String.class );
+            OptionSpec<String> meta = parser.accepts( "meta",
+                    "meta (description) file" ).withOptionalArg().describedAs( "meta_file.txt" ).ofType( String.class );
+            OptionSpec<String> study = parser.accepts("study",
+                    "cancer study id").withOptionalArg().describedAs("study").ofType(String.class);
+            // might not need this parsed into the arguement because it always does bulk insert
+            parser.accepts( "loadMode", "direct (per record) or bulk load of data" )
+                    .withOptionalArg().describedAs( "[directLoad|bulkLoad (default)]" ).ofType( String.class );
+            parser.accepts("noprogress", "this option can be given to avoid the messages regarding memory usage and % complete");
+            OptionSpec<String> overWriteExistingFlag = parser.accepts("overwrite-existing",
+                    "Flag that enables re-uploading data for the patient/sample entries that already exist in the database").withOptionalArg().describedAs("overwrite-existing").ofType(String.class);
+            OptionSet options = null;
+
+            try {
+                options = parser.parse( args );
+            } catch (OptionException e) {
+                throw new UsageException(
+                        progName, description, parser,
+                        e.getMessage());
+            }
+
+            File embeddingData_f = null;
+            if( options.has( data ) ){
+                embeddingData_f = new File( options.valueOf( data ) );
+            } else {
+                throw new UsageException(
+                        progName, description, parser,
+                        "'data' argument required.");
+            }
+            boolean relaxed = false;
+            String cancerStudyStableId = null;
+            if( options.has ( study ) )
+            {
+                cancerStudyStableId = options.valueOf(study);
+            }
+            if( options.has ( meta ) )
+            {
+                properties = new TrimmedProperties();
+                properties.load(new FileInputStream(options.valueOf(meta)));
+                cancerStudyStableId = properties.getProperty("cancer_study_identifier");
+            }
+
+            CancerStudy cancerStudy = DaoCancerStudy.getCancerStudyByStableId(cancerStudyStableId);
+            if (cancerStudy == null) {
+                throw new IllegalArgumentException("Unknown cancer study: " + cancerStudyStableId);
+            }
+
+            setFile(cancerStudy, embeddingData_f);
+            importData();
+
+        }catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    public void runInConsole() {
+        try {
+            Date start = new Date();
+            ProgressMonitor.setConsoleModeAndParseShowProgress(this.args);
+            this.run();
+            ConsoleUtil.showMessages();
+            System.err.println("Done.");
+            Date end = new Date();
+            long totalTime = end.getTime() - start.getTime();
+            System.err.println ("Total time:  " + totalTime + " ms\n");
+
+        }
+        catch (UsageException e) {
+            e.printUsageLine();
+        }
+        catch (Throwable t) {
+            ConsoleUtil.showWarnings();
+            System.err.println ("\nABORTED!");
+            t.printStackTrace();
+        }
+    }
+
+    public static void main(String[] args){
+        ConsoleRunnable runner = new ImportEmbeddingData(args);
+        runner.run();
+    }
+
+}

--- a/src/main/java/org/mskcc/cbio/portal/scripts/ImportEmbeddingData.java
+++ b/src/main/java/org/mskcc/cbio/portal/scripts/ImportEmbeddingData.java
@@ -10,6 +10,7 @@ import org.mskcc.cbio.portal.dao.DaoEmbeddingData;
 import org.mskcc.cbio.portal.dao.DaoEmbeddingDefinition;
 import org.mskcc.cbio.portal.model.CancerStudy;
 import org.mskcc.cbio.portal.util.ConsoleUtil;
+import org.mskcc.cbio.portal.util.FileUtil;
 import org.mskcc.cbio.portal.util.ProgressMonitor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,6 +21,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+/**
+ * Script to import an embedding data
+ * @author leslie
+ */
 public class ImportEmbeddingData extends ConsoleRunnable{
     private static final Logger log = LoggerFactory.getLogger(ImportEmbeddingData.class);
     private CancerStudy cancerStudy;
@@ -34,6 +39,7 @@ public class ImportEmbeddingData extends ConsoleRunnable{
     private static Properties properties;
     Map<String, Integer> seenEmbeddingIds = new HashMap<>();
     public static final String TABLE = "embedding_data";
+
     /**
      * Instantiates a ConsoleRunnable to run with the given command line args.
      *
@@ -52,54 +58,66 @@ public class ImportEmbeddingData extends ConsoleRunnable{
 
     // need to pay attention to the order at which it is passed to the method  must be order
     //might delete test for adding embedding data  and the model
+    // TODO Need to be able to count the number of sample and patient embedding added to display that into the progress message
     public void importData()throws Exception{
         ClickHouseBulkLoader.bulkLoadOn();
-        FileReader reader = new FileReader(embeddingDataFile);
-        BufferedReader buff = new BufferedReader(reader);
-        String line = buff.readLine();
+        try(BufferedReader buff = new BufferedReader(new FileReader(embeddingDataFile))){
+            String line = buff.readLine();
 
-        // Get the headers to know which index belongs to which value
-        String[] headerNames = splitFields(line);
-        Map<String, Integer> headerIndexMap = makeHeaderIndexMap(headerNames);
-        // need to fix this to not be hardcoded and to be create a single point
-        // of entry a helper method to handle extracting this values
-        int embeddingIdIndex = headerIndexMap.get(EMBEDDING_ID_COLUMN_NAME);
-        int sampleIndex = headerIndexMap.get(SAMPLE_ID_COLUMN_NAME);
-        int patientIndex = headerIndexMap.get(PATIENT_ID_COLUMN_NAME);
-        int xIndex = headerIndexMap.get(X__COLUMN_NAME);
-        int yIndex = headerIndexMap.get(Y_COLUMN_NAME);
-        int customIndex = headerIndexMap.get(CUSTOM_ATTRIBUTE_COLUMN_NAME);
+            // Get the headers to know which index belongs to which value
+            String[] headerNames = splitFields(line);
+            Map<String, Integer> headerIndexMap = makeHeaderIndexMap(headerNames);
+            // need to fix this to not be hardcoded and to be create a single point
+            // of entry a helper method to handle extracting this values
+            int embeddingIdIndex = findEmbeddingIndex(headerIndexMap);
+            int sampleIndex =findSampleIndex(headerIndexMap);
+            int patientIndex = findPatientIndex(headerIndexMap);
+            int xIndex = findXIndex(headerIndexMap);
+            int yIndex = findYIndex(headerIndexMap);
+            int customIndex = findCustomAttributeIndex(headerIndexMap);
+            ProgressMonitor.setCurrentMessage("Loading embedding data into database...");
+            int recordCount = 0;
 
-        while((line = buff.readLine())!=null){
-            String[] fieldValues = getFieldValues(line, headerIndexMap);
-            String embeddingId = fieldValues[embeddingIdIndex];
-            int cancerStudyId =  cancerStudy.getInternalId();
-            String sampleId = fieldValues[sampleIndex];
-            String patientId = fieldValues[patientIndex];
-            String x = fieldValues[xIndex];
-            String y = fieldValues[yIndex];
-            String customAttribute = fieldValues[customIndex];
-            // check if we have gotten the embedding id before  by checking
-            // the hashMap else query for embedding definition for the internal id
-            Integer internalId = seenEmbeddingIds.get(embeddingId);
+            while((line = buff.readLine())!=null){
+                String[] fieldValues = getFieldValues(line, headerIndexMap);
 
-            if (internalId == null) {
-                internalId = DaoEmbeddingDefinition.getDefinitionId(embeddingId);
+                String embeddingId = fieldValues[embeddingIdIndex].trim();
+                int cancerStudyId =  cancerStudy.getInternalId();
+                String sampleId = fieldValues[sampleIndex].trim();
+                String patientId = fieldValues[patientIndex].trim();
+                String x = fieldValues[xIndex].trim();
+                String y = fieldValues[yIndex].trim();
+                String customAttribute = fieldValues[customIndex].trim();
+                // check if we have gotten the embedding id before  by checking
+                // the hashMap else query for embedding definition for the internal id
+                Integer internalId = seenEmbeddingIds.get(embeddingId);
 
-                if (internalId <= 0) {
-                    throw new IllegalArgumentException(
-                            "Embedding definition not found: " + embeddingId
-                    );
+                if (internalId == null) {
+                    internalId = DaoEmbeddingDefinition.getDefinitionId(embeddingId);
+
+                    if (internalId <= 0) {
+                        throw new IllegalArgumentException(
+                                "Embedding definition not found: " + embeddingId
+                        );
+                    }
+                    seenEmbeddingIds.put(embeddingId, internalId);
                 }
-                seenEmbeddingIds.put(embeddingId, internalId);
-            }
-            DaoEmbeddingData.addDatum(TABLE,Integer.toString(internalId), patientId,
-                    sampleId,x,y,customAttribute, cancerStudyId);
+                DaoEmbeddingData.addEmbeddingData(TABLE,Integer.toString(internalId), patientId,
+                        sampleId,x,y,customAttribute, cancerStudyId);
+                recordCount+=1;
 
-        }
-        if (ClickHouseBulkLoader.isBulkLoad()) {
-            ClickHouseBulkLoader.flushAll();
-            ClickHouseBulkLoader.relaxedModeOff();
+
+            }
+            if (ClickHouseBulkLoader.isBulkLoad()) {
+                ClickHouseBulkLoader.flushAll();
+                ClickHouseBulkLoader.relaxedModeOff();
+            }
+            ProgressMonitor.setCurrentMessage("--> records inserted into `" + TABLE + "` table: " + recordCount);
+        }finally {
+            if (ClickHouseBulkLoader.isBulkLoad()) {
+                ClickHouseBulkLoader.flushAll();
+                ClickHouseBulkLoader.relaxedModeOff();
+            }
         }
     }
 
@@ -131,6 +149,50 @@ public class ImportEmbeddingData extends ConsoleRunnable{
         }
         return headerIndexMap;
     }
+
+    private int findEmbeddingIndex(Map<String, Integer> headerIndexMap){
+        if (!headerIndexMap.containsKey(EMBEDDING_ID_COLUMN_NAME)) {
+            throw new RuntimeException("Missing required column: " + EMBEDDING_ID_COLUMN_NAME);
+        }
+        return headerIndexMap.get(EMBEDDING_ID_COLUMN_NAME);
+    }
+
+    private int findSampleIndex(Map<String, Integer> headerIndexMap){
+        if (!headerIndexMap.containsKey(SAMPLE_ID_COLUMN_NAME)) {
+            throw new RuntimeException("Missing required column: " + SAMPLE_ID_COLUMN_NAME);
+        }
+        return headerIndexMap.get(SAMPLE_ID_COLUMN_NAME);
+    }
+
+    private int findPatientIndex(Map<String, Integer> headerIndexMap){
+        if (!headerIndexMap.containsKey(PATIENT_ID_COLUMN_NAME)) {
+            throw new RuntimeException("Missing required column: " + PATIENT_ID_COLUMN_NAME);
+        }
+        return headerIndexMap.get(PATIENT_ID_COLUMN_NAME);
+    }
+
+    private int findXIndex(Map<String, Integer> headerIndexMap){
+        if (!headerIndexMap.containsKey(X__COLUMN_NAME)) {
+            throw new RuntimeException("Missing required column for embedding point: " + X__COLUMN_NAME);
+        }
+        return headerIndexMap.get(X__COLUMN_NAME);
+    }
+
+    private int findYIndex(Map<String, Integer> headerIndexMap){
+        if (!headerIndexMap.containsKey(Y_COLUMN_NAME)) {
+            throw new RuntimeException("Missing required column for embedding point: " + Y_COLUMN_NAME);
+        }
+        return headerIndexMap.get(Y_COLUMN_NAME);
+    }
+
+    private int findCustomAttributeIndex(Map<String, Integer> headerIndexMap){
+        if (!headerIndexMap.containsKey(CUSTOM_ATTRIBUTE_COLUMN_NAME)) {
+            throw new RuntimeException("Missing required column: " + CUSTOM_ATTRIBUTE_COLUMN_NAME);
+        }
+        return headerIndexMap.get(CUSTOM_ATTRIBUTE_COLUMN_NAME);
+    }
+
+
 
 
     @Override
@@ -188,6 +250,10 @@ public class ImportEmbeddingData extends ConsoleRunnable{
             if (cancerStudy == null) {
                 throw new IllegalArgumentException("Unknown cancer study: " + cancerStudyStableId);
             }
+            ProgressMonitor.setCurrentMessage("Reading data from:  " + embeddingData_f.getAbsolutePath());
+            int numLines = FileUtil.getNumLines(embeddingData_f);
+            ProgressMonitor.setCurrentMessage(" --> total number of lines:  " + numLines);
+            ProgressMonitor.setMaxValue(numLines);
 
             setFile(cancerStudy, embeddingData_f);
             importData();

--- a/src/main/java/org/mskcc/cbio/portal/scripts/ImportEmbeddingDefinition.java
+++ b/src/main/java/org/mskcc/cbio/portal/scripts/ImportEmbeddingDefinition.java
@@ -1,0 +1,186 @@
+package org.mskcc.cbio.portal.scripts;
+
+import joptsimple.OptionException;
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
+import org.mskcc.cbio.portal.dao.DaoEmbeddingDefinition;
+import org.mskcc.cbio.portal.model.EmbeddingDefinition;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ImportEmbeddingDefinition extends ConsoleRunnable{
+
+    public static final String DELIMITER = "\t";
+    public static final String EMBEDDING_ID_COLUMN_NAME = "EMBEDDING_ID";
+    public static final String SHORT_NAME_COLUMN_NAME = "SHORT_NAME";
+    public static final String NAME_COLUMN_NAME = "NAME";
+    public static final String ENTITY_TYPE_COLUMN_NAME = "ENTITY_TYPE";
+    public static final String REDUCTION_TECHNIQUE_COLUMN_NAME = "REDUCTION_TECHNIQUE";
+
+    private File embeddingDefinitionFile;
+
+    /**
+     * Instantiates a ConsoleRunnable to run with the given command line args.
+     *
+     * @param args the command line arguments to be used
+     * @see {@link #run()}
+     */
+    public ImportEmbeddingDefinition(String[] args) {
+        super(args);
+    }
+
+    public void setEmbeddingDefinitionFile(File embeddingDefinitionFile) {
+        this.embeddingDefinitionFile = embeddingDefinitionFile;
+    }
+
+    //TODO need to enoforce checks so fields place correctly in the database
+    public void importData() throws Exception{
+        FileReader reader = new FileReader(embeddingDefinitionFile);
+        BufferedReader buff = new BufferedReader(reader);
+
+        String line = buff.readLine();
+        String[] headerNames = splitFields(line);
+        Map<String, Integer> headerIndexMap = makeHeaderIndexMap(headerNames);
+
+        int embeddingIdIndex = findAndValidateEmbeddingIdColumn(headerIndexMap);
+        int shortNameIndex = findAndValidateShortNameColumn(headerIndexMap);
+        int nameIndex = findAndValidateNameColumn(headerIndexMap);
+        int entityTypeIndex = findAndValidateEntityTypeColumn(headerIndexMap);
+        int reductionTechniqueIndex = findAndValidateReductionTechniqueColumn(headerIndexMap);
+        while((line = buff.readLine())!=null){
+            String[] fieldValues = getFieldValues(line, headerIndexMap);
+
+            //create a new Embedding definition
+            // Pass it to the Dao to add to the database
+            String embeddingId = fieldValues[embeddingIdIndex].trim();
+            String shortName = fieldValues[shortNameIndex].trim();
+            String name = fieldValues[nameIndex].trim();
+            String entityType = fieldValues[entityTypeIndex].trim();
+            String reductionTechnique = fieldValues[reductionTechniqueIndex].trim();
+
+            // to create embedding definition object for each line and pass it to the dao for insert
+            if(DaoEmbeddingDefinition.checkDefinitionExists(embeddingId)){
+                return;
+            }
+
+            // create and add to the database
+            DaoEmbeddingDefinition.addDatum(new EmbeddingDefinition(embeddingId,
+                    shortName,name,entityType,reductionTechnique));
+        }
+        buff.close();
+    }
+
+    private int findAndValidateEmbeddingIdColumn(Map<String, Integer> headerIndexMap) {
+        if (!headerIndexMap.containsKey(EMBEDDING_ID_COLUMN_NAME)) {
+            throw new RuntimeException("Missing required column: " + EMBEDDING_ID_COLUMN_NAME);
+        }
+        return headerIndexMap.get(EMBEDDING_ID_COLUMN_NAME);
+    }
+
+    private int findAndValidateShortNameColumn(Map<String, Integer> headerIndexMap) {
+        if (!headerIndexMap.containsKey(SHORT_NAME_COLUMN_NAME)) {
+            throw new RuntimeException("Missing required column: " + SHORT_NAME_COLUMN_NAME);
+        }
+        return headerIndexMap.get(SHORT_NAME_COLUMN_NAME);
+    }
+
+    private int findAndValidateNameColumn(Map<String, Integer> headerIndexMap) {
+        if (!headerIndexMap.containsKey(NAME_COLUMN_NAME)) {
+            throw new RuntimeException("Missing required column: " + NAME_COLUMN_NAME);
+        }
+        return headerIndexMap.get(NAME_COLUMN_NAME);
+    }
+
+    private int findAndValidateEntityTypeColumn(Map<String, Integer> headerIndexMap) {
+        if (!headerIndexMap.containsKey(ENTITY_TYPE_COLUMN_NAME)) {
+            throw new RuntimeException("Missing required column: " + ENTITY_TYPE_COLUMN_NAME);
+        }
+        return headerIndexMap.get(ENTITY_TYPE_COLUMN_NAME);
+    }
+
+    private int findAndValidateReductionTechniqueColumn(Map<String, Integer> headerIndexMap) {
+        if (!headerIndexMap.containsKey(REDUCTION_TECHNIQUE_COLUMN_NAME)) {
+            throw new RuntimeException("Missing required column: " + REDUCTION_TECHNIQUE_COLUMN_NAME);
+        }
+        return headerIndexMap.get(REDUCTION_TECHNIQUE_COLUMN_NAME);
+    }
+
+    private String[] splitFields(String line) throws IOException {
+        return line.split(DELIMITER, -1);
+    }
+
+    private Map<String, Integer> makeHeaderIndexMap(String[] headerNames) {
+        Map<String, Integer> headerIndexMap = new HashMap<String, Integer>();
+        for (int i= 0; i < headerNames.length; i++) {
+            headerIndexMap.put(headerNames[i], i);
+        }
+        return headerIndexMap;
+    }
+
+    private String[] getFieldValues(String line, Map<String, Integer> headerIndexMap) {
+        // split on delimiter:
+        String[] fieldValues = line.split(DELIMITER, -1);
+
+        // validate: if number of fields is incorrect, give exception
+        if (fieldValues.length != headerIndexMap.size()) {
+            throw new IllegalArgumentException("Number of columns in line is not as expected. Expected: "
+                    + headerIndexMap.size() + " columns, found: " + fieldValues.length + ", for line: " + line);
+        }
+
+        // now iterate over lines and trim each value:
+        for (int i = 0; i < fieldValues.length; i++) {
+            fieldValues[i] = fieldValues[i].trim();
+        }
+        return fieldValues;
+    }
+
+    @Override
+    public void run() {
+        String progName = "importEmbeddingDefinition";
+        String description = "Import Embedding definition file";
+
+        try{
+            OptionParser parser = new OptionParser();
+            OptionSpec<String> data = parser.accepts("data", "profile data file").withRequiredArg()
+                    .describedAs("data_file.txt").ofType(String.class);
+            parser.accepts("noprogress", "this option can be given to avoid the messages regarding memory usage and % complete");
+
+            OptionSet options = null;
+            try {
+                options = parser.parse(args);
+            } catch (OptionException e) {
+                throw new UsageException(
+                        progName, description, parser,
+                        e.getMessage());
+            }
+            File embeddingDefinitionFile = null;
+            if (options.has(data)) {
+                embeddingDefinitionFile = new File(options.valueOf(data));
+            } else {
+                throw new UsageException(
+                        progName, description, parser,
+                        "'data' argument required.");
+            }
+
+            setEmbeddingDefinitionFile(embeddingDefinitionFile);
+            importData();
+
+
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void main(String[] args){
+        ConsoleRunnable runner = new ImportEmbeddingDefinition(args);
+        runner.runInConsole();
+    }
+}

--- a/src/main/java/org/mskcc/cbio/portal/scripts/ImportEmbeddingDefinition.java
+++ b/src/main/java/org/mskcc/cbio/portal/scripts/ImportEmbeddingDefinition.java
@@ -6,6 +6,7 @@ import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
 import org.mskcc.cbio.portal.dao.DaoEmbeddingDefinition;
 import org.mskcc.cbio.portal.model.EmbeddingDefinition;
+import org.mskcc.cbio.portal.util.ProgressMonitor;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -42,41 +43,41 @@ public class ImportEmbeddingDefinition extends ConsoleRunnable{
 
     //TODO need to enoforce checks so fields place correctly in the database
     public void importData() throws Exception{
-        FileReader reader = new FileReader(embeddingDefinitionFile);
-        BufferedReader buff = new BufferedReader(reader);
 
-        String line = buff.readLine();
-        String[] headerNames = splitFields(line);
-        Map<String, Integer> headerIndexMap = makeHeaderIndexMap(headerNames);
+        try(BufferedReader buff = new BufferedReader(new FileReader(embeddingDefinitionFile))) {
+            String line = buff.readLine();
+            String[] headerNames = splitFields(line);
+            Map<String, Integer> headerIndexMap = makeHeaderIndexMap(headerNames);
 
-        int embeddingIdIndex = findAndValidateEmbeddingIdColumn(headerIndexMap);
-        int shortNameIndex = findAndValidateShortNameColumn(headerIndexMap);
-        int nameIndex = findAndValidateNameColumn(headerIndexMap);
-        int entityTypeIndex = findAndValidateEntityTypeColumn(headerIndexMap);
-        int reductionTechniqueIndex = findAndValidateReductionTechniqueColumn(headerIndexMap);
-        int descriptionIndex = findAndValidateDescriptionColumn(headerIndexMap);
-        while((line = buff.readLine())!=null){
-            String[] fieldValues = getFieldValues(line, headerIndexMap);
+            int embeddingIdIndex = findAndValidateEmbeddingIdColumn(headerIndexMap);
+            int shortNameIndex = findAndValidateShortNameColumn(headerIndexMap);
+            int nameIndex = findAndValidateNameColumn(headerIndexMap);
+            int entityTypeIndex = findAndValidateEntityTypeColumn(headerIndexMap);
+            int reductionTechniqueIndex = findAndValidateReductionTechniqueColumn(headerIndexMap);
+            int descriptionIndex = findAndValidateDescriptionColumn(headerIndexMap);
+            ProgressMonitor.setCurrentMessage("Loading embedding definition(Metadata) into database...");
+            while((line = buff.readLine())!=null){
+                String[] fieldValues = getFieldValues(line, headerIndexMap);
 
-            //create a new Embedding definition
-            // Pass it to the Dao to add to the database
-            String embeddingId = fieldValues[embeddingIdIndex].trim();
-            String shortName = fieldValues[shortNameIndex].trim();
-            String name = fieldValues[nameIndex].trim();
-            String entityType = fieldValues[entityTypeIndex].trim();
-            String reductionTechnique = fieldValues[reductionTechniqueIndex].trim();
-            String description = fieldValues[descriptionIndex].trim();
 
-            // to create embedding definition object for each line and pass it to the dao for insert
-            if(DaoEmbeddingDefinition.checkDefinitionExists(embeddingId)){
-                return;
+                String embeddingId = fieldValues[embeddingIdIndex].trim();
+                String shortName = fieldValues[shortNameIndex].trim();
+                String name = fieldValues[nameIndex].trim();
+                String entityType = fieldValues[entityTypeIndex].trim();
+                String reductionTechnique = fieldValues[reductionTechniqueIndex].trim();
+                String description = fieldValues[descriptionIndex].trim();
+
+                // Definition exists skip that line
+                if(DaoEmbeddingDefinition.checkDefinitionExists(embeddingId)){
+                    ProgressMonitor.logWarning("Embedding definition already exists, skipping: " + embeddingId);
+                    continue;
+                }
+
+                // create and add to the database
+                DaoEmbeddingDefinition.addDatum(new EmbeddingDefinition(embeddingId,
+                        shortName,name,description,entityType,reductionTechnique));
             }
-
-            // create and add to the database
-            DaoEmbeddingDefinition.addDatum(new EmbeddingDefinition(embeddingId,
-                    shortName,name,description,entityType,reductionTechnique));
         }
-        buff.close();
     }
 
     private int findAndValidateEmbeddingIdColumn(Map<String, Integer> headerIndexMap) {

--- a/src/main/java/org/mskcc/cbio/portal/scripts/ImportEmbeddingDefinition.java
+++ b/src/main/java/org/mskcc/cbio/portal/scripts/ImportEmbeddingDefinition.java
@@ -89,7 +89,7 @@ public class ImportEmbeddingDefinition extends ConsoleRunnable{
 
     private int findAndValidateDescriptionColumn(Map<String, Integer> headerIndexMap) {
         if (!headerIndexMap.containsKey(DESCRIPTION_COLUMN_NAME)) {
-            throw new RuntimeException("Missing required column: " + EMBEDDING_ID_COLUMN_NAME);
+            throw new RuntimeException("Missing required column: " + DESCRIPTION_COLUMN_NAME);
         }
         return headerIndexMap.get(DESCRIPTION_COLUMN_NAME);
     }

--- a/src/main/java/org/mskcc/cbio/portal/scripts/ImportEmbeddingDefinition.java
+++ b/src/main/java/org/mskcc/cbio/portal/scripts/ImportEmbeddingDefinition.java
@@ -22,6 +22,7 @@ public class ImportEmbeddingDefinition extends ConsoleRunnable{
     public static final String NAME_COLUMN_NAME = "NAME";
     public static final String ENTITY_TYPE_COLUMN_NAME = "ENTITY_TYPE";
     public static final String REDUCTION_TECHNIQUE_COLUMN_NAME = "REDUCTION_TECHNIQUE";
+    public static final String DESCRIPTION_COLUMN_NAME = "DESCRIPTION";
 
     private File embeddingDefinitionFile;
 
@@ -53,6 +54,7 @@ public class ImportEmbeddingDefinition extends ConsoleRunnable{
         int nameIndex = findAndValidateNameColumn(headerIndexMap);
         int entityTypeIndex = findAndValidateEntityTypeColumn(headerIndexMap);
         int reductionTechniqueIndex = findAndValidateReductionTechniqueColumn(headerIndexMap);
+        int descriptionIndex = findAndValidateDescriptionColumn(headerIndexMap);
         while((line = buff.readLine())!=null){
             String[] fieldValues = getFieldValues(line, headerIndexMap);
 
@@ -63,6 +65,7 @@ public class ImportEmbeddingDefinition extends ConsoleRunnable{
             String name = fieldValues[nameIndex].trim();
             String entityType = fieldValues[entityTypeIndex].trim();
             String reductionTechnique = fieldValues[reductionTechniqueIndex].trim();
+            String description = fieldValues[descriptionIndex].trim();
 
             // to create embedding definition object for each line and pass it to the dao for insert
             if(DaoEmbeddingDefinition.checkDefinitionExists(embeddingId)){
@@ -71,7 +74,7 @@ public class ImportEmbeddingDefinition extends ConsoleRunnable{
 
             // create and add to the database
             DaoEmbeddingDefinition.addDatum(new EmbeddingDefinition(embeddingId,
-                    shortName,name,entityType,reductionTechnique));
+                    shortName,name,description,entityType,reductionTechnique));
         }
         buff.close();
     }
@@ -81,6 +84,13 @@ public class ImportEmbeddingDefinition extends ConsoleRunnable{
             throw new RuntimeException("Missing required column: " + EMBEDDING_ID_COLUMN_NAME);
         }
         return headerIndexMap.get(EMBEDDING_ID_COLUMN_NAME);
+    }
+
+    private int findAndValidateDescriptionColumn(Map<String, Integer> headerIndexMap) {
+        if (!headerIndexMap.containsKey(DESCRIPTION_COLUMN_NAME)) {
+            throw new RuntimeException("Missing required column: " + EMBEDDING_ID_COLUMN_NAME);
+        }
+        return headerIndexMap.get(DESCRIPTION_COLUMN_NAME);
     }
 
     private int findAndValidateShortNameColumn(Map<String, Integer> headerIndexMap) {

--- a/src/test/java/org/mskcc/cbio/portal/integrationTest/dao/TestDaoEmbeddingDefinition.java
+++ b/src/test/java/org/mskcc/cbio/portal/integrationTest/dao/TestDaoEmbeddingDefinition.java
@@ -27,6 +27,7 @@ public class TestDaoEmbeddingDefinition extends IntegrationTestBase {
                 "umap_rna",
                 "RNA UMAP",
                 "RNA Expression UMAP Embedding",
+                "UMAP coordinates based on H&E histopathology embeddings",
                 "sample",
                 "UMAP"
         );
@@ -47,6 +48,7 @@ public class TestDaoEmbeddingDefinition extends IntegrationTestBase {
                 "umap_rna",
                 "RNA UMAP",
                 "RNA Expression UMAP Embedding",
+                "UMAP coordinates based on H&E histopathology embeddings",
                 "sample",
                 "UMAP"
         );

--- a/src/test/java/org/mskcc/cbio/portal/integrationTest/dao/TestDaoEmbeddingDefinition.java
+++ b/src/test/java/org/mskcc/cbio/portal/integrationTest/dao/TestDaoEmbeddingDefinition.java
@@ -1,0 +1,58 @@
+package org.mskcc.cbio.portal.integrationTest.dao;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mskcc.cbio.portal.dao.DaoEmbeddingDefinition;
+import org.mskcc.cbio.portal.dao.DaoException;
+import org.mskcc.cbio.portal.integrationTest.IntegrationTestBase;
+import org.mskcc.cbio.portal.model.EmbeddingDefinition;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = { "classpath:/applicationContext-dao.xml" })
+public class TestDaoEmbeddingDefinition extends IntegrationTestBase {
+
+    /**
+     * Tests .
+     * @throws DaoException Database Error.
+     */
+    @Test
+    public void addDatum() throws DaoException {
+        EmbeddingDefinition emb = new EmbeddingDefinition(
+                "umap_rna",
+                "RNA UMAP",
+                "RNA Expression UMAP Embedding",
+                "sample",
+                "UMAP"
+        );
+        DaoEmbeddingDefinition.addDatum(emb);
+        assertTrue(
+                DaoEmbeddingDefinition.checkDefinitionExists(
+                        "umap_rna"
+                )
+        );
+    }
+
+    @Test
+    public void getDefinitionId() throws DaoException{
+        // insert into the database
+        // get the id
+        // assert that it is  equal
+        EmbeddingDefinition emb = new EmbeddingDefinition(
+                "umap_rna",
+                "RNA UMAP",
+                "RNA Expression UMAP Embedding",
+                "sample",
+                "UMAP"
+        );
+        DaoEmbeddingDefinition.addDatum(emb);
+        assertEquals(1,DaoEmbeddingDefinition.getDefinitionId(emb.getEmbeddingId()));
+    }
+
+
+}

--- a/src/test/java/org/mskcc/cbio/portal/integrationTest/dao/TestDaoEmbeddingDefinition.java
+++ b/src/test/java/org/mskcc/cbio/portal/integrationTest/dao/TestDaoEmbeddingDefinition.java
@@ -53,6 +53,8 @@ public class TestDaoEmbeddingDefinition extends IntegrationTestBase {
                 "UMAP"
         );
         DaoEmbeddingDefinition.addDatum(emb);
+        // Hardcoded to 1 because only one definition is added, meaning the definition id will be one.
+        // This assumption is based on how ClickHouseAutoIncrement works.
         assertEquals(1,DaoEmbeddingDefinition.getDefinitionId(emb.getEmbeddingId()));
     }
 

--- a/src/test/java/org/mskcc/cbio/portal/integrationTest/scripts/TestImportEmbeddingData.java
+++ b/src/test/java/org/mskcc/cbio/portal/integrationTest/scripts/TestImportEmbeddingData.java
@@ -46,10 +46,12 @@ public class TestImportEmbeddingData extends IntegrationTestBase {
 
         // Insert embedding definitions matching the IDs used in data_embedding.txt
         DaoEmbeddingDefinition.addDatum(new EmbeddingDefinition(
-                "umap_1", "UMAP 1", "UMAP Embedding", "patient", "UMAP"
+                "umap_1", "UMAP 1", "UMAP Embedding", "UMAP coordinates based on H&E histopathology embeddings",
+                "patient", "UMAP"
         ));
         DaoEmbeddingDefinition.addDatum(new EmbeddingDefinition(
-                "pca_1", "PCA 1", "PCA Embedding", "sample", "PCA"
+                "pca_1", "PCA 1", "PCA Embedding", "PCA coordinates based on H&E histopathology embeddings",
+                "sample", "PCA"
         ));
     }
 

--- a/src/test/java/org/mskcc/cbio/portal/integrationTest/scripts/TestImportEmbeddingData.java
+++ b/src/test/java/org/mskcc/cbio/portal/integrationTest/scripts/TestImportEmbeddingData.java
@@ -1,0 +1,74 @@
+package org.mskcc.cbio.portal.integrationTest.scripts;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mskcc.cbio.portal.dao.DaoCancerStudy;
+import org.mskcc.cbio.portal.dao.DaoEmbeddingData;
+import org.mskcc.cbio.portal.dao.DaoEmbeddingDefinition;
+import org.mskcc.cbio.portal.dao.DaoException;
+import org.mskcc.cbio.portal.integrationTest.IntegrationTestBase;
+import org.mskcc.cbio.portal.model.CancerStudy;
+import org.mskcc.cbio.portal.model.EmbeddingData;
+import org.mskcc.cbio.portal.model.EmbeddingDefinition;
+import org.mskcc.cbio.portal.scripts.ImportEmbeddingData;
+import org.mskcc.cbio.portal.util.ProgressMonitor;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = { "classpath:/applicationContext-dao.xml" })
+public class TestImportEmbeddingData extends IntegrationTestBase {
+
+    private CancerStudy cancerStudy = null;
+
+    /**
+     * This is executed n times, for each of the n test methods below:
+     * @throws DaoException
+     */
+    @Before
+    public void setUp() throws DaoException
+    {
+//        DaoCancerStudy.reCacheAll();
+//        ProgressMonitor.resetWarnings();
+
+        // new dummy study to simulate importing clinical data in empty study:
+        cancerStudy = new CancerStudy("testnew","testnew","testnew","brca",true);
+        cancerStudy.setReferenceGenome("hg19");
+        DaoCancerStudy.addCancerStudy(cancerStudy);
+        // implicit test:
+        cancerStudy = DaoCancerStudy.getCancerStudyByStableId("testnew");
+
+        // Insert embedding definitions matching the IDs used in data_embedding.txt
+        DaoEmbeddingDefinition.addDatum(new EmbeddingDefinition(
+                "umap_1", "UMAP 1", "UMAP Embedding", "patient", "UMAP"
+        ));
+        DaoEmbeddingDefinition.addDatum(new EmbeddingDefinition(
+                "pca_1", "PCA 1", "PCA Embedding", "sample", "PCA"
+        ));
+    }
+
+    @Test
+    public void importData() throws Exception {
+        ProgressMonitor.setConsoleMode(false);
+        String[] args = {
+                "--data","src/test/resources/data_embedding.txt",
+                "--meta","src/test/resources/meta_embedding.txt",
+                "--loadMode", "bulkLoad"
+        };
+
+        ImportEmbeddingData importEmbeddingData = new ImportEmbeddingData(args);
+        importEmbeddingData.run();
+        // Check the definition exists
+        assertTrue(DaoEmbeddingDefinition.checkDefinitionExists("umap_1"));
+        assertTrue(DaoEmbeddingDefinition.checkDefinitionExists("pca_1"));
+        // Check the actual embedding data exists
+        List<EmbeddingData> data = DaoEmbeddingData.getEmbeddingDataByCancerStudy(2);
+        assertEquals(8, data.size());
+    }
+}

--- a/src/test/java/org/mskcc/cbio/portal/integrationTest/scripts/TestImportEmbeddingDefinition.java
+++ b/src/test/java/org/mskcc/cbio/portal/integrationTest/scripts/TestImportEmbeddingDefinition.java
@@ -30,4 +30,16 @@ public class TestImportEmbeddingDefinition extends IntegrationTestBase {
        assertTrue(DaoEmbeddingDefinition.checkDefinitionExists("mosaic_patient"));
        assertTrue(DaoEmbeddingDefinition.checkDefinitionExists("patient_record_embedding"));
     }
+//
+//    @Test
+//    public void testDefinitionExists(){
+//        ProgressMonitor.setConsoleMode(false);
+//        String[] args = {
+//                "--data","src/test/resources/data_embedding_definition_test_with_duplicate.txt",
+//                "--noprogress"
+//        };
+//        ImportEmbeddingDefinition importEmbeddingDefinition = new ImportEmbeddingDefinition(args);
+//        importEmbeddingDefinition.run();
+//
+//    }
 }

--- a/src/test/java/org/mskcc/cbio/portal/integrationTest/scripts/TestImportEmbeddingDefinition.java
+++ b/src/test/java/org/mskcc/cbio/portal/integrationTest/scripts/TestImportEmbeddingDefinition.java
@@ -1,0 +1,33 @@
+package org.mskcc.cbio.portal.integrationTest.scripts;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mskcc.cbio.portal.dao.DaoEmbeddingDefinition;
+import static org.junit.Assert.assertTrue;
+import org.mskcc.cbio.portal.integrationTest.IntegrationTestBase;
+import org.mskcc.cbio.portal.scripts.ImportEmbeddingDefinition;
+import org.mskcc.cbio.portal.util.ProgressMonitor;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.io.File;
+
+@RunWith(SpringJUnit4ClassRunner .class)
+@ContextConfiguration(locations = { "classpath:/applicationContext-dao.xml" })
+public class TestImportEmbeddingDefinition extends IntegrationTestBase {
+
+    @Test
+    public void importData() throws Exception {
+        ProgressMonitor.setConsoleMode(false);
+        String[] args = {
+                "--data","src/test/resources/data_embedding_definition.txt",
+                "--noprogress"
+        };
+
+        ImportEmbeddingDefinition importEmbeddingDefinition = new ImportEmbeddingDefinition(args);
+        importEmbeddingDefinition.run();
+       //for now we will change this later to use the script to check existence of t instead of the Dao
+       assertTrue(DaoEmbeddingDefinition.checkDefinitionExists("mosaic_patient"));
+       assertTrue(DaoEmbeddingDefinition.checkDefinitionExists("patient_record_embedding"));
+    }
+}

--- a/src/test/resources/clickhouse_cgds.sql
+++ b/src/test/resources/clickhouse_cgds.sql
@@ -57,6 +57,7 @@ DROP TABLE IF EXISTS sample_to_gene_panel_derived;
 DROP TABLE IF EXISTS structural_variant;
 DROP TABLE IF EXISTS type_of_cancer;
 DROP TABLE IF EXISTS users;
+DROP TABLE IF EXISTS embedding;
  */
 
 CREATE TABLE allele_specific_copy_number
@@ -769,6 +770,32 @@ CREATE TABLE users
     `email` Nullable(String),
     `name` Nullable(String),
     `enabled` Nullable(Int32)
+)
+    ENGINE = MergeTree
+ORDER BY tuple();
+
+CREATE TABLE embedding_definition
+(
+    `internal_id` Int32,
+    `embedding_id` String,
+    `short_name` String,
+    `name` String,
+    `description` String,
+    `entity_type` String,
+    `reduction_technique` String
+)
+    ENGINE = MergeTree
+ORDER BY tuple(internal_id, embedding_id);
+
+CREATE TABLE embedding_data
+(
+    `embedding_id` Int32,
+    `patient_id` String,
+    `sample_id` String,
+    `x` Float32,
+    `y` Float32,
+    `custom_attribute` String,
+    `study_id` Int32,
 )
     ENGINE = MergeTree
 ORDER BY tuple();

--- a/src/test/resources/clickhouse_cgds.sql
+++ b/src/test/resources/clickhouse_cgds.sql
@@ -57,7 +57,8 @@ DROP TABLE IF EXISTS sample_to_gene_panel_derived;
 DROP TABLE IF EXISTS structural_variant;
 DROP TABLE IF EXISTS type_of_cancer;
 DROP TABLE IF EXISTS users;
-DROP TABLE IF EXISTS embedding;
+DROP TABLE IF EXISTS embedding_definition;
+DROP TABLE IF EXISTS embedding_data;
  */
 
 CREATE TABLE allele_specific_copy_number

--- a/src/test/resources/clickhouse_cgds.sql
+++ b/src/test/resources/clickhouse_cgds.sql
@@ -790,7 +790,7 @@ ORDER BY tuple(internal_id, embedding_id);
 
 CREATE TABLE embedding_data
 (
-    `embedding_id` Int32,
+    `embedding_definition_id` Int32,
     `patient_id` String,
     `sample_id` String,
     `x` Float32,

--- a/src/test/resources/data_embedding.txt
+++ b/src/test/resources/data_embedding.txt
@@ -1,0 +1,9 @@
+EMBEDDING_ID	PATIENT_ID	SAMPLE_ID	X	Y	CUSTOM_ATTRIBUTE
+umap_1	TCGA-A2-A04P		1.2	3.4	{"data_split":"train"}
+umap_1	TCGA-A1-A0SK		2.1	0.8	{"data_split":"train"}
+umap_1	TCGA-A2-A0CM		4.5	1.1	{"data_split":"validation"}
+umap_1	TCGA-AR-A1AR		3.3	2.2	{"data_split":"test"}
+pca_1	TCGA-B6-A0WX	TCGA-B6-A0WX-01	0.5	1.9	{"data_split":"train"}
+pca_1	TCGA-BH-A1F0	TCGA-BH-A1F0-01	2.7	3.1	{"data_split":"validation"}
+pca_1	TCGA-B6-A0I6	TCGA-B6-A0I6-01	1.8	0.4	{"data_split":"test"}
+pca_1	TCGA-BH-A18V	TCGA-BH-A18V-01	3.9	2.6	{"data_split":"test"}

--- a/src/test/resources/data_embedding.txt
+++ b/src/test/resources/data_embedding.txt
@@ -1,4 +1,4 @@
-EMBEDDING_ID	PATIENT_ID	SAMPLE_ID	X	Y	CUSTOM_ATTRIBUTE
+EMBEDDING_ID	PATIENT_ID	SAMPLE_ID	X	Y	CUSTOM_ATTRIBUTES
 umap_1	TCGA-A2-A04P		1.2	3.4	{"data_split":"train"}
 umap_1	TCGA-A1-A0SK		2.1	0.8	{"data_split":"train"}
 umap_1	TCGA-A2-A0CM		4.5	1.1	{"data_split":"validation"}

--- a/src/test/resources/data_embedding_definition.txt
+++ b/src/test/resources/data_embedding_definition.txt
@@ -1,0 +1,3 @@
+EMBEDDING_ID	SHORT_NAME	NAME	DESCRIPTION	ENTITY_TYPE	REDUCTION_TECHNIQUE
+mosaic_patient	UMAP	UMAP Patient Embedding	UMAP embedding for patient similarity	PATIENT	umap
+patient_record_embedding	PCA	PCA Sample Embedding	PCA embedding for sample similarity	SAMPLE	pca

--- a/src/test/resources/data_embedding_definition_test_with_duplicate.txt
+++ b/src/test/resources/data_embedding_definition_test_with_duplicate.txt
@@ -1,0 +1,6 @@
+EMBEDDING_ID	SHORT_NAME	NAME	DESCRIPTION	ENTITY_TYPE	REDUCTION_TECHNIQUE
+mosaic_patient	UMAP	UMAP Patient Embedding	UMAP embedding for patient similarity	PATIENT	umap
+mosaic_patient	UMAP	UMAP Patient Embedding	UMAP embedding for patient similarity	PATIENT	umap
+mosaic_patient	UMAP	UMAP Patient Embedding	UMAP embedding for patient similarity	PATIENT	umap
+mosaic_patient	UMAP	UMAP Patient Embedding	UMAP embedding for patient similarity	PATIENT	umap
+patient_record_embedding	PCA	PCA Sample Embedding	PCA embedding for sample similarity	SAMPLE	pca

--- a/src/test/resources/meta_embedding.txt
+++ b/src/test/resources/meta_embedding.txt
@@ -1,0 +1,2 @@
+cancer_study_identifier: testnew
+embedding_type: DATA

--- a/tests/system_tests_import_data.py
+++ b/tests/system_tests_import_data.py
@@ -80,6 +80,8 @@ class DataImporterTests(unittest.TestCase):
             call(*common_part, 'org.mskcc.cbio.portal.scripts.ImportSampleList', f'{study_directory}/case_lists/cases_sequenced.txt', '--noprogress'),
             call(*common_part, 'org.mskcc.cbio.portal.scripts.ImportSampleList', f'{study_directory}/case_lists/cases_test.txt', '--noprogress'),
             call(*common_part, 'org.mskcc.cbio.portal.scripts.AddCaseList', 'study_es_0', 'all', '--noprogress'),
+            call(*common_part, 'org.mskcc.cbio.portal.scripts.ImportEmbeddingDefinition','--data', f'{study_directory}/data_embedding_definition.txt', '--noprogress'),
+            call(*common_part, 'org.mskcc.cbio.portal.scripts.ImportEmbeddingData', '--meta', f'{study_directory}/meta_embedding.txt', '--loadMode', 'bulkload','--data', f'{study_directory}/data_embedding.txt', '--noprogress'),
             make_study_available_call,
         ])
 

--- a/tests/test_data/data_embedding.txt
+++ b/tests/test_data/data_embedding.txt
@@ -1,0 +1,9 @@
+EMBEDDING_ID	PATIENT_ID	SAMPLE_ID	X	Y	CUSTOM_ATTRIBUTES
+mosaic_sample	TEST-PAT1		1.2	3.4	{"data_split":"train"}
+mosaic_sample	TEST-PAT2		2.1	0.8	{"data_split":"train"}
+mosaic_sample	TEST-PAT3		4.5	1.1	{"data_split":"validation"}
+mosaic_sample	TEST-PAT4		3.3	2.2	{"data_split":"test"}
+patient_record_embedding	TEST-PAT5	TCGA-A1-A0SB-01	0.5	1.9	{"data_split":"train"}
+patient_record_embedding	TEST-PAT6	TCGA-A1-A0SD-01	2.7	3.1	{"data_split":"validation"}
+patient_record_embedding	TEST-PAT7	TCGA-A1-A0SE-01	1.8	0.4	{"data_split":"test"}
+patient_record_embedding	TEST-PAT9	TCGA-A1-A0SH-01	3.9	2.6	{"data_split":"test"}

--- a/tests/test_data/data_embedding_definition.txt
+++ b/tests/test_data/data_embedding_definition.txt
@@ -1,0 +1,3 @@
+EMBEDDING_ID	SHORT_NAME	NAME	DESCRIPTION	ENTITY_TYPE	REDUCTION_TECHNIQUE
+mosaic_sample	UMAP	UMAP Patient Embedding	UMAP embedding for patient similarity	PATIENT	umap
+patient_record_embedding	PCA	PCA Sample Embedding	PCA embedding for sample similarity	SAMPLE	pca

--- a/tests/test_data/study_es_0/data_embedding.txt
+++ b/tests/test_data/study_es_0/data_embedding.txt
@@ -1,0 +1,9 @@
+EMBEDDING_ID	PATIENT_ID	SAMPLE_ID	X	Y	CUSTOM_ATTRIBUTE
+umap_1	TCGA-A2-A04P		1.2	3.4	{"data_split":"train"}
+umap_1	TCGA-A1-A0SK		2.1	0.8	{"data_split":"train"}
+umap_1	TCGA-A2-A0CM		4.5	1.1	{"data_split":"validation"}
+umap_1	TCGA-AR-A1AR		3.3	2.2	{"data_split":"test"}
+pca_1	TCGA-B6-A0WX	TCGA-B6-A0WX-01	0.5	1.9	{"data_split":"train"}
+pca_1	TCGA-BH-A1F0	TCGA-BH-A1F0-01	2.7	3.1	{"data_split":"validation"}
+pca_1	TCGA-B6-A0I6	TCGA-B6-A0I6-01	1.8	0.4	{"data_split":"test"}
+pca_1	TCGA-BH-A18V	TCGA-BH-A18V-01	3.9	2.6	{"data_split":"test"}

--- a/tests/test_data/study_es_0/data_embedding.txt
+++ b/tests/test_data/study_es_0/data_embedding.txt
@@ -1,4 +1,4 @@
-EMBEDDING_ID	PATIENT_ID	SAMPLE_ID	X	Y	CUSTOM_ATTRIBUTE
+EMBEDDING_ID	PATIENT_ID	SAMPLE_ID	X	Y	CUSTOM_ATTRIBUTES
 umap_1	TCGA-A2-A04P		1.2	3.4	{"data_split":"train"}
 umap_1	TCGA-A1-A0SK		2.1	0.8	{"data_split":"train"}
 umap_1	TCGA-A2-A0CM		4.5	1.1	{"data_split":"validation"}

--- a/tests/test_data/study_es_0/data_embedding_definition.txt
+++ b/tests/test_data/study_es_0/data_embedding_definition.txt
@@ -1,0 +1,3 @@
+EMBEDDING_ID	SHORT_NAME	NAME	DESCRIPTION	ENTITY_TYPE	REDUCTION_TECHNIQUE
+umap_1	UMAP	UMAP Patient Embedding	UMAP embedding for patient similarity	PATIENT	umap
+pca_1	PCA	PCA Sample Embedding	PCA embedding for sample similarity	SAMPLE	pca

--- a/tests/test_data/study_es_0/meta_embedding.txt
+++ b/tests/test_data/study_es_0/meta_embedding.txt
@@ -1,0 +1,2 @@
+data_filename: data_embedding.txt
+embedding_type:	DATA 

--- a/tests/test_data/study_es_0/meta_embedding.txt
+++ b/tests/test_data/study_es_0/meta_embedding.txt
@@ -1,2 +1,3 @@
+cancer_study_identifier: study_es_0
 data_filename: data_embedding.txt
 embedding_type:	DATA 

--- a/tests/test_data/study_es_0/meta_embedding_definition.txt
+++ b/tests/test_data/study_es_0/meta_embedding_definition.txt
@@ -1,3 +1,2 @@
-cancer_study_identifier: study_es_0
-data_filename: data_embedding_definition.txt	
+data_filename: data_embedding_definition.txt
 embedding_type:	DEFINITION

--- a/tests/test_data/study_es_0/meta_embedding_definition.txt
+++ b/tests/test_data/study_es_0/meta_embedding_definition.txt
@@ -1,0 +1,3 @@
+cancer_study_identifier: study_es_0
+data_filename: data_embedding_definition.txt	
+embedding_type:	DEFINITION

--- a/tests/unit_tests_validate_data.py
+++ b/tests/unit_tests_validate_data.py
@@ -3235,6 +3235,21 @@ class CNADiscretePDAAnnotationsValidatorTestCase(PostClinicalDataFileTestCase):
         record_list = self.get_log_records()
         self.assertEqual('Validation complete', record_list[-1].getMessage())
 
+class EmbeddingDefinitionValidatorTestCase(PostClinicalDataFileTestCase):
+    def test_valid_embedding_definition_file(self):
+        self.logger.setLevel(logging.ERROR)
+        record_list = self.validate('data_embedding_definition.txt',
+                                    validateData.EmbeddingDefinitionValidator)
+        self.assertEqual(0, len(record_list))
+
+class EmbeddingValidatorTestCase(PostClinicalDataFileTestCase):
+    def test_valid_embedding_file(self):
+        self.logger.setLevel(logging.ERROR)
+        record_list = self.validate('data_embedding.txt',
+                                    validateData.EmbeddingValidator)
+        self.assertEqual(0, len(record_list))
+
+
 
 if __name__ == '__main__':
     unittest.main(buffer=True)

--- a/tests/unit_tests_validate_data.py
+++ b/tests/unit_tests_validate_data.py
@@ -3246,7 +3246,7 @@ class EmbeddingValidatorTestCase(PostClinicalDataFileTestCase):
     def test_valid_embedding_file(self):
         self.logger.setLevel(logging.ERROR)
         record_list = self.validate('data_embedding.txt',
-                                    validateData.EmbeddingValidator)
+                                    validateData.EmbeddingDataValidator)
         self.assertEqual(0, len(record_list))
 
 


### PR DESCRIPTION
Describe changes proposed in this pull request:
- Introduced Python validation layer for embedding data types, including EmbeddingDefinitionValidator and EmbeddingValidator in validateData.py
- Implemented Java ingestion layer for embedding definitions, including EmbeddingDefinition model, DaoEmbeddingDefinition, and ImportEmbeddingDefinition
- Implemented Java ingestion layer for embedding data, including EmbeddingData model, DaoEmbeddingData, and ImportEmbeddingData using ClickHouseBulkLoader for high-volume coordinate ingestion
-  Registered EMBEDDING and EMBEDDING_DEFINITION meta types in IMPORTER_CLASSNAME_BY_META_TYPE and IMPORTER_REQUIRES_METADATA (TODO: negative tests and edge cases to be added in a follow-up)
- Added tests for ImportEmbeddingDefinition and ImportEmbeddingData scripts 
- Added unit tests for EmbeddingDefinitionValidator and EmbeddingValidator covering the happy path (TODO: negative tests and edge cases to be added in a follow-up)

# Checks
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] Is this PR adding logic based on one or more **clinical** attributes? 
- [ ] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR

**Note future plan**

- [x] Rename ambiguous embeddingId fields for clarity on both new models for EmbeddingDefinition and EmbeddingData. Needs to be renamed for clarity 
- [ ] Write more tests for the importer, which includes the Java layer(import) and Python layer(validation)
- [x]  Edit the validation requirements for meta files so that definition no longer reqires cancser study id rather the embedding meta file requires cacncer study id 
- [x] Use the log to provide useful outputs throughout the importing process
- [ ]  Fix a situation where data has been imported to the data embedding table it should not appear twice on the table. It should only appear once,  Possible solutions using ReplacingMegeTree as the engine for the table so clickhouse sorts ut out later dont forget the orderyby 
