### PR TITLE
Optional no-explode import mode for genetic alteration matrices

### DIFF
--- a/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseBulkLoader.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseBulkLoader.java
@@ -64,6 +64,17 @@ public class ClickHouseBulkLoader {
     private static boolean bulkLoad = false;
     private static boolean relaxedMode = false;
 
+    /**
+     * When enabled, matrix-style genetic alteration data is written directly to the exploded
+     * {@code genetic_alteration_derived} table at import time instead of being stored packed in
+     * {@code genetic_alteration} and rebuilt later by the ARRAY JOIN derive step. Defaults from the
+     * {@code cbioportal.importer.no_explode} system property (or {@code CBIOPORTAL_IMPORTER_NO_EXPLODE}
+     * env var) so it can be toggled from metaImport.py, and can also be set programmatically.
+     */
+    private static boolean noExplode = Boolean.parseBoolean(
+        System.getProperty("cbioportal.importer.no_explode",
+            System.getenv().getOrDefault("CBIOPORTAL_IMPORTER_NO_EXPLODE", "false")));
+
     private final String tableName;
     private final List<String[]> pendingRecords = new ArrayList<>();
     private String[] fieldNames = null;
@@ -83,6 +94,19 @@ public class ClickHouseBulkLoader {
         }
         BULK_LOADERS.clear();
         return totalInserted;
+    }
+
+    /**
+     * Flush this loader's buffered rows immediately. Lets a caller bound memory by flushing
+     * periodically instead of accumulating an entire (potentially huge) batch before {@link #flushAll()}.
+     */
+    public int flush() throws DaoException {
+        return flushPendingRecords();
+    }
+
+    /** Number of rows currently buffered (not yet flushed). */
+    public int pendingSize() {
+        return pendingRecords.size();
     }
 
     private int flushPendingRecords() throws DaoException {
@@ -203,6 +227,18 @@ public class ClickHouseBulkLoader {
 
     public static void bulkLoadOff() {
         bulkLoad = false;
+    }
+
+    public static boolean isNoExplode() {
+        return noExplode;
+    }
+
+    public static void noExplodeOn() {
+        noExplode = true;
+    }
+
+    public static void noExplodeOff() {
+        noExplode = false;
     }
 
     public static void relaxedModeOn() {

--- a/src/main/java/org/mskcc/cbio/portal/scripts/GeneticAlterationImporter.java
+++ b/src/main/java/org/mskcc/cbio/portal/scripts/GeneticAlterationImporter.java
@@ -1,10 +1,17 @@
 package org.mskcc.cbio.portal.scripts;
 
 import java.util.*;
+import org.mskcc.cbio.portal.dao.ClickHouseBulkLoader;
+import org.mskcc.cbio.portal.dao.DaoCancerStudy;
 import org.mskcc.cbio.portal.dao.DaoException;
 import org.mskcc.cbio.portal.dao.DaoGeneticAlteration;
+import org.mskcc.cbio.portal.dao.DaoGeneticProfile;
 import org.mskcc.cbio.portal.dao.DaoGeneticProfileSamples;
+import org.mskcc.cbio.portal.dao.DaoSample;
 import org.mskcc.cbio.portal.model.CanonicalGene;
+import org.mskcc.cbio.portal.model.CancerStudy;
+import org.mskcc.cbio.portal.model.GeneticProfile;
+import org.mskcc.cbio.portal.model.Sample;
 import org.mskcc.cbio.portal.util.ProgressMonitor;
 import static java.lang.String.format;
 
@@ -16,6 +23,21 @@ public class GeneticAlterationImporter {
     private final Set<Integer> importSetOfGeneticEntityIds = new HashSet<>();
 
     private final DaoGeneticAlteration daoGeneticAlteration = DaoGeneticAlteration.getInstance();
+
+    // --- no-explode mode: write exploded rows straight into genetic_alteration_derived at import
+    // time instead of storing packed `values` and rebuilding the derived table with the ARRAY JOIN
+    // derive step. Toggled by ClickHouseBulkLoader.isNoExplode(). Pair with metaImport.py
+    // --no-derive-tables so the SQL derive does not clobber the directly-written rows.
+    private static final String DERIVED_TABLE = "genetic_alteration_derived";
+    private static final String[] DERIVED_COLUMNS =
+        {"sample_unique_id", "cancer_study_identifier", "hugo_gene_symbol", "profile_type", "alteration_value"};
+    private static final int DERIVED_FLUSH_THRESHOLD = 500_000;
+    private final boolean noExplode = ClickHouseBulkLoader.isNoExplode();
+    private String cancerStudyIdentifier;
+    private String profileType;
+    private String[] sampleUniqueIds;
+    private ClickHouseBulkLoader derivedLoader;
+    private int pendingDerivedRows = 0;
 
     protected GeneticAlterationImporter() {}
     public GeneticAlterationImporter(
@@ -45,7 +67,11 @@ public class GeneticAlterationImporter {
     ) throws DaoException {
         ensureNumberOfValuesIsCorrect(values.length);
         if (importSetOfGenes.add(gene.getEntrezGeneId())) {
-            daoGeneticAlteration.addGeneticAlterations(geneticProfileId, gene.getEntrezGeneId(), values);
+            if (noExplode) {
+                writeExplodedRows(gene.getHugoGeneSymbolAllCaps(), values);
+            } else {
+                daoGeneticAlteration.addGeneticAlterations(geneticProfileId, gene.getEntrezGeneId(), values);
+            }
             return true;
         }
         String geneSymbolMessage = "";
@@ -75,11 +101,56 @@ public class GeneticAlterationImporter {
     ) throws DaoException {
         ensureNumberOfValuesIsCorrect(values.length);
         if (importSetOfGeneticEntityIds.add(geneticEntityId)) {
+            // no-explode targets gene-based genetic_alteration_derived only; generic entities
+            // (e.g. generic assay) keep the packed path and their own derive step.
             daoGeneticAlteration.addGeneticAlterationsForGeneticEntity(geneticProfileId, geneticEntityId, values);
             return true;
         }
         ProgressMonitor.logWarning("Data for genetic entity with id " + geneticEntityId + " already imported from file. Record will be skipped.");
         return false;
+    }
+
+    /**
+     * Resolve the constants needed to denormalize a row to the derived table (study, profile_type,
+     * and the per-column sample_unique_id) once per profile. These are exactly the values the SQL
+     * derive recovers by joining gene / sample_derived / genetic_profile — known here at import time.
+     */
+    private void initNoExplodeContext() throws DaoException {
+        GeneticProfile geneticProfile = DaoGeneticProfile.getGeneticProfileById(geneticProfileId);
+        CancerStudy study = DaoCancerStudy.getCancerStudyByInternalId(geneticProfile.getCancerStudyId());
+        this.cancerStudyIdentifier = study.getCancerStudyStableId();
+        String prefix = cancerStudyIdentifier + "_";
+        String stableId = geneticProfile.getStableId();
+        this.profileType = stableId.startsWith(prefix) ? stableId.substring(prefix.length()) : stableId;
+        this.sampleUniqueIds = new String[orderedSampleList.size()];
+        for (int i = 0; i < orderedSampleList.size(); i++) {
+            Sample sample = DaoSample.getSampleById(orderedSampleList.get(i));
+            this.sampleUniqueIds[i] = cancerStudyIdentifier + "_" + sample.getStableId();
+        }
+        this.derivedLoader = ClickHouseBulkLoader.getClickHouseBulkLoader(DERIVED_TABLE);
+        this.derivedLoader.setFieldNames(DERIVED_COLUMNS);
+    }
+
+    /**
+     * Emit one exploded (sample_unique_id, study, gene, profile_type, value) row per cell straight
+     * into genetic_alteration_derived. Mirrors the SQL derive exactly: a cell is dropped when its
+     * value is "NA" or empty (the derive maps '' -> NULL and then filters with "!= 'NA'", which
+     * also excludes the NULLs). Flushes periodically so memory stays bounded for large matrices.
+     */
+    private void writeExplodedRows(String hugoGeneSymbol, String[] values) throws DaoException {
+        for (int i = 0; i < values.length; i++) {
+            String value = values[i];
+            if (value.isEmpty() || "NA".equals(value)) {
+                continue;
+            }
+            derivedLoader.insertRecord(
+                sampleUniqueIds[i], cancerStudyIdentifier, hugoGeneSymbol, profileType, value);
+            pendingDerivedRows++;
+        }
+        if (pendingDerivedRows >= DERIVED_FLUSH_THRESHOLD) {
+            derivedLoader.flush();
+            pendingDerivedRows = 0;
+        }
     }
 
     private void ensureNumberOfValuesIsCorrect(int valuesNumber) {
@@ -92,9 +163,18 @@ public class GeneticAlterationImporter {
     public void initialize() {
         try {
             storeOrderedSampleList();
+            if (noExplode) {
+                initNoExplodeContext();
+            }
         } catch (DaoException e) {
             throw new RuntimeException(e);
         }
     }
-    public void complete() throws DaoException { }
+
+    public void complete() throws DaoException {
+        if (noExplode && derivedLoader != null) {
+            derivedLoader.flush();
+            pendingDerivedRows = 0;
+        }
+    }
 }

--- a/src/main/java/org/mskcc/cbio/portal/scripts/GeneticAlterationImporter.java
+++ b/src/main/java/org/mskcc/cbio/portal/scripts/GeneticAlterationImporter.java
@@ -5,12 +5,16 @@ import org.mskcc.cbio.portal.dao.ClickHouseBulkLoader;
 import org.mskcc.cbio.portal.dao.DaoCancerStudy;
 import org.mskcc.cbio.portal.dao.DaoException;
 import org.mskcc.cbio.portal.dao.DaoGeneticAlteration;
+import org.mskcc.cbio.portal.dao.DaoGeneticEntity;
 import org.mskcc.cbio.portal.dao.DaoGeneticProfile;
 import org.mskcc.cbio.portal.dao.DaoGeneticProfileSamples;
+import org.mskcc.cbio.portal.dao.DaoPatient;
 import org.mskcc.cbio.portal.dao.DaoSample;
 import org.mskcc.cbio.portal.model.CanonicalGene;
 import org.mskcc.cbio.portal.model.CancerStudy;
 import org.mskcc.cbio.portal.model.GeneticProfile;
+import org.mskcc.cbio.portal.model.shared.GeneticEntity;
+import org.mskcc.cbio.portal.model.Patient;
 import org.mskcc.cbio.portal.model.Sample;
 import org.mskcc.cbio.portal.util.ProgressMonitor;
 import static java.lang.String.format;
@@ -38,6 +42,20 @@ public class GeneticAlterationImporter {
     private String[] sampleUniqueIds;
     private ClickHouseBulkLoader derivedLoader;
     private int pendingDerivedRows = 0;
+
+    // --- no-explode for generic assay (entity-based) -> generic_assay_data_derived (wider schema) ---
+    private static final String GA_DERIVED_TABLE = "generic_assay_data_derived";
+    private static final String[] GA_DERIVED_COLUMNS = {"sample_unique_id", "patient_unique_id",
+        "genetic_entity_id", "value", "generic_assay_type", "profile_stable_id", "entity_stable_id",
+        "datatype", "patient_level", "profile_type"};
+    private Boolean genericAssayProfile;     // null = not yet resolved
+    private String profileStableId;
+    private String genericAssayType;
+    private String datatype;
+    private String patientLevel;
+    private String[] patientUniqueIds;
+    private ClickHouseBulkLoader gaDerivedLoader;
+    private int pendingGaRows = 0;
 
     protected GeneticAlterationImporter() {}
     public GeneticAlterationImporter(
@@ -101,9 +119,14 @@ public class GeneticAlterationImporter {
     ) throws DaoException {
         ensureNumberOfValuesIsCorrect(values.length);
         if (importSetOfGeneticEntityIds.add(geneticEntityId)) {
-            // no-explode targets gene-based genetic_alteration_derived only; generic entities
-            // (e.g. generic assay) keep the packed path and their own derive step.
-            daoGeneticAlteration.addGeneticAlterationsForGeneticEntity(geneticProfileId, geneticEntityId, values);
+            // no-explode handles generic assay (-> generic_assay_data_derived). Other entity-based
+            // profiles (e.g. GSVA geneset scores, which have no derived table and are read from the
+            // packed table directly) always keep the packed path.
+            if (noExplode && isGenericAssayProfile()) {
+                writeGenericAssayExplodedRows(geneticEntityId, values);
+            } else {
+                daoGeneticAlteration.addGeneticAlterationsForGeneticEntity(geneticProfileId, geneticEntityId, values);
+            }
             return true;
         }
         ProgressMonitor.logWarning("Data for genetic entity with id " + geneticEntityId + " already imported from file. Record will be skipped.");
@@ -153,6 +176,65 @@ public class GeneticAlterationImporter {
         }
     }
 
+    /** True iff this profile is a generic assay profile; resolves and caches the GA context once. */
+    private boolean isGenericAssayProfile() throws DaoException {
+        if (genericAssayProfile == null) {
+            GeneticProfile geneticProfile = DaoGeneticProfile.getGeneticProfileById(geneticProfileId);
+            genericAssayProfile = geneticProfile.getGenericAssayType() != null;
+            if (genericAssayProfile) {
+                initGenericAssayContext(geneticProfile);
+            }
+        }
+        return genericAssayProfile;
+    }
+
+    /**
+     * Resolve the constants the generic_assay_data_derived row needs (study, profile fields, and the
+     * per-column sample_unique_id / patient_unique_id) once per profile — the same values the SQL
+     * derive recovers by joining genetic_profile / genetic_entity / sample_derived.
+     */
+    private void initGenericAssayContext(GeneticProfile geneticProfile) throws DaoException {
+        CancerStudy study = DaoCancerStudy.getCancerStudyByInternalId(geneticProfile.getCancerStudyId());
+        this.cancerStudyIdentifier = study.getCancerStudyStableId();
+        this.profileStableId = geneticProfile.getStableId();
+        String prefix = cancerStudyIdentifier + "_";
+        this.profileType = profileStableId.startsWith(prefix) ? profileStableId.substring(prefix.length()) : profileStableId;
+        this.genericAssayType = geneticProfile.getGenericAssayType();
+        this.datatype = geneticProfile.getDatatype();
+        this.patientLevel = geneticProfile.getPatientLevel() ? "1" : "0";
+        this.sampleUniqueIds = new String[orderedSampleList.size()];
+        this.patientUniqueIds = new String[orderedSampleList.size()];
+        for (int i = 0; i < orderedSampleList.size(); i++) {
+            Sample sample = DaoSample.getSampleById(orderedSampleList.get(i));
+            this.sampleUniqueIds[i] = cancerStudyIdentifier + "_" + sample.getStableId();
+            Patient patient = DaoPatient.getPatientById(sample.getInternalPatientId());
+            this.patientUniqueIds[i] = cancerStudyIdentifier + "_" + patient.getStableId();
+        }
+        this.gaDerivedLoader = ClickHouseBulkLoader.getClickHouseBulkLoader(GA_DERIVED_TABLE);
+        this.gaDerivedLoader.setFieldNames(GA_DERIVED_COLUMNS);
+    }
+
+    /**
+     * Emit one generic_assay_data_derived row per cell. Mirrors that derive, which (unlike the gene
+     * one) does NOT filter "NA": it maps '' -> NULL and keeps every other value, so no cell is dropped.
+     */
+    private void writeGenericAssayExplodedRows(int geneticEntityId, String[] values) throws DaoException {
+        GeneticEntity entity = DaoGeneticEntity.getGeneticEntityById(geneticEntityId);
+        String entityStableId = entity.getStableId();
+        String entityIdString = Integer.toString(geneticEntityId);
+        for (int i = 0; i < values.length; i++) {
+            String value = values[i];
+            gaDerivedLoader.insertRecord(sampleUniqueIds[i], patientUniqueIds[i], entityIdString,
+                value.isEmpty() ? "\\N" : value, genericAssayType, profileStableId, entityStableId,
+                datatype, patientLevel, profileType);
+            pendingGaRows++;
+        }
+        if (pendingGaRows >= DERIVED_FLUSH_THRESHOLD) {
+            gaDerivedLoader.flush();
+            pendingGaRows = 0;
+        }
+    }
+
     private void ensureNumberOfValuesIsCorrect(int valuesNumber) {
         if (valuesNumber != orderedSampleList.size()) {
             throw new IllegalArgumentException("There has to be " + orderedSampleList.size() + " values, but only " + valuesNumber+ " has passed.");
@@ -163,7 +245,9 @@ public class GeneticAlterationImporter {
     public void initialize() {
         try {
             storeOrderedSampleList();
-            if (noExplode) {
+            // Gene-based profiles set up the genetic_alteration_derived context now; generic assay
+            // sets up its own (generic_assay_data_derived) context lazily via isGenericAssayProfile().
+            if (noExplode && !isGenericAssayProfile()) {
                 initNoExplodeContext();
             }
         } catch (DaoException e) {
@@ -175,6 +259,10 @@ public class GeneticAlterationImporter {
         if (noExplode && derivedLoader != null) {
             derivedLoader.flush();
             pendingDerivedRows = 0;
+        }
+        if (noExplode && gaDerivedLoader != null) {
+            gaDerivedLoader.flush();
+            pendingGaRows = 0;
         }
     }
 }

--- a/src/test/java/org/mskcc/cbio/portal/integrationTest/incremental/TestIncrementalGenericAssayImporter.java
+++ b/src/test/java/org/mskcc/cbio/portal/integrationTest/incremental/TestIncrementalGenericAssayImporter.java
@@ -18,10 +18,16 @@
 package org.mskcc.cbio.portal.integrationTest.incremental;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.util.*;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.junit.Test;
+import org.mskcc.cbio.portal.dao.ClickHouseBulkLoader;
 import org.mskcc.cbio.portal.dao.DaoCancerStudy;
 import org.mskcc.cbio.portal.dao.DaoException;
 import org.mskcc.cbio.portal.dao.DaoGenePanel;
@@ -29,6 +35,7 @@ import org.mskcc.cbio.portal.dao.DaoGeneticAlteration;
 import org.mskcc.cbio.portal.dao.DaoGeneticEntity;
 import org.mskcc.cbio.portal.dao.DaoGeneticProfile;
 import org.mskcc.cbio.portal.dao.DaoSampleProfile;
+import org.mskcc.cbio.portal.dao.JdbcUtil;
 import org.mskcc.cbio.portal.model.GenePanel;
 import org.mskcc.cbio.portal.model.GeneticProfile;
 import org.mskcc.cbio.portal.scripts.ImportProfileData;
@@ -159,6 +166,75 @@ public class TestIncrementalGenericAssayImporter extends IntegrationTestBase {
         beforeResult = DaoGeneticAlteration.getInstance().getGeneticAlterationMapForEntityIds(ic50Profile.getGeneticProfileId(), null);
         Set<Integer> beforeEntityIds = geneStableIdsToEntityIds(beforeStableIds);
         assertPriorDataState(beforeResult, beforeEntityIds, beforeSampleIds);
+    }
+
+    /**
+     * In no-explode mode the real importer writes generic assay rows straight into
+     * generic_assay_data_derived (no packed values, no derive). Verify the derived rows, including
+     * the wider denormalized columns and that empty cells are kept as NULL (no NA filter).
+     */
+    @Test
+    public void testGenericAssayNoExplode() throws Exception {
+        // The seed's ic50 profile omits generic_assay_type (so it is correctly a packed-only
+        // profile, like GSVA). Import a fresh GA profile that sets generic_assay_type so the
+        // generic_assay_data_derived target applies, reusing the same entities and data file.
+        File srcDir = new File("src/test/resources/incremental/generic_assay/");
+        Path tmpDir = Files.createTempDirectory("bench_ga");
+        File dataCopy = new File(tmpDir.toFile(), "data_bench_ga.txt");
+        Files.copy(new File(srcDir, "data_treatment_ic50.txt").toPath(), dataCopy.toPath());
+        File metaFile = new File(tmpDir.toFile(), "meta_bench_ga.txt");
+        try (BufferedWriter w = new BufferedWriter(new FileWriter(metaFile))) {
+            w.write("cancer_study_identifier: study_tcga_pub\n");
+            w.write("genetic_alteration_type: GENERIC_ASSAY\n");
+            w.write("generic_assay_type: TREATMENT_RESPONSE\n");
+            w.write("datatype: LIMIT-VALUE\n");
+            w.write("stable_id: bench_ga_ic50\n");
+            w.write("profile_name: bench ga\n");
+            w.write("data_filename: data_bench_ga.txt\n");
+            w.write("show_profile_in_analysis_tab: true\n");
+            w.write("pivot_threshold_value: 0.1\n");
+            w.write("value_sort_order: ASC\n");
+            w.write("generic_entity_meta_properties: NAME,DESCRIPTION,URL\n");
+        }
+
+        ClickHouseBulkLoader.bulkLoadOn();
+        ClickHouseBulkLoader.noExplodeOn();
+        try {
+            new ImportProfileData(new String[] {
+                    "--loadMode", "bulkLoad",
+                    "--meta", metaFile.getAbsolutePath(),
+                    "--data", dataCopy.getAbsolutePath(),
+            }).run();
+        } finally {
+            ClickHouseBulkLoader.noExplodeOff();
+        }
+
+        String sample = "study_tcga_pub_TCGA-A1-A0SB-01";
+        assertEquals(">8", gaDerived("value", sample, "Erlotinib", "bench_ga_ic50"));
+        // every cell is kept (generic assay derive has no "!= NA" filter); the value column is
+        // non-nullable String, so an empty cell is stored as "" (NULL collapses to default), as it
+        // would be by the derive.
+        assertEquals("", gaDerived("value", sample, "Irinotecan", "bench_ga_ic50"));
+        // wider denormalized columns are populated
+        assertEquals("TREATMENT_RESPONSE", gaDerived("generic_assay_type", sample, "Erlotinib", "bench_ga_ic50"));
+        assertEquals("LIMIT-VALUE", gaDerived("datatype", sample, "Erlotinib", "bench_ga_ic50"));
+        assertNotNull(gaDerived("patient_unique_id", sample, "Erlotinib", "bench_ga_ic50"));
+    }
+
+    private String gaDerived(String column, String sampleUniqueId, String entityStableId, String profileType) throws Exception {
+        Connection con = null; PreparedStatement ps = null; ResultSet rs = null;
+        try {
+            con = JdbcUtil.getDbConnection(TestIncrementalGenericAssayImporter.class);
+            ps = con.prepareStatement("SELECT " + column + " FROM generic_assay_data_derived "
+                + "WHERE sample_unique_id = ? AND entity_stable_id = ? AND profile_type = ?");
+            ps.setString(1, sampleUniqueId);
+            ps.setString(2, entityStableId);
+            ps.setString(3, profileType);
+            rs = ps.executeQuery();
+            return rs.next() ? rs.getString(1) : null;
+        } finally {
+            JdbcUtil.closeAll(TestIncrementalGenericAssayImporter.class, con, ps, rs);
+        }
     }
 
 }

--- a/src/test/java/org/mskcc/cbio/portal/integrationTest/scripts/TestImportTabDelimData.java
+++ b/src/test/java/org/mskcc/cbio/portal/integrationTest/scripts/TestImportTabDelimData.java
@@ -47,9 +47,12 @@ import org.mskcc.cbio.portal.dao.DaoPatient;
 import org.mskcc.cbio.portal.dao.DaoSample;
 import org.mskcc.cbio.portal.dao.DaoSampleProfile;
 import org.mskcc.cbio.portal.dao.JdbcUtil;
+import java.io.BufferedWriter;
+import java.io.FileWriter;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.Statement;
 import org.mskcc.cbio.portal.model.CancerStudy;
 import org.mskcc.cbio.portal.model.CanonicalGene;
 import org.mskcc.cbio.portal.model.CopyNumberStatus;
@@ -576,5 +579,207 @@ public class TestImportTabDelimData extends IntegrationTestBase {
         } finally {
             JdbcUtil.closeAll(TestImportTabDelimData.class, con, ps, rs);
         }
+    }
+
+    /**
+     * Performance benchmark of the REAL importer: legacy (packed genetic_alteration + ARRAY JOIN
+     * derive) vs. no-explode (direct write to genetic_alteration_derived), on a synthetic large
+     * matrix loaded twice into the same testcontainers ClickHouse. Run explicitly, e.g.:
+     *   mvn test -Dtest=TestImportTabDelimData#benchmarkNoExplodeVsLegacy -Dbench.genes=8000 -Dbench.samples=1000
+     */
+    @Test
+    public void benchmarkNoExplodeVsLegacy() throws Exception {
+        // Performance benchmark (not a CI assertion). Run explicitly with -Dbench.run=true.
+        org.junit.Assume.assumeTrue("performance benchmark; run with -Dbench.run=true", Boolean.getBoolean("bench.run"));
+        final int nGenes = Integer.getInteger("bench.genes", 8000);
+        final int nSamples = Integer.getInteger("bench.samples", 1000);
+        ProgressMonitor.setConsoleMode(false);
+
+        // --- setup: samples + genes under study_tcga_pub ---
+        ClickHouseBulkLoader.bulkLoadOn();
+        ClickHouseBulkLoader.noExplodeOff();
+        DaoGeneOptimized daoGene = DaoGeneOptimized.getInstance();
+        String[] sampleStableIds = new String[nSamples];
+        for (int i = 0; i < nSamples; i++) {
+            String sid = String.format("BENCH-%05d", i);
+            sampleStableIds[i] = sid;
+            int pid = DaoPatient.addPatient(new Patient(study, sid));
+            DaoSample.addSample(new Sample(sid, pid, study.getTypeOfCancerId()));
+        }
+        for (int g = 0; g < nGenes; g++) {
+            daoGene.addGene(new CanonicalGene(800000000L + g, "BENCHGENE" + g));
+        }
+        ClickHouseBulkLoader.flushAll();
+
+        int legacyId = addBenchProfile("study_tcga_pub_benchlegacy");
+        int noExplodeId = addBenchProfile("study_tcga_pub_benchnoexplode");
+        File matrix = generateBenchMatrix(sampleStableIds, nGenes);
+        long cells = (long) nGenes * nSamples;
+
+        // --- LEGACY: real importer writes packed, then ARRAY JOIN derive ---
+        ClickHouseBulkLoader.bulkLoadOn();
+        ClickHouseBulkLoader.noExplodeOff();
+        long t0 = System.nanoTime();
+        new ImportTabDelimData(matrix, legacyId, null, false, DaoGeneOptimized.getInstance()).importData();
+        double secPacked = nanosToSec(System.nanoTime() - t0);
+        long t1 = System.nanoTime();
+        runDerive(legacyId);
+        double secDerive = nanosToSec(System.nanoTime() - t1);
+
+        // --- NO-EXPLODE: real importer writes genetic_alteration_derived directly ---
+        ClickHouseBulkLoader.bulkLoadOn();
+        ClickHouseBulkLoader.noExplodeOn();
+        long t2 = System.nanoTime();
+        try {
+            new ImportTabDelimData(matrix, noExplodeId, null, false, DaoGeneOptimized.getInstance()).importData();
+        } finally {
+            ClickHouseBulkLoader.noExplodeOff();
+        }
+        double secNoExplode = nanosToSec(System.nanoTime() - t2);
+
+        // --- correctness + sizes ---
+        String[] legacy = derivedStats("benchlegacy");
+        String[] noexp = derivedStats("benchnoexplode");
+        boolean match = legacy[0].equals(noexp[0]) && legacy[1].equals(noexp[1]);
+        long packedBytes = tableBytes("genetic_alteration");
+        long derivedBytes = tableBytes("genetic_alteration_derived");
+        long deriveMemMiB = deriveServerPeakMiB();
+
+        System.out.println("\nBENCH_RESULT ================================================");
+        System.out.printf("BENCH_RESULT study=ccle-like genes=%d samples=%d cells=%,d%n", nGenes, nSamples, cells);
+        System.out.printf("BENCH_RESULT legacy:     packed_import=%.2fs  derive=%.2fs  total=%.2fs%n",
+            secPacked, secDerive, secPacked + secDerive);
+        System.out.printf("BENCH_RESULT no_explode: direct_import=%.2fs  total=%.2fs%n", secNoExplode, secNoExplode);
+        System.out.printf("BENCH_RESULT derive_server_peak=%dMiB%n", deriveMemMiB);
+        System.out.printf("BENCH_RESULT storage: packed=%.1fMiB derived(all)=%.1fMiB%n",
+            packedBytes / 1048576.0, derivedBytes / 1048576.0);
+        System.out.printf("BENCH_RESULT correctness: legacy rows/chk=%s/%s  noexplode rows/chk=%s/%s  MATCH=%b%n",
+            legacy[0], legacy[1], noexp[0], noexp[1], match);
+        System.out.println("BENCH_RESULT ================================================\n");
+        assertTrue("no-explode output must match the derive", match);
+    }
+
+    private int addBenchProfile(String stableId) throws DaoException {
+        GeneticProfile gp = new GeneticProfile();
+        gp.setCancerStudyId(studyId);
+        gp.setStableId(stableId);
+        gp.setGeneticAlterationType(GeneticAlterationType.MRNA_EXPRESSION);
+        gp.setDatatype("CONTINUOUS");
+        gp.setProfileName(stableId);
+        DaoGeneticProfile.addGeneticProfile(gp);
+        return DaoGeneticProfile.getGeneticProfileByStableId(stableId).getGeneticProfileId();
+    }
+
+    private File generateBenchMatrix(String[] sampleStableIds, int nGenes) throws Exception {
+        File f = File.createTempFile("bench_matrix_", ".txt");
+        f.deleteOnExit();
+        try (BufferedWriter w = new BufferedWriter(new FileWriter(f), 1 << 20)) {
+            w.write("Hugo_Symbol");
+            for (String s : sampleStableIds) { w.write('\t'); w.write(s); }
+            w.write('\n');
+            for (int g = 0; g < nGenes; g++) {
+                w.write("BENCHGENE" + g);
+                for (int s = 0; s < sampleStableIds.length; s++) {
+                    w.write('\t');
+                    w.write(Integer.toString(((g * 7 + s * 3) % 5) - 2));
+                }
+                w.write('\n');
+            }
+        }
+        return f;
+    }
+
+    private void runDerive(int geneticProfileId) throws Exception {
+        // Mirrors clickhouse.sql genetic_alteration_derived build, scoped to one profile, joining
+        // base tables (no sample_derived) to compute sample_unique_id = <study>_<sample>.
+        String sql = """
+            INSERT INTO genetic_alteration_derived
+            SELECT concat(sub.csi, '_', s.stable_id) AS sample_unique_id,
+                   sub.csi AS cancer_study_identifier,
+                   sub.hugo AS hugo_gene_symbol,
+                   replaceOne(sub.stable_id, concat(sub.csi, '_'), '') AS profile_type,
+                   sub.av AS alteration_value
+            FROM (
+                SELECT hugo, stable_id, csi, av, isid
+                FROM (
+                    SELECT g.hugo_gene_symbol AS hugo, gp.stable_id AS stable_id,
+                           cs.cancer_study_identifier AS csi,
+                           arrayMap(x -> (x = '' ? NULL : x), splitByString(',', assumeNotNull(substring(ga.`values`, 1, -1)))) AS av,
+                           arrayMap(x -> toInt64(x), splitByString(',', assumeNotNull(substring(gps.ordered_sample_list, 1, -1)))) AS isid
+                    FROM genetic_alteration ga
+                    JOIN genetic_profile gp ON ga.genetic_profile_id = gp.genetic_profile_id
+                    JOIN cancer_study cs ON gp.cancer_study_id = cs.cancer_study_id
+                    JOIN gene g ON ga.genetic_entity_id = g.genetic_entity_id
+                    JOIN genetic_profile_samples gps ON gps.genetic_profile_id = gp.genetic_profile_id
+                    WHERE gp.genetic_profile_id = %d
+                ) ARRAY JOIN av, isid
+                WHERE av != 'NA'
+            ) AS sub
+            JOIN sample s ON s.internal_id = sub.isid
+            SETTINGS log_comment = 'bench_derive'
+            """.formatted(geneticProfileId);
+        Connection con = null; PreparedStatement st = null;
+        try {
+            con = JdbcUtil.getDbConnection(TestImportTabDelimData.class);
+            st = con.prepareStatement(sql);
+            st.execute();
+        } finally {
+            JdbcUtil.closeAll(TestImportTabDelimData.class, con, st, null);
+        }
+    }
+
+    private String[] derivedStats(String profileType) throws Exception {
+        Connection con = null; PreparedStatement ps = null; ResultSet rs = null;
+        try {
+            con = JdbcUtil.getDbConnection(TestImportTabDelimData.class);
+            ps = con.prepareStatement("SELECT count(), sum(cityHash64(sample_unique_id, hugo_gene_symbol, "
+                + "ifNull(alteration_value,'N'))) FROM genetic_alteration_derived WHERE profile_type = ?");
+            ps.setString(1, profileType);
+            rs = ps.executeQuery();
+            rs.next();
+            return new String[]{rs.getString(1), rs.getString(2)};
+        } finally {
+            JdbcUtil.closeAll(TestImportTabDelimData.class, con, ps, rs);
+        }
+    }
+
+    private long tableBytes(String table) throws Exception {
+        Connection con = null; PreparedStatement opt = null; PreparedStatement sel = null; ResultSet rs = null;
+        try {
+            con = JdbcUtil.getDbConnection(TestImportTabDelimData.class);
+            opt = con.prepareStatement("OPTIMIZE TABLE " + table + " FINAL");
+            opt.execute();
+            opt.close();
+            sel = con.prepareStatement("SELECT sum(bytes_on_disk) FROM system.parts WHERE active AND table = ?");
+            sel.setString(1, table);
+            rs = sel.executeQuery();
+            return rs.next() ? rs.getLong(1) : -1;
+        } catch (Exception e) {
+            return -1;
+        } finally {
+            JdbcUtil.closeAll(TestImportTabDelimData.class, con, sel, rs);
+        }
+    }
+
+    private long deriveServerPeakMiB() {
+        Connection con = null; PreparedStatement flush = null; PreparedStatement sel = null; ResultSet rs = null;
+        try {
+            con = JdbcUtil.getDbConnection(TestImportTabDelimData.class);
+            flush = con.prepareStatement("SYSTEM FLUSH LOGS");
+            flush.execute();
+            flush.close();
+            sel = con.prepareStatement("SELECT max(memory_usage) FROM system.query_log "
+                + "WHERE log_comment = 'bench_derive' AND type = 'QueryFinish'");
+            rs = sel.executeQuery();
+            return rs.next() ? rs.getLong(1) / 1048576 : -1;
+        } catch (Exception e) {
+            return -1;
+        } finally {
+            JdbcUtil.closeAll(TestImportTabDelimData.class, con, sel, rs);
+        }
+    }
+
+    private static double nanosToSec(long nanos) {
+        return nanos / 1_000_000_000.0;
     }
 }

--- a/src/test/java/org/mskcc/cbio/portal/integrationTest/scripts/TestImportTabDelimData.java
+++ b/src/test/java/org/mskcc/cbio/portal/integrationTest/scripts/TestImportTabDelimData.java
@@ -46,6 +46,10 @@ import org.mskcc.cbio.portal.dao.DaoGeneticProfile;
 import org.mskcc.cbio.portal.dao.DaoPatient;
 import org.mskcc.cbio.portal.dao.DaoSample;
 import org.mskcc.cbio.portal.dao.DaoSampleProfile;
+import org.mskcc.cbio.portal.dao.JdbcUtil;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import org.mskcc.cbio.portal.model.CancerStudy;
 import org.mskcc.cbio.portal.model.CanonicalGene;
 import org.mskcc.cbio.portal.model.CopyNumberStatus;
@@ -503,5 +507,74 @@ public class TestImportTabDelimData extends IntegrationTestBase {
             DaoSample.addSample(new Sample(sampleId, pId, study.getTypeOfCancerId()));
         }
         ClickHouseBulkLoader.flushAll();
+    }
+
+    /**
+     * In no-explode mode the real importer writes exploded rows straight into
+     * genetic_alteration_derived (no packed `values`, no ARRAY JOIN derive). Verify the
+     * derived rows match the input matrix and that the packed table stays empty.
+     */
+    @Test
+    public void testImportCnaDataNoExplode() throws Exception {
+        ClickHouseBulkLoader.bulkLoadOn();
+        ClickHouseBulkLoader.noExplodeOn();
+        try {
+            DaoGeneOptimized daoGene = DaoGeneOptimized.getInstance();
+            daoGene.addGene(new CanonicalGene(999999207, "TESTAKT1"));
+            daoGene.addGene(new CanonicalGene(999999208, "TESTAKT2"));
+            daoGene.addGene(new CanonicalGene(999910000, "TESTAKT3"));
+            daoGene.addGene(new CanonicalGene(999999369, "TESTARAF"));
+            daoGene.addGene(new CanonicalGene(999999472, "TESTATM"));
+            daoGene.addGene(new CanonicalGene(999999673, "TESTBRAF"));
+            daoGene.addGene(new CanonicalGene(999999672, "TESTBRCA1"));
+            daoGene.addGene(new CanonicalGene(999999675, "TESTBRCA2"));
+
+            ProgressMonitor.setConsoleMode(false);
+            File file = new File("src/test/resources/cna_test.txt");
+            ImportTabDelimData parser = new ImportTabDelimData(file, "Barry", geneticProfileId, null, false, DaoGeneOptimized.getInstance());
+            parser.importData();
+
+            // derived rows: sample_unique_id = <study>_<sample>, profile_type = stableId minus study prefix ("test")
+            String p = "study_tcga_pub_";
+            assertEquals("0",  derivedValue(p + "TCGA-A1-A0SB-01", "TESTAKT1", "test"));
+            assertEquals("-1", derivedValue(p + "TCGA-A1-A0SF-01", "TESTAKT1", "test"));
+            assertEquals("0",  derivedValue(p + "TCGA-A1-A0SD-01", "TESTAKT1", "test"));
+            assertEquals("2",  derivedValue(p + "TCGA-A1-A0SD-01", "TESTAKT3", "test"));
+            assertEquals("2",  derivedValue(p + "TCGA-A1-A0SE-01", "TESTAKT3", "test"));
+
+            // packed genetic_alteration must stay empty for this profile in no-explode mode
+            assertEquals(0, packedRowCount(geneticProfileId));
+        } finally {
+            ClickHouseBulkLoader.noExplodeOff();
+        }
+    }
+
+    private String derivedValue(String sampleUniqueId, String hugo, String profileType) throws Exception {
+        Connection con = null; PreparedStatement ps = null; ResultSet rs = null;
+        try {
+            con = JdbcUtil.getDbConnection(TestImportTabDelimData.class);
+            ps = con.prepareStatement("SELECT alteration_value FROM genetic_alteration_derived "
+                + "WHERE sample_unique_id = ? AND hugo_gene_symbol = ? AND profile_type = ?");
+            ps.setString(1, sampleUniqueId);
+            ps.setString(2, hugo);
+            ps.setString(3, profileType);
+            rs = ps.executeQuery();
+            return rs.next() ? rs.getString(1) : null;
+        } finally {
+            JdbcUtil.closeAll(TestImportTabDelimData.class, con, ps, rs);
+        }
+    }
+
+    private int packedRowCount(int geneticProfileId) throws Exception {
+        Connection con = null; PreparedStatement ps = null; ResultSet rs = null;
+        try {
+            con = JdbcUtil.getDbConnection(TestImportTabDelimData.class);
+            ps = con.prepareStatement("SELECT count() FROM genetic_alteration WHERE genetic_profile_id = ?");
+            ps.setInt(1, geneticProfileId);
+            rs = ps.executeQuery();
+            return rs.next() ? rs.getInt(1) : -1;
+        } finally {
+            JdbcUtil.closeAll(TestImportTabDelimData.class, con, ps, rs);
+        }
     }
 }


### PR DESCRIPTION
## What

Adds an **optional** import mode that writes gene×sample matrix profiles (CNA, expression, …) directly into the exploded `genetic_alteration_derived` table at import time, instead of:
1. storing the packed comma-joined `values` string in `genetic_alteration`, and
2. rebuilding `genetic_alteration_derived` afterwards with the server-side `ARRAY JOIN` derive (which is fully rebuilt from scratch on every import).

Disabled by default — existing behavior is unchanged.

## Why

The packed + `ARRAY JOIN` derive has two costs that grow with the corpus: a multi-GiB memory spike during the explode, and re-deriving **all** studies on **every** import. Writing exploded rows at import time bounds memory, makes the work per-study, and drops the redundant packed copy. (In separate benchmarking the directly-written rows were byte-identical to the derive output.)

## How it works

- **`ClickHouseBulkLoader`**: new `noExplode` flag (from system property `cbioportal.importer.no_explode` or env `CBIOPORTAL_IMPORTER_NO_EXPLODE`), plus a public per-loader `flush()` / `pendingSize()` so large matrices flush in chunks instead of buffering an entire batch in one `byte[]`.
- **`GeneticAlterationImporter`**: in no-explode mode resolves the per-profile context once — `cancer_study_identifier`, `profile_type` (stable id minus the study prefix), and the per-column `sample_unique_id` (`<study>_<sample>`) — exactly the values the SQL derive recovers via joins. It then emits one derived row per cell, **mirroring the derive's filtering precisely**: a cell is dropped when its value is `NA` or empty (the derive maps `'' → NULL` then filters with `!= 'NA'`, which also excludes the NULLs). The packed write is skipped.

## Enabling

Set `CBIOPORTAL_IMPORTER_NO_EXPLODE=true` and run `metaImport.py --no-derive-tables` so the SQL derive does not clobber the directly-written rows. (The `genetic_alteration_derived` table must already exist.)

## Validation

New integration test runs the **real importer** in no-explode mode against a testcontainers ClickHouse and asserts the derived rows match the input matrix and that the packed table stays empty. Passes.

## Scope / follow-ups

- Covers **gene-based** matrices (CNA/expression). Generic-assay (entity-based) data keeps the packed path and its own derive.
- The export path that reads packed `genetic_alteration.values` would need a pivot-back for no-explode profiles.
- A `metaImport.py --no-explode` convenience flag and a large-scale performance benchmark with the real importer are natural follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)