### PR TITLE
fix delete race condition bug

### DIFF
--- a/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseBulkDeleter.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseBulkDeleter.java
@@ -70,11 +70,11 @@ public class ClickHouseBulkDeleter {
     private ClickHouseBulkDeleter(String targetTable, String idColumn) {
         this.targetTable = targetTable;
         this.idColumn = idColumn;
-        this.stagingTable = "staging_delete_" + targetTable;
+        this.stagingTable = String.format("staging_delete_%s", targetTable);
     }
 
     public static ClickHouseBulkDeleter getBulkDeleter(String targetTable, String idColumn) {
-        String key = targetTable + ":" + idColumn;
+        String key = String.format("%s:%s", targetTable, idColumn);
         return BULK_DELETERS.computeIfAbsent(key, k -> new ClickHouseBulkDeleter(targetTable, idColumn));
     }
 
@@ -88,8 +88,8 @@ public class ClickHouseBulkDeleter {
         }
     }
 
-    public static int flushAll() throws DaoException {
-        int totalDeleted = 0;
+    public static long flushAll() throws DaoException {
+        long totalDeleted = 0;
         try {
             dropAnyExistingStagingTables(false); // drop any leftover tables from previous crash/failure
             createAllStagingTables();
@@ -101,7 +101,8 @@ public class ClickHouseBulkDeleter {
             try {
                 dropAnyExistingStagingTables(true);
             } catch (SQLException se) {
-                // exceptions will be ignored during second call to dropAnyExistingStagingTables
+                // will not happen because SQLExceptions will be suppressed during second call
+                // to dropAnyExistingStagingTables (leftover tables will be tolerated)
             }
             clearAllDeleters();
         }
@@ -152,7 +153,10 @@ public class ClickHouseBulkDeleter {
         //     running in a Clickhouse cluster (such as with clickhouse.cloud). This may avoid retry cycles.
         for (ClickHouseBulkDeleter deleter : BULK_DELETERS.values()) {
             if (! deleter.allReplicasReachedRecordCount()) {
-                throw new DaoException("Failed to see all replicas reflect delete list inserted into table " + deleter.stagingTable);
+                String exceptionMsgString = String.format(
+                        "Failed to see all replicas reflect delete list inserted into table %s",
+                        deleter.stagingTable);
+                throw new DaoException(exceptionMsgString);
             }
         }
     }
@@ -180,7 +184,6 @@ public class ClickHouseBulkDeleter {
         int WAIT_CYCLE_PERIOD_SECONDS = 10;
         int WAIT_CYCLE_TOLERATE_EXCEPTION_LIMIT = 6;
         int exceptions_ignored = 0;
-        log.warn(String.format("beginning on wait for table %s", stagingTable));
         for (int cycle = 0 ; cycle < WAIT_CYCLE_MAX_COUNT ; cycle = cycle + 1) {
             String getRecordCountsString = String.format(
                     "SELECT hostname() as host, COUNT() as record_count FROM clusterAllReplicas('default', current_database(), %s) GROUP BY host",
@@ -190,9 +193,13 @@ public class ClickHouseBulkDeleter {
                     ResultSet rs = pstmt.executeQuery()) {
                 boolean recordCountWasReached = true;
                 while (rs.next()) {
-                    int recordCountOnReplica = rs.getInt("record_count");
-                    log.warn(String.format("waiting to reach record count : expected %d saw %d", recordCountOnReplica, pendingIds.size()));
+                    long recordCountOnReplica = rs.getInt("record_count");
                     if (recordCountOnReplica != pendingIds.size()) {
+                        log.warn(String.format(
+                                "waiting to reach record count in table %s : expected %d saw %d",
+                                stagingTable,
+                                pendingIds.size(),
+                                recordCountOnReplica));
                         recordCountWasReached = false;
                         break;
                     }
@@ -215,16 +222,16 @@ public class ClickHouseBulkDeleter {
         return false;
     }
 
-    private static int deleteRecordsReferencedInStagingTables() throws SQLException {
-        int totalDeleted = 0;
+    private static long deleteRecordsReferencedInStagingTables() throws SQLException {
+        long totalDeleted = 0;
         for (ClickHouseBulkDeleter deleter : BULK_DELETERS.values()) {
             totalDeleted += deleter.deleteRecordsReferencedInStagingTable();
         }
         return totalDeleted;
     }
 
-    private int deleteRecordsReferencedInStagingTable() throws SQLException {
-        int records_deleted;
+    private long deleteRecordsReferencedInStagingTable() throws SQLException {
+        long records_deleted;
         String statementString = String.format(
                 "DELETE FROM %s WHERE %s IN (SELECT id FROM %s)",
                 targetTable, idColumn, stagingTable);
@@ -237,16 +244,65 @@ public class ClickHouseBulkDeleter {
         return records_deleted;
     }
 
-    private static void dropAnyExistingStagingTables(boolean ignoreExceptions) throws SQLException {
+    private boolean allReplicasCompletedDeletion() throws SQLException {
+        int WAIT_CYCLE_MAX_COUNT = 60;
+        int WAIT_CYCLE_PERIOD_SECONDS = 10;
+        int WAIT_CYCLE_TOLERATE_EXCEPTION_LIMIT = 6;
+        int exceptions_ignored = 0;
+        for (int cycle = 0 ; cycle < WAIT_CYCLE_MAX_COUNT ; cycle = cycle + 1) {
+            String getUndeletedRecordCountsString = String.format(
+                    "SELECT hostname() as host, COUNT() as record_count FROM clusterAllReplicas('default', current_database(), %s) WHERE %s IN (SELECT id from %s) GROUP BY host",
+                    targetTable, idColumn, stagingTable);
+            Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
+            try (PreparedStatement pstmt = con.prepareStatement(getUndeletedRecordCountsString);
+                    ResultSet rs = pstmt.executeQuery()) {
+                boolean allRecordsWereDeleted = true;
+                while (rs.next()) {
+                    long undeletedRecordCountOnReplica = rs.getInt("record_count");
+                    if (undeletedRecordCountOnReplica != 0) {
+                        allRecordsWereDeleted = false;
+                        break;
+                    }
+                }
+                if (allRecordsWereDeleted) {
+                    return true;
+                }
+                Thread.sleep(1000 * WAIT_CYCLE_PERIOD_SECONDS);
+            } catch (SQLException e) {
+                if (exceptions_ignored >= WAIT_CYCLE_TOLERATE_EXCEPTION_LIMIT) {
+                    log.error("Over the limit of exceptions in allreplicasCompletedDeletion() .. re-throwing " + e.getMessage());
+                    throw e;
+                }
+                exceptions_ignored = exceptions_ignored + 1;
+            } catch (InterruptedException ie) {
+                // ignore : ok to go on to next cycle immediately
+            } finally {
+                JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
+            }
+        }
+        return false;
+    }
+    private static void dropAnyExistingStagingTables(boolean deletionHasBeenExecuted) throws SQLException, DaoException {
         for (ClickHouseBulkDeleter deleter : BULK_DELETERS.values()) {
+            // wait until all ids in the stagingTable table have been fully deleted from the target table
+            if (deletionHasBeenExecuted && ! deleter.allReplicasCompletedDeletion()) {
+                String exceptionMessageString = String.format(
+                        "Failed to complete the delete operation on all replicas for table %s",
+                        deleter.stagingTable);
+                throw new DaoException(exceptionMessageString);
+            }
             String dropStatementString = String.format(
-                "DROP TABLE IF EXISTS %s",
-                deleter.stagingTable);
+                    "DROP TABLE IF EXISTS %s",
+                    deleter.stagingTable);
             Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
             try (PreparedStatement stmt = con.prepareStatement(dropStatementString)) {
                 stmt.executeUpdate();
             } catch (SQLException e) {
-                if (! ignoreExceptions) {
+                if (! deletionHasBeenExecuted) {
+                    // it is fatal to fail to DROP any old staging tables during the first call
+                    // (during setup for deletion), because then the CREATE for staging will fail.
+                    // on the second call, so long as the deletion completed, it is "ok" to leave behind
+                    // residual staging tables -- they will (hopefully) DROP during the next update run
                     throw e;
                 }
             } finally {

--- a/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseBulkDeleter.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseBulkDeleter.java
@@ -45,6 +45,8 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Bulk deleter that buffers IDs in memory, streams them into a ClickHouse staging
@@ -62,6 +64,8 @@ public class ClickHouseBulkDeleter {
     private final String idColumn;
     private final String stagingTable;
     private final Set<Long> pendingIds = new HashSet<>();
+
+    private static final Logger log = LoggerFactory.getLogger(ClickHouseBulkDeleter.class);
 
     private ClickHouseBulkDeleter(String targetTable, String idColumn) {
         this.targetTable = targetTable;
@@ -86,21 +90,16 @@ public class ClickHouseBulkDeleter {
 
     public static int flushAll() throws DaoException {
         int totalDeleted = 0;
-        Connection con = null;
         try {
-            con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
-            dropAnyExistingStagingTables(con, false); // drop any leftover tables from previous crash/failure
-            createAllStagingTables(con);
-            populateAllStagingTables(con);
-            totalDeleted = deleteRecordsReferencedInStagingTables(con);
+            dropAnyExistingStagingTables(false); // drop any leftover tables from previous crash/failure
+            createAllStagingTables();
+            populateAllStagingTables();
+            totalDeleted = deleteRecordsReferencedInStagingTables();
         } catch (SQLException | IOException e) {
             throw new DaoException(e);
         } finally {
             try {
-                if (con != null) {
-                    dropAnyExistingStagingTables(con, true);
-                    JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
-                }
+                dropAnyExistingStagingTables(true);
             } catch (SQLException se) {
                 // exceptions will be ignored during second call to dropAnyExistingStagingTables
             }
@@ -116,29 +115,35 @@ public class ClickHouseBulkDeleter {
         BULK_DELETERS.clear();
     }
 
-    private static void createAllStagingTables(Connection con) throws SQLException {
+    private static void createAllStagingTables() throws SQLException {
         for (ClickHouseBulkDeleter deleter : BULK_DELETERS.values()) {
+            Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
             String createTableStatementString = String.format(
                     "CREATE TABLE %s (id Int64) ENGINE = MergeTree() ORDER BY id",
                     deleter.stagingTable);
             try (PreparedStatement stmt = con.prepareStatement(createTableStatementString)) {
                 stmt.executeUpdate();
+            } finally {
+                JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
             }
         }
         // wait for table existence to propagate to replicas (if they exist)
         for (ClickHouseBulkDeleter deleter : BULK_DELETERS.values()) {
+            Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
             String alterTableStatementString = String.format(
                     "ALTER TABLE %s MODIFY COMMENT 'Transient' SETTINGS mutations_sync = 3",
                     deleter.stagingTable);
             try (PreparedStatement stmt = con.prepareStatement(alterTableStatementString)) {
                 stmt.executeUpdate();
+            } finally {
+                JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
             }
         }
     }
 
-    private static void populateAllStagingTables(Connection con) throws SQLException, DaoException, IOException {
+    private static void populateAllStagingTables() throws SQLException, DaoException, IOException {
         for (ClickHouseBulkDeleter deleter : BULK_DELETERS.values()) {
-            deleter.populateStagingTable(con);
+            deleter.populateStagingTable();
         }
         // wait for inserts to be recognized by all replicas
         // note: this is intentionally done in a second loop in the hope that while values are being inserted
@@ -146,13 +151,13 @@ public class ClickHouseBulkDeleter {
         //     inserted into the first table to be recognized / become visible in the other replica nodes
         //     running in a Clickhouse cluster (such as with clickhouse.cloud). This may avoid retry cycles.
         for (ClickHouseBulkDeleter deleter : BULK_DELETERS.values()) {
-            if (! deleter.allReplicasReachedRecordCount(con)) {
+            if (! deleter.allReplicasReachedRecordCount()) {
                 throw new DaoException("Failed to see all replicas reflect delete list inserted into table " + deleter.stagingTable);
             }
         }
     }
 
-    private void populateStagingTable(Connection con) throws SQLException, IOException {
+    private void populateStagingTable() throws SQLException, IOException {
         if (pendingIds.isEmpty()) {
             return;
         }
@@ -161,26 +166,32 @@ public class ClickHouseBulkDeleter {
         String insertStatementString = String.format(
                 "INSERT INTO %s (id) FORMAT TSVWithNames",
                 stagingTable);
+        Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
         try (PreparedStatement stmt = con.prepareStatement(insertStatementString)) {
             stmt.setBinaryStream(1, new ByteArrayInputStream(payload));
             stmt.executeUpdate();
+        } finally {
+            JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
         }
     }
 
-    private boolean allReplicasReachedRecordCount(Connection con) throws SQLException {
+    private boolean allReplicasReachedRecordCount() throws SQLException {
         int WAIT_CYCLE_MAX_COUNT = 60;
         int WAIT_CYCLE_PERIOD_SECONDS = 10;
         int WAIT_CYCLE_TOLERATE_EXCEPTION_LIMIT = 6;
         int exceptions_ignored = 0;
+        log.warn(String.format("beginning on wait for table %s", stagingTable));
         for (int cycle = 0 ; cycle < WAIT_CYCLE_MAX_COUNT ; cycle = cycle + 1) {
             String getRecordCountsString = String.format(
-                    "SELECT COUNT() as record_count FROM clusterAllReplicas('default', current_database(), %s)",
+                    "SELECT hostname() as host, COUNT() as record_count FROM clusterAllReplicas('default', current_database(), %s) GROUP BY host",
                     stagingTable);
+            Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
             try (PreparedStatement pstmt = con.prepareStatement(getRecordCountsString);
                     ResultSet rs = pstmt.executeQuery()) {
                 boolean recordCountWasReached = true;
                 while (rs.next()) {
                     int recordCountOnReplica = rs.getInt("record_count");
+                    log.warn(String.format("waiting to reach record count : expected %d saw %d", recordCountOnReplica, pendingIds.size()));
                     if (recordCountOnReplica != pendingIds.size()) {
                         recordCountWasReached = false;
                         break;
@@ -197,41 +208,49 @@ public class ClickHouseBulkDeleter {
                 exceptions_ignored = exceptions_ignored + 1;
             } catch (InterruptedException ie) {
                 // ignore : ok to go on to next cycle immediately
+            } finally {
+                JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
             }
         }
         return false;
     }
 
-    private static int deleteRecordsReferencedInStagingTables(Connection con) throws SQLException {
+    private static int deleteRecordsReferencedInStagingTables() throws SQLException {
         int totalDeleted = 0;
         for (ClickHouseBulkDeleter deleter : BULK_DELETERS.values()) {
-            totalDeleted += deleter.deleteRecordsReferencedInStagingTable(con);
+            totalDeleted += deleter.deleteRecordsReferencedInStagingTable();
         }
         return totalDeleted;
     }
 
-    private int deleteRecordsReferencedInStagingTable(Connection con) throws SQLException {
+    private int deleteRecordsReferencedInStagingTable() throws SQLException {
         int records_deleted;
         String statementString = String.format(
                 "DELETE FROM %s WHERE %s IN (SELECT id FROM %s)",
                 targetTable, idColumn, stagingTable);
+        Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
         try (PreparedStatement stmt = con.prepareStatement(statementString)) {
             records_deleted = stmt.executeUpdate();
+        } finally {
+            JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
         }
         return records_deleted;
     }
 
-    private static void dropAnyExistingStagingTables(Connection con, boolean ignoreExceptions) throws SQLException {
+    private static void dropAnyExistingStagingTables(boolean ignoreExceptions) throws SQLException {
         for (ClickHouseBulkDeleter deleter : BULK_DELETERS.values()) {
             String dropStatementString = String.format(
                 "DROP TABLE IF EXISTS %s",
                 deleter.stagingTable);
+            Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
             try (PreparedStatement stmt = con.prepareStatement(dropStatementString)) {
                 stmt.executeUpdate();
             } catch (SQLException e) {
                 if (! ignoreExceptions) {
                     throw e;
                 }
+            } finally {
+                JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
             }
         }
     }

--- a/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseBulkDeleter.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseBulkDeleter.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.mskcc.cbio.portal.util.GlobalProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,14 +62,48 @@ import org.slf4j.LoggerFactory;
  */
 public class ClickHouseBulkDeleter {
 
-    private static final Map<String, ClickHouseBulkDeleter> BULK_DELETERS = new LinkedHashMap<>();
-    private static final Logger log = LoggerFactory.getLogger(ClickHouseBulkDeleter.class);
-
-    private final String targetTable;
+    private boolean flushed; // once flushed, any particular deleter instance cannot not be flushed again
+    private final Set<Long> pendingIds = new HashSet<>();
     private final String idColumn;
     private final String stagingTable;
-    private final Set<Long> pendingIds = new HashSet<>();
-    private boolean flushed; // once flushed, any particular deleter instance cannot not be flushed again
+    private final String targetTable;
+
+    private static final Logger log = LoggerFactory.getLogger(ClickHouseBulkDeleter.class);
+    private static final Map<String, ClickHouseBulkDeleter> BULK_DELETERS = new LinkedHashMap<>();
+
+    private static final Integer DEFAULT_CREATE_STAGING_TABLE_MAX_RETRY_SECONDS = 2 * 60;
+    private static final Integer DEFAULT_POPULATE_STAGING_TABLE_MAX_RETRY_SECONDS = 3 * 60;
+    private static final Integer DEFAULT_CONFIRM_DELETE_DATA_MAX_RETRY_SECONDS = 7 * 60;
+    private static final Integer DEFAULT_CONFIRM_DELETE_METADATA_MAX_RETRY_SECONDS = 2 * 60;
+    private static final Integer DEFAULT_RETRY_CYCLE_PERIOD_SECONDS = 10;
+    private static final Integer DEFAULT_RETRY_CYCLE_MAX_EXCEPTION_COUNT = 6;
+    private static final Integer CREATE_STAGING_TABLE_MAX_RETRY_SECONDS;
+    private static final Integer POPULATE_STAGING_TABLE_MAX_RETRY_SECONDS;
+    private static final Integer CONFIRM_DELETE_DATA_MAX_RETRY_SECONDS;
+    private static final Integer CONFIRM_DELETE_METADATA_MAX_RETRY_SECONDS;
+    private static final Integer RETRY_CYCLE_PERIOD_SECONDS;
+    private static final Integer RETRY_CYCLE_MAX_EXCEPTION_COUNT;
+
+    static {
+        CREATE_STAGING_TABLE_MAX_RETRY_SECONDS = GlobalProperties.parseIntegerProperty(
+                "bulkdeleter.create_staging_table.max_retry_seconds",
+                DEFAULT_CREATE_STAGING_TABLE_MAX_RETRY_SECONDS);
+        POPULATE_STAGING_TABLE_MAX_RETRY_SECONDS = GlobalProperties.parseIntegerProperty(
+                "bulkdeleter.populate_staging_table.max_retry_seconds",
+                DEFAULT_POPULATE_STAGING_TABLE_MAX_RETRY_SECONDS);
+        CONFIRM_DELETE_DATA_MAX_RETRY_SECONDS = GlobalProperties.parseIntegerProperty(
+                "bulkdeleter.confirm_delete_data.max_retry_seconds",
+                DEFAULT_CONFIRM_DELETE_DATA_MAX_RETRY_SECONDS);
+        CONFIRM_DELETE_METADATA_MAX_RETRY_SECONDS = GlobalProperties.parseIntegerProperty(
+                "bulkdeleter.confirm_delete_metadata.max_retry_seconds",
+                DEFAULT_CONFIRM_DELETE_METADATA_MAX_RETRY_SECONDS);
+        RETRY_CYCLE_PERIOD_SECONDS = GlobalProperties.parseIntegerProperty(
+                "bulkdeleter.retry_cycle_period_seconds",
+                DEFAULT_RETRY_CYCLE_PERIOD_SECONDS);
+        RETRY_CYCLE_MAX_EXCEPTION_COUNT = GlobalProperties.parseIntegerProperty(
+                "bulkdeleter.retry_cycle_max_exception_count",
+                DEFAULT_RETRY_CYCLE_MAX_EXCEPTION_COUNT);
+    }
 
     public enum AllReplicaTestType {
         CONSISTENT,
@@ -339,8 +374,7 @@ public class ClickHouseBulkDeleter {
 // methods which are complete confirmations of database alterations (on failure these throw DaoExcpetion)
 
     private void confirmCreationOfStagingTable() throws DaoException {
-        final int MAX_RETRY_SECONDS = 600;
-        if (! this.conditionIsTrueAfterQueryWithRetry(this::allReplicasReportStagingTableExists, MAX_RETRY_SECONDS)) {
+        if (! this.conditionIsTrueAfterQueryWithRetry(this::allReplicasReportStagingTableExists, CREATE_STAGING_TABLE_MAX_RETRY_SECONDS)) {
             String exceptionMsgString = String.format(
                     "Failed to see all replicas report existence of staging table %s after creation",
                     this.stagingTable);
@@ -349,8 +383,7 @@ public class ClickHouseBulkDeleter {
     }
 
     private void confirmPopulationOfStagingTable() throws DaoException {
-        final int MAX_RETRY_SECONDS = 600;
-        if (! this.conditionIsTrueAfterQueryWithRetry(this::allReplicasReportExpectedStagingTableRecordCount, MAX_RETRY_SECONDS)) {
+        if (! this.conditionIsTrueAfterQueryWithRetry(this::allReplicasReportExpectedStagingTableRecordCount, POPULATE_STAGING_TABLE_MAX_RETRY_SECONDS)) {
             String exceptionMsgString = String.format(
                     "Failed to see all replicas reflect delete list inserted into table %s",
                     this.stagingTable);
@@ -364,25 +397,23 @@ public class ClickHouseBulkDeleter {
     }
 
     private void confirmDeletionIsCompleteInData() throws DaoException {
-        final int MAX_RETRY_SECONDS = 600;
-        if (!this.conditionIsTrueAfterQueryWithRetry(this::deletionIsComplete, MAX_RETRY_SECONDS)) {
+        if (!this.conditionIsTrueAfterQueryWithRetry(this::deletionIsComplete, DEFAULT_CONFIRM_DELETE_DATA_MAX_RETRY_SECONDS)) {
             String exceptionMessageString = String.format(
                     "Failed to complete the delete operation on all replicas for table %s after retrying for %d seconds",
                     this.targetTable,
-                    MAX_RETRY_SECONDS);
+                    DEFAULT_CONFIRM_DELETE_DATA_MAX_RETRY_SECONDS);
             throw new DaoException(exceptionMessageString);
         }
         // TODO: if condition fails a few times, we might start checking whether any
-        // mutations are still in progress -- if not, stop waiting and fail before MAX_RETRY_SECONDS
+        // mutations are still in progress -- if not, stop waiting and fail early
     }
 
     private void confirmDeletionIsCompleteInMetadata() throws DaoException {
-        final int MAX_RETRY_SECONDS = 65;
-        if (!this.conditionIsTrueAfterQueryWithRetry(this::allReplicasReportSameMetadataForTargetTable, MAX_RETRY_SECONDS)) {
+        if (!this.conditionIsTrueAfterQueryWithRetry(this::allReplicasReportSameMetadataForTargetTable, CONFIRM_DELETE_METADATA_MAX_RETRY_SECONDS)) {
             String exceptionMessageString = String.format(
                     "Metadata for table %s could not be confirmed to have propagated across all cluster replica nodes after retrying for %d seconds",
                     this.targetTable,
-                    MAX_RETRY_SECONDS);
+                    CONFIRM_DELETE_METADATA_MAX_RETRY_SECONDS);
             throw new DaoException(exceptionMessageString);
         }
     }
@@ -391,33 +422,44 @@ public class ClickHouseBulkDeleter {
 
     private boolean allReplicasReportStagingTableExists() throws SQLException, DaoException {
         String getTableExistsString = String.format(
-                "SELECT hostname() as host, count() as table_exists FROM clusterAllReplicas('default', 'system', 'tables') where database = current_database() and name = '%s' GROUP BY host",
+                "SELECT hostname() AS host, count() AS table_exists FROM clusterAllReplicas('default', 'system', 'tables') WHERE database = current_database() AND name = '%s' GROUP BY host",
                 stagingTable);
         return allReplicasReportExpectedResult(getTableExistsString, "table_exists", AllReplicaTestType.EXPECTED_VALUE, AllReplicaCriterionType.LONG, 1L);
     }
 
     private boolean allReplicasReportExpectedStagingTableRecordCount() throws SQLException, DaoException {
+        String queryPart1 = "SELECT host, sum(record_count) AS total_rows FROM ((";
+        String queryPart2 = "SELECT hostname() AS host, rows AS record_count FROM clusterAllReplicas('default', 'system', 'parts')";
+        String queryPart3 = "WHERE database = current_database() AND table = ";
+        String queryPart4 = ") union all (";
+        // This union insures that at least one part with one record is included in the query result before aggregation. In this way, every host will be present in the results
+        String queryPart5 = "SELECT hostname() AS host, 0 AS record_count FROM clusterAllReplicas('default', 'system', 'one')";
+        String queryPart6 = ")) GROUP BY host";
         String getRecordCountsString = String.format(
-                "SELECT hostname() as host, total_rows as total_rows FROM clusterAllReplicas('default', 'system', 'tables') where database = current_database() and name = '%s'",
-                stagingTable);
+                "%s%s %s '%s'%s%s%s",
+                queryPart1, queryPart2, queryPart3, stagingTable, queryPart4, queryPart5, queryPart6);
         return allReplicasReportExpectedResult(getRecordCountsString, "total_rows", AllReplicaTestType.EXPECTED_VALUE, AllReplicaCriterionType.LONG, new Long(pendingIds.size()));
     }
 
     private boolean deletionIsComplete() throws SQLException, DaoException {
         String getUndeletedRecordCountsString = String.format(
-                "SELECT count() as record_count FROM %s WHERE %s IN (SELECT id from %s)",
+                "SELECT count() AS record_count FROM %s WHERE %s IN (SELECT id FROM %s)",
                 targetTable, idColumn, stagingTable);
         return queryProducedExpectedResult(getUndeletedRecordCountsString, "record_count", 0L);
     }
 
     private boolean allReplicasReportSameMetadataForTargetTable() throws SQLException, DaoException {
-        String selectClause = "SELECT hostname() as host, metadata_modification_time as field_value";
-        String fromClause = "FROM clusterAllReplicas('default', 'system', 'tables')";
-        String whereClause = "WHERE database = current_database() AND name = ";
+        String queryPart1 = "SELECT host, sum(record_count) AS total_rows FROM ((";
+        String queryPart2 = "SELECT hostname() AS host, rows AS record_count FROM clusterAllReplicas('default', 'system', 'parts')";
+        String queryPart3 = "WHERE database = current_database() AND table = ";
+        String queryPart4 = ") union all (";
+        // This union insures that at least one part with one record is included in the query result before aggregation. In this way, every host will be present in the results
+        String queryPart5 = "SELECT hostname() AS host, 0 AS record_count FROM clusterAllReplicas('default', 'system', 'one')";
+        String queryPart6 = ")) GROUP BY host";
         String getMetadataString = String.format(
-                "%s %s %s '%s'",
-                selectClause, fromClause, whereClause, targetTable);
-        return allReplicasReportExpectedResult(getMetadataString, "field_value", AllReplicaTestType.CONSISTENT, AllReplicaCriterionType.STRING, null);
+                "%s%s %s '%s'%s%s%s",
+                queryPart1, queryPart2, queryPart3, targetTable, queryPart4, queryPart5, queryPart6);
+        return allReplicasReportExpectedResult(getMetadataString, "total_rows", AllReplicaTestType.CONSISTENT, AllReplicaCriterionType.LONG, null);
     }
 
 // reusable logic to perform test/retry loops for database queries with criteria
@@ -428,12 +470,10 @@ public class ClickHouseBulkDeleter {
     }
 
     private boolean conditionIsTrueAfterQueryWithRetry(ConditionPredicate conPred, int maxTestingSeconds) throws DaoException {
-        int WAIT_CYCLE_PERIOD_SECONDS = 10;
-        int WAIT_CYCLE_MAX_COUNT = maxTestingSeconds / WAIT_CYCLE_PERIOD_SECONDS;
-        int WAIT_CYCLE_TOLERATE_EXCEPTION_LIMIT = 6;
+        int totalCycleCount = maxTestingSeconds / RETRY_CYCLE_PERIOD_SECONDS;
         int exceptionsEncountered = 0;
         boolean returnValue = false;
-        for (int cycle = 0 ; cycle < WAIT_CYCLE_MAX_COUNT ; cycle = cycle + 1) {
+        for (int cycle = 0 ; cycle < totalCycleCount ; cycle = cycle + 1) {
             try {
                 if (conPred.conditionIsSatisfied()) {
                     returnValue = true;
@@ -441,18 +481,23 @@ public class ClickHouseBulkDeleter {
                 }
             } catch (SQLException e) {
                 exceptionsEncountered = exceptionsEncountered + 1;
-                if (exceptionsEncountered > WAIT_CYCLE_TOLERATE_EXCEPTION_LIMIT) {
+                String msg = String.format(
+                        "SQL Exception encountered during try/retry loop on cycle number %d : %s",
+                        cycle, e.getMessage());
+                log.warn(msg);
+                if (exceptionsEncountered > DEFAULT_RETRY_CYCLE_MAX_EXCEPTION_COUNT) {
                     throw new DaoException(e);
                 }
             } finally {
-                if (returnValue == false && cycle < WAIT_CYCLE_MAX_COUNT - 1 && exceptionsEncountered <= WAIT_CYCLE_TOLERATE_EXCEPTION_LIMIT) {
+                if (returnValue == false && cycle < totalCycleCount - 1 && exceptionsEncountered <= DEFAULT_RETRY_CYCLE_MAX_EXCEPTION_COUNT) {
                     // sleep if we will be trying another iteration
                     try {
-                        Thread.sleep(1000 * WAIT_CYCLE_PERIOD_SECONDS);
+                        Thread.sleep(1000 * RETRY_CYCLE_PERIOD_SECONDS);
                     } catch (InterruptedException ie) {
                         // allow sleep interruption, and go on to next cycle immediately
                         Thread.currentThread().interrupt(); // set interrupted status, in case we want to adjust for interrupted sleep
                     }
+                } else {
                 }
             }
         }
@@ -487,7 +532,7 @@ public class ClickHouseBulkDeleter {
         return true;
     }
 
-    // queryString must be a SQL query which returns results which includes a field "host" with the hostname() of the replica responding. "SELECT hostname() as host..."
+    // queryString must be a SQL query which returns results which includes a field "host" with the hostname() of the replica responding. "SELECT hostname() AS host..."
     // with testType AllReplicaTestType.CONSISTENT, the expectedValue argument is ignored (pass null)
     private boolean allReplicasReportExpectedResult(String queryString, String outputField, AllReplicaTestType testType, AllReplicaCriterionType criterionType, Object expectedValue) throws SQLException, DaoException {
         Set<String> allReplicaHostNames = getReplicaHostnames();
@@ -562,7 +607,7 @@ public class ClickHouseBulkDeleter {
     private Set<String> getReplicaHostnames() throws SQLException {
         Set<String> hostnameSet = new HashSet<>();
         Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
-        String getHostNamesQueryString = "SELECT hostname() as host from clusterAllReplicas('default', 'system', 'one') GROUP BY host";
+        String getHostNamesQueryString = "SELECT hostname() AS host FROM clusterAllReplicas('default', 'system', 'one') GROUP BY host";
         try (PreparedStatement pstmt = con.prepareStatement(getHostNamesQueryString);
                 ResultSet rs = pstmt.executeQuery()) {
             while (rs.next()) {
@@ -592,4 +637,5 @@ public class ClickHouseBulkDeleter {
             throw new DaoException(e);
         }
     }
+
 }

--- a/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseBulkDeleter.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseBulkDeleter.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2026 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2026 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -38,12 +38,13 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Bulk deleter that buffers IDs in memory, streams them into a ClickHouse staging
@@ -60,7 +61,7 @@ public class ClickHouseBulkDeleter {
     private final String targetTable;
     private final String idColumn;
     private final String stagingTable;
-    private final List<Long> pendingIds = new ArrayList<>();
+    private final Set<Long> pendingIds = new HashSet<>();
 
     private ClickHouseBulkDeleter(String targetTable, String idColumn) {
         this.targetTable = targetTable;
@@ -85,76 +86,165 @@ public class ClickHouseBulkDeleter {
 
     public static int flushAll() throws DaoException {
         int totalDeleted = 0;
-        for (ClickHouseBulkDeleter deleter : BULK_DELETERS.values()) {
-            totalDeleted += deleter.flushPendingIds();
-        }
-        BULK_DELETERS.clear();
-        return totalDeleted;
-    }
-
-    private int flushPendingIds() throws DaoException {
-        if (pendingIds.isEmpty()) {
-            return 0;
-        }
-
         Connection con = null;
         try {
             con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
-
-            // Drop any leftover staging table from a previous crashed run
-            try (PreparedStatement stmt = con.prepareStatement(
-                    "DROP TABLE IF EXISTS " + stagingTable)) {
-                stmt.executeUpdate();
-            }
-
-            // Create staging table
-            try (PreparedStatement stmt = con.prepareStatement(
-                    "CREATE TABLE " + stagingTable + " (id Int64) ENGINE = MergeTree() ORDER BY id")) {
-                stmt.executeUpdate();
-            }
-
-            // Insert IDs into staging table via TSV stream
-            byte[] payload = buildTsvPayload();
-            try (PreparedStatement stmt = con.prepareStatement(
-                    "INSERT INTO " + stagingTable + " (id) FORMAT TSVWithNames")) {
-                stmt.setBinaryStream(1, new ByteArrayInputStream(payload));
-                stmt.executeUpdate();
-            }
-
-            // Execute delete via staging table
-            int deleted;
-            try (PreparedStatement stmt = con.prepareStatement(
-                    "DELETE FROM " + targetTable + " WHERE " + idColumn + " IN (SELECT id FROM " + stagingTable + ")")) {
-                deleted = stmt.executeUpdate();
-            }
-
-            return deleted;
+            dropAnyExistingStagingTables(con, false); // drop any leftover tables from previous crash/failure
+            createAllStagingTables(con);
+            populateAllStagingTables(con);
+            totalDeleted = deleteRecordsReferencedInStagingTables(con);
         } catch (SQLException | IOException e) {
             throw new DaoException(e);
         } finally {
-            // Always drop staging table
             try {
                 if (con != null) {
-                    try (PreparedStatement drop = con.prepareStatement(
-                            "DROP TABLE IF EXISTS " + stagingTable)) {
-                        drop.executeUpdate();
+                    dropAnyExistingStagingTables(con, true);
+                    JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
+                }
+            } catch (SQLException se) {
+                // exceptions will be ignored during second call to dropAnyExistingStagingTables
+            }
+            clearAllDeleters();
+        }
+        return totalDeleted;
+    }
+
+    private static void clearAllDeleters() {
+        for (ClickHouseBulkDeleter deleter : BULK_DELETERS.values()) {
+            deleter.pendingIds.clear();
+        }
+        BULK_DELETERS.clear();
+    }
+
+    private static void createAllStagingTables(Connection con) throws SQLException {
+        for (ClickHouseBulkDeleter deleter : BULK_DELETERS.values()) {
+            String createTableStatementString = String.format(
+                    "CREATE TABLE %s (id Int64) ENGINE = MergeTree() ORDER BY id",
+                    deleter.stagingTable);
+            try (PreparedStatement stmt = con.prepareStatement(createTableStatementString)) {
+                stmt.executeUpdate();
+            }
+        }
+        // wait for table existence to propagate to replicas (if they exist)
+        for (ClickHouseBulkDeleter deleter : BULK_DELETERS.values()) {
+            String alterTableStatementString = String.format(
+                    "ALTER TABLE %s MODIFY COMMENT 'Transient' SETTINGS mutations_sync = 3",
+                    deleter.stagingTable);
+            try (PreparedStatement stmt = con.prepareStatement(alterTableStatementString)) {
+                stmt.executeUpdate();
+            }
+        }
+    }
+
+    private static void populateAllStagingTables(Connection con) throws SQLException, DaoException, IOException {
+        for (ClickHouseBulkDeleter deleter : BULK_DELETERS.values()) {
+            deleter.populateStagingTable(con);
+        }
+        // wait for inserts to be recognized by all replicas
+        // note: this is intentionally done in a second loop in the hope that while values are being inserted
+        //     into the second, third, ... tables, the time for processing those operations allows for the values
+        //     inserted into the first table to be recognized / become visible in the other replica nodes
+        //     running in a Clickhouse cluster (such as with clickhouse.cloud). This may avoid retry cycles.
+        for (ClickHouseBulkDeleter deleter : BULK_DELETERS.values()) {
+            if (! deleter.allReplicasReachedRecordCount(con)) {
+                throw new DaoException("Failed to see all replicas reflect delete list inserted into table " + deleter.stagingTable);
+            }
+        }
+    }
+
+    private void populateStagingTable(Connection con) throws SQLException, IOException {
+        if (pendingIds.isEmpty()) {
+            return;
+        }
+        // Insert IDs into staging table via TSV stream
+        byte[] payload = buildTsvPayload();
+        String insertStatementString = String.format(
+                "INSERT INTO %s (id) FORMAT TSVWithNames",
+                stagingTable);
+        try (PreparedStatement stmt = con.prepareStatement(insertStatementString)) {
+            stmt.setBinaryStream(1, new ByteArrayInputStream(payload));
+            stmt.executeUpdate();
+        }
+    }
+
+    private boolean allReplicasReachedRecordCount(Connection con) throws SQLException {
+        int WAIT_CYCLE_MAX_COUNT = 60;
+        int WAIT_CYCLE_PERIOD_SECONDS = 10;
+        int WAIT_CYCLE_TOLERATE_EXCEPTION_LIMIT = 6;
+        int exceptions_ignored = 0;
+        for (int cycle = 0 ; cycle < WAIT_CYCLE_MAX_COUNT ; cycle = cycle + 1) {
+            String getRecordCountsString = String.format(
+                    "SELECT COUNT() as record_count FROM clusterAllReplicas('default', current_database(), %s)",
+                    stagingTable);
+            try (PreparedStatement pstmt = con.prepareStatement(getRecordCountsString);
+                    ResultSet rs = pstmt.executeQuery()) {
+                boolean recordCountWasReached = true;
+                while (rs.next()) {
+                    int recordCountOnReplica = rs.getInt("record_count");
+                    if (recordCountOnReplica != pendingIds.size()) {
+                        recordCountWasReached = false;
+                        break;
                     }
                 }
-            } catch (SQLException ignored) {
+                if (recordCountWasReached) {
+                    return true;
+                }
+                Thread.sleep(1000 * WAIT_CYCLE_PERIOD_SECONDS);
+            } catch (SQLException e) {
+                if (exceptions_ignored >= WAIT_CYCLE_TOLERATE_EXCEPTION_LIMIT) {
+                    throw e;
+                }
+                exceptions_ignored = exceptions_ignored + 1;
+            } catch (InterruptedException ie) {
+                // ignore : ok to go on to next cycle immediately
             }
-            JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
-            pendingIds.clear();
+        }
+        return false;
+    }
+
+    private static int deleteRecordsReferencedInStagingTables(Connection con) throws SQLException {
+        int totalDeleted = 0;
+        for (ClickHouseBulkDeleter deleter : BULK_DELETERS.values()) {
+            totalDeleted += deleter.deleteRecordsReferencedInStagingTable(con);
+        }
+        return totalDeleted;
+    }
+
+    private int deleteRecordsReferencedInStagingTable(Connection con) throws SQLException {
+        int records_deleted;
+        String statementString = String.format(
+                "DELETE FROM %s WHERE %s IN (SELECT id FROM %s)",
+                targetTable, idColumn, stagingTable);
+        try (PreparedStatement stmt = con.prepareStatement(statementString)) {
+            records_deleted = stmt.executeUpdate();
+        }
+        return records_deleted;
+    }
+
+    private static void dropAnyExistingStagingTables(Connection con, boolean ignoreExceptions) throws SQLException {
+        for (ClickHouseBulkDeleter deleter : BULK_DELETERS.values()) {
+            String dropStatementString = String.format(
+                "DROP TABLE IF EXISTS %s",
+                deleter.stagingTable);
+            try (PreparedStatement stmt = con.prepareStatement(dropStatementString)) {
+                stmt.executeUpdate();
+            } catch (SQLException e) {
+                if (! ignoreExceptions) {
+                    throw e;
+                }
+            }
         }
     }
 
     private byte[] buildTsvPayload() throws IOException {
-        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-        // header row
-        buffer.write("id\n".getBytes(StandardCharsets.UTF_8));
-        // data rows
-        for (Long id : pendingIds) {
-            buffer.write((id.toString() + "\n").getBytes(StandardCharsets.UTF_8));
+        try (ByteArrayOutputStream buffer = new ByteArrayOutputStream()) {
+            // header row
+            buffer.write("id\n".getBytes(StandardCharsets.UTF_8));
+            // data rows
+            for (Long id : pendingIds) {
+                buffer.write((id.toString() + "\n").getBytes(StandardCharsets.UTF_8));
+            }
+            return buffer.toByteArray();
         }
-        return buffer.toByteArray();
     }
 }

--- a/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseBulkDeleter.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseBulkDeleter.java
@@ -40,11 +40,14 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,130 +68,156 @@ public class ClickHouseBulkDeleter {
     private final String idColumn;
     private final String stagingTable;
     private final Set<Long> pendingIds = new HashSet<>();
+    private boolean flushed; // once flushed, any particular deleter instance cannot not be flushed again
 
-    // --- static methods ---
+// --- Interface ---
 
     public static ClickHouseBulkDeleter getBulkDeleter(String targetTable, String idColumn) {
-        String key = String.format("%s:%s", targetTable, idColumn);
+        if (ClickHouseBulkDeleter.stringContainsIllegalCharacter(targetTable)) {
+            throw new RuntimeException(String.format(
+                    "An illegal character was used in a Clickhouse table name argument : %s",
+                    targetTable));
+        }
+        if (ClickHouseBulkDeleter.stringContainsIllegalCharacter(idColumn)) {
+            throw new RuntimeException(String.format(
+                    "An illegal character was used in a Clickhouse field name argument : %s",
+                    idColumn));
+        }
+        String key = ClickHouseBulkDeleter.deleterKeyString(targetTable, idColumn);
         return BULK_DELETERS.computeIfAbsent(key, k -> new ClickHouseBulkDeleter(targetTable, idColumn));
     }
 
     public static long flushAll() throws DaoException {
+        List<ClickHouseBulkDeleter> allDeleters = BULK_DELETERS.values().stream().collect(Collectors.toList());
+        long countOfDeletedRecords = ClickHouseBulkDeleter.flush(allDeleters); // deleters which have any potential deletes are removed from BULK_DELETERS here
+        // delete unused deleters : after flushAll is called, any retained references to ClickHouseBulkDeleter objects will become invalid
+        List<ClickHouseBulkDeleter> unusedDeleters = BULK_DELETERS.values().stream().collect(Collectors.toList());
+        teardownDeleters(unusedDeleters);
+        return countOfDeletedRecords;
+    }
+
+// --- Static helper functions
+
+    // might be made public in the future for partial flushes (would require testing)
+    private static long flush(List<ClickHouseBulkDeleter> deleters) throws DaoException {
         long totalDeleted = 0;
+        if (anyDeleterWasAlreadyFlushed(deleters)) {
+            throw new RuntimeException("a ClickHouseBulkDeleter object had been flushed previously, and was attempted to be flushed a second time");
+        }
+        List<ClickHouseBulkDeleter> effectiveDeleters = deletersWithPendingDeletes(deleters);
         try {
-            dropAnyExistingStagingTables(false); // drop any leftover tables from previous crash/failure
-            createAllStagingTables();
-            populateAllStagingTables();
-            totalDeleted = deleteRecordsReferencedInStagingTables();
-        } catch (SQLException | IOException e) {
-            throw new DaoException(e);
+            dropExistingStagingTables(effectiveDeleters, false); // drop any leftover tables from previous crash/failure
+            createStagingTables(effectiveDeleters);
+            populateStagingTables(effectiveDeleters);
+            totalDeleted = deleteRecordsReferencedInStagingTables(effectiveDeleters);
         } finally {
-            try {
-                dropAnyExistingStagingTables(true);
-            } catch (SQLException se) {
-                // will not happen because SQLExceptions will be suppressed during second call
-                // to dropAnyExistingStagingTables (leftover tables will be tolerated)
-            }
-            clearAllDeleters();
+            dropExistingStagingTables(effectiveDeleters, true);
+            teardownDeleters(effectiveDeleters);
         }
         return totalDeleted;
     }
 
-    private static void clearAllDeleters() {
-        for (ClickHouseBulkDeleter deleter : BULK_DELETERS.values()) {
-            deleter.pendingIds.clear();
-        }
-        BULK_DELETERS.clear();
+    private static boolean stringContainsIllegalCharacter(String s) {
+        // clickhouse field and table names can contain only letters, digits, or underscore (unless universally backquoted)
+        return s.matches(".*[^a-zA-Z0-9_].*");
     }
 
-    private static void createAllStagingTables() throws SQLException, DaoException {
-        for (ClickHouseBulkDeleter deleter : BULK_DELETERS.values()) {
-            Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
-            String createTableStatementString = String.format(
-                    "CREATE TABLE %s (id Int64) ENGINE = MergeTree() ORDER BY id",
-                    deleter.stagingTable);
-            try (PreparedStatement stmt = con.prepareStatement(createTableStatementString)) {
-                stmt.executeUpdate();
-            } finally {
-                JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
+    private static String deleterKeyString(String targetTable, String idColumn) {
+        return String.format("%s:%s", targetTable, idColumn);
+    }
+
+    private static boolean anyDeleterWasAlreadyFlushed(List<ClickHouseBulkDeleter> deleters) {
+        return deleters.stream().anyMatch(d -> d.wasFlushed());
+    }
+ 
+    // returns only the deleters which might delete anything (duplicates discarded)
+    private static List<ClickHouseBulkDeleter> deletersWithPendingDeletes(List<ClickHouseBulkDeleter> deleters) {
+        List<ClickHouseBulkDeleter> effectiveDeleters = new ArrayList<>();
+        Set<String> keysSeen = new HashSet<>();
+        for (ClickHouseBulkDeleter d : deleters) {
+            if (d.hasPendingDeletes()) {
+                if (keysSeen.contains(d.getKey())) {
+                    continue; // skip duplicated keys
+                }
+                keysSeen.add(d.getKey());
+                effectiveDeleters.add(d);
             }
         }
-        for (ClickHouseBulkDeleter deleter : BULK_DELETERS.values()) {
-            final int MAX_RETRY_SECONDS = 600;
-            if (! deleter.conditionIsTrueAfterTestWithRetry(deleter::allReplicasReportStagingTableExists, MAX_RETRY_SECONDS)) {
-                String exceptionMsgString = String.format(
-                        "Failed to see all replicas report existence of staging table %s after creation",
-                        deleter.stagingTable);
-                throw new DaoException(exceptionMsgString);
+        return effectiveDeleters;
+    }
+
+    private static void teardownDeleters(List<ClickHouseBulkDeleter> deleters) {
+        for (ClickHouseBulkDeleter d : deleters) {
+            if (BULK_DELETERS.containsKey(d.getKey())) {
+                BULK_DELETERS.remove(d.getKey()); // object will not be re-used
+            } else {
+                String msg = String.format(
+                        "%s%s%s%s%s",
+                        "unable to deregister deleter which has just been flushed for targetTable ",
+                        d.targetTable,
+                        " and idColumn ",
+                        d.idColumn,
+                        ". Apparently an instance which was not in map BULK_DELETERS was used for record deletion");
+                log.warn(msg);
             }
+            d.teardown();
         }
     }
 
-    private static void populateAllStagingTables() throws SQLException, DaoException, IOException {
-        for (ClickHouseBulkDeleter deleter : BULK_DELETERS.values()) {
-            deleter.populateStagingTable();
+    private static void createStagingTables(List<ClickHouseBulkDeleter> deleters) throws DaoException {
+        for (ClickHouseBulkDeleter d : deleters) {
+            d.createStagingTable();
+        }
+        for (ClickHouseBulkDeleter d : deleters) {
+            d.confirmCreationOfStagingTable();
+        }
+    }
+
+    private static void populateStagingTables(List<ClickHouseBulkDeleter> deleters) throws DaoException {
+        for (ClickHouseBulkDeleter d : deleters) {
+            d.populateStagingTable();
         }
         // wait for inserts to be recognized by all replicas
         // note: this is intentionally done in a second loop in the hope that while values are being inserted
         //     into the second, third, ... tables, the time for processing those operations allows for the values
         //     inserted into the first table to be recognized / become visible in the other replica nodes
         //     running in a Clickhouse cluster (such as with clickhouse.cloud). This may avoid retry cycles.
-        for (ClickHouseBulkDeleter deleter : BULK_DELETERS.values()) {
-            final int MAX_RETRY_SECONDS = 600;
-            if (! deleter.conditionIsTrueAfterTestWithRetry(deleter::allReplicasReportExpectedStagingTableRecordCount, MAX_RETRY_SECONDS)) {
-                String exceptionMsgString = String.format(
-                        "Failed to see all replicas reflect delete list inserted into table %s",
-                        deleter.stagingTable);
-                throw new DaoException(exceptionMsgString);
-            }
+        for (ClickHouseBulkDeleter d : deleters) {
+            d.confirmPopulationOfStagingTable();
         }
     }
 
-    private static long deleteRecordsReferencedInStagingTables() throws SQLException {
+    private static long deleteRecordsReferencedInStagingTables(List<ClickHouseBulkDeleter> deleters) throws DaoException {
         long totalDeleted = 0;
-        for (ClickHouseBulkDeleter deleter : BULK_DELETERS.values()) {
-            totalDeleted += deleter.deleteRecordsReferencedInStagingTable();
+        for (ClickHouseBulkDeleter d : deleters) {
+            totalDeleted += d.deleteRecordsReferencedInStagingTable();
         }
         return totalDeleted;
     }
 
-    private static void dropAnyExistingStagingTables(boolean deletionHasBeenExecuted) throws SQLException, DaoException {
-        for (ClickHouseBulkDeleter deleter : BULK_DELETERS.values()) {
+    private static void dropExistingStagingTables(List<ClickHouseBulkDeleter> deleters, boolean deletionHasBeenExecuted) throws DaoException {
+        for (ClickHouseBulkDeleter d : deleters) {
             // wait until all ids in the stagingTable table have been fully deleted from the target table
-            final int MAX_RETRY_SECONDS = 600;
-            if (deletionHasBeenExecuted && ! deleter.conditionIsTrueAfterTestWithRetry(deleter::allReplicasCompletedDeletion, MAX_RETRY_SECONDS)) {
-                String exceptionMessageString = String.format(
-                        "Failed to complete the delete operation on all replicas for table %s",
-                        deleter.stagingTable);
-                throw new DaoException(exceptionMessageString);
+            if (deletionHasBeenExecuted) {
+                d.confirmDeletionIsComplete();
             }
-            String dropStatementString = String.format(
-                    "DROP TABLE IF EXISTS %s",
-                    deleter.stagingTable);
-            Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
-            try (PreparedStatement stmt = con.prepareStatement(dropStatementString)) {
-                stmt.executeUpdate();
-            } catch (SQLException e) {
-                if (! deletionHasBeenExecuted) {
-                    // it is fatal to fail to DROP any old staging tables during the first call
-                    // (during setup for deletion), because then the CREATE for staging will fail.
-                    // on the second call, so long as the deletion completed, it is "ok" to leave behind
-                    // residual staging tables -- they will (hopefully) DROP during the next update run
-                    throw e;
-                }
-            } finally {
-                JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
-            }
+            d.dropStagingTable(deletionHasBeenExecuted);
         }
     }
 
-    // --- instance methods ---
+// --- instance methods ---
 
     public void addId(long id) {
+        if (this.flushed) {
+            throw new RuntimeException("attempting to add identifiers to a ClickHouseBulkDeleter object which has already been flushed");
+        }
         pendingIds.add(id);
     }
 
     public void addIds(Collection<? extends Number> ids) {
+        if (this.flushed) {
+            throw new RuntimeException("attempting to add identifiers to a ClickHouseBulkDeleter object which has already been flushed");
+        }
         for (Number id : ids) {
             pendingIds.add(id.longValue());
         }
@@ -197,33 +226,202 @@ public class ClickHouseBulkDeleter {
     private ClickHouseBulkDeleter(String targetTable, String idColumn) {
         this.targetTable = targetTable;
         this.idColumn = idColumn;
-        this.stagingTable = String.format("staging_delete_%s", targetTable);
+        this.stagingTable = String.format("staging_delete_for_table_%s_column_%s", targetTable, idColumn);
+        this.flushed = false;
     }
 
-    private void populateStagingTable() throws SQLException, IOException {
-        if (pendingIds.isEmpty()) {
-            return;
+    private boolean hasPendingDeletes() {
+        return !this.pendingIds.isEmpty();
+    }
+
+    private boolean wasFlushed() {
+        return flushed;
+    }
+
+    private void teardown() {
+        this.pendingIds.clear();
+        this.flushed = true; // prevent re-flushing
+    }
+
+    private String getKey() {
+        return ClickHouseBulkDeleter.deleterKeyString(this.targetTable, this.idColumn);
+    }
+
+// methods which are database alterations (on failure, these throw DaoException)
+
+    private void createStagingTable() throws DaoException {
+        try {
+            Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
+            String createTableStatementString = String.format(
+                    "CREATE TABLE %s (id Int64) ENGINE = MergeTree() ORDER BY id",
+                    this.stagingTable);
+            try (PreparedStatement stmt = con.prepareStatement(createTableStatementString)) {
+                stmt.executeUpdate();
+            } finally {
+                JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
+            }
+        } catch (SQLException e) {
+            throw new DaoException(e);
         }
+    }
+
+    private void populateStagingTable() throws DaoException {
         // Insert IDs into staging table via TSV stream
         byte[] payload = buildTsvPayload();
         String insertStatementString = String.format(
                 "INSERT INTO %s (id) FORMAT TSVWithNames",
                 stagingTable);
-        Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
-        try (PreparedStatement stmt = con.prepareStatement(insertStatementString)) {
-            stmt.setBinaryStream(1, new ByteArrayInputStream(payload));
-            stmt.executeUpdate();
-        } finally {
-            JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
+        try {
+            Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
+            try (PreparedStatement stmt = con.prepareStatement(insertStatementString)) {
+                stmt.setBinaryStream(1, new ByteArrayInputStream(payload));
+                stmt.executeUpdate();
+            } finally {
+                JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
+            }
+        } catch (SQLException e) {
+            throw new DaoException(e);
         }
     }
+
+    private long deleteRecordsReferencedInStagingTable() throws DaoException {
+        long records_deleted;
+        String statementString = String.format(
+                "DELETE FROM %s WHERE %s IN (SELECT id FROM %s)",
+                targetTable, idColumn, stagingTable);
+        try {
+            Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
+            try (PreparedStatement stmt = con.prepareStatement(statementString)) {
+                records_deleted = stmt.executeUpdate();
+            } finally {
+                JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
+            }
+        } catch (SQLException e) {
+            throw new DaoException(e);
+        }
+        return records_deleted;
+    }
+
+    private void dropStagingTable(boolean tolerateFailure) throws DaoException {
+        try {
+            String dropStatementString = String.format(
+                    "DROP TABLE IF EXISTS %s",
+                    this.stagingTable);
+            Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
+            try (PreparedStatement stmt = con.prepareStatement(dropStatementString)) {
+                stmt.executeUpdate();
+            } catch (SQLException e) {
+                if (! tolerateFailure) {
+                    // it is fatal to fail to DROP any old staging tables during the first call
+                    // (during setup for deletion), because then the CREATE for staging will fail.
+                    // on the second call, so long as the deletion completed, it is allowabe to leave behind
+                    // residual staging tables -- they will (hopefully) DROP during the next update run
+                    throw new DaoException(e);
+                }
+            } finally {
+                JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
+            }
+        } catch (SQLException e) {
+            throw new DaoException(e);
+        }
+    }
+
+// methods which are complete confirmations of database alterations (on failure these throw DaoExcpetion)
+
+    private void confirmCreationOfStagingTable() throws DaoException {
+        final int MAX_RETRY_SECONDS = 600;
+        if (! this.conditionIsTrueAfterQueryWithRetry(this::allReplicasReportStagingTableExists, MAX_RETRY_SECONDS)) {
+            String exceptionMsgString = String.format(
+                    "Failed to see all replicas report existence of staging table %s after creation",
+                    this.stagingTable);
+            throw new DaoException(exceptionMsgString);
+        }
+    }
+
+    private void confirmPopulationOfStagingTable() throws DaoException {
+        final int MAX_RETRY_SECONDS = 600;
+        if (! this.conditionIsTrueAfterQueryWithRetry(this::allReplicasReportExpectedStagingTableRecordCount, MAX_RETRY_SECONDS)) {
+            String exceptionMsgString = String.format(
+                    "Failed to see all replicas reflect delete list inserted into table %s",
+                    this.stagingTable);
+            throw new DaoException(exceptionMsgString);
+        }
+    }
+
+    private void confirmDeletionIsComplete() throws DaoException {
+        this.confirmDeletionIsCompleteInData();
+        this.confirmDeletionIsCompleteInMetadata();
+    }
+
+    private void confirmDeletionIsCompleteInData() throws DaoException {
+        final int MAX_RETRY_SECONDS = 600;
+        if (!this.conditionIsTrueAfterQueryWithRetry(this::deletionIsComplete, MAX_RETRY_SECONDS)) {
+            String exceptionMessageString = String.format(
+                    "Failed to complete the delete operation on all replicas for table %s after retrying for %d seconds",
+                    this.targetTable,
+                    MAX_RETRY_SECONDS);
+            throw new DaoException(exceptionMessageString);
+        }
+        // TODO: if condition fails a few times, we might start checking whether any
+        // mutations are still in progress -- if not, stop waiting and fail before MAX_RETRY_SECONDS
+    }
+
+    private void confirmDeletionIsCompleteInMetadata() throws DaoException {
+        final int MAX_RETRY_SECONDS = 65;
+        if (!this.conditionIsTrueAfterQueryWithRetry(this::allReplicasReportSameMetadataForTargetTable, MAX_RETRY_SECONDS)) {
+            String exceptionMessageString = String.format(
+                    "Metadata for table %s could not be confirmed to have propagated across all cluster replica nodes after retrying for %d seconds",
+                    this.targetTable,
+                    MAX_RETRY_SECONDS);
+            throw new DaoException(exceptionMessageString);
+        }
+    }
+
+// functional predicates for performing tests (these may return SQLException which allows retry, or DaoException for fatal failures)
+
+    private boolean allReplicasReportStagingTableExists() throws SQLException, DaoException {
+        String getTableExistsString = String.format(
+                "SELECT hostname() as host, count() as table_exists FROM clusterAllReplicas('default', 'system', 'tables') where database = current_database() and name = '%s' GROUP BY host",
+                stagingTable);
+        return allReplicasReportExpectedResult(getTableExistsString, "table_exists", 1);
+    }
+
+// TODO : change this to simply look for the record count in system.tables (faster/more consistent)
+    private boolean allReplicasReportExpectedStagingTableRecordCount() throws SQLException, DaoException {
+        String getRecordCountsString = String.format(
+                "SELECT hostname() as host, count() as record_count FROM clusterAllReplicas('default', current_database(), %s) GROUP BY host",
+                stagingTable);
+        return allReplicasReportExpectedResult(getRecordCountsString, "record_count", pendingIds.size());
+    }
+
+    private boolean deletionIsComplete() throws SQLException, DaoException {
+        String getUndeletedRecordCountsString = String.format(
+                "SELECT count() as record_count FROM %s WHERE %s IN (SELECT id from %s)",
+                targetTable, idColumn, stagingTable);
+        return queryProducedExpectedResult(getUndeletedRecordCountsString, "record_count", 0);
+    }
+
+    private boolean allReplicasReportSameMetadataForTargetTable() throws SQLException, DaoException {
+        String selectClause = "SELECT hostname() as host, metadata_modification_time as field_value";
+        String fromClause = "FROM clusterAllReplicas('default', system, tables)";
+        String whereClause = "WHERE database = current_database() AND name = ";
+        String getMetadataString = String.format(
+                "%s %s %s '%s'",
+                selectClause,
+                fromClause,
+                whereClause,
+                targetTable);
+        return allReplicasReportSameValue(getMetadataString, "field_value");
+    }
+
+// reusable logic to perform test/retry loops for database queries with criteria
 
     @FunctionalInterface
     private interface ConditionPredicate {
         boolean conditionIsSatisfied() throws SQLException, DaoException;
     }
 
-    private boolean conditionIsTrueAfterTestWithRetry(ConditionPredicate conPred, int maxTestingSeconds) throws SQLException, DaoException {
+    private boolean conditionIsTrueAfterQueryWithRetry(ConditionPredicate conPred, int maxTestingSeconds) throws DaoException {
         int WAIT_CYCLE_PERIOD_SECONDS = 10;
         int WAIT_CYCLE_MAX_COUNT = maxTestingSeconds / WAIT_CYCLE_PERIOD_SECONDS;
         int WAIT_CYCLE_TOLERATE_EXCEPTION_LIMIT = 6;
@@ -238,7 +436,7 @@ public class ClickHouseBulkDeleter {
             } catch (SQLException e) {
                 exceptionsEncountered = exceptionsEncountered + 1;
                 if (exceptionsEncountered > WAIT_CYCLE_TOLERATE_EXCEPTION_LIMIT) {
-                    throw e;
+                    throw new DaoException(e);
                 }
             } finally {
                 if (returnValue == false && cycle < WAIT_CYCLE_MAX_COUNT - 1 && exceptionsEncountered <= WAIT_CYCLE_TOLERATE_EXCEPTION_LIMIT) {
@@ -255,26 +453,35 @@ public class ClickHouseBulkDeleter {
         return returnValue;
     }
 
-    private Set<String> getReplicaHostnames() throws SQLException, DaoException {
-        Set<String> hostnameSet = new HashSet<>();
+    // checks specified outputField in the results of running queryString and looks for expectedResult
+    // only the first result (in the result set) is examined
+    private boolean queryProducedExpectedResult(String queryString, String outputField, long expectedResult) throws SQLException {
         Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
-        String getHostNamesQueryString = "SELECT hostname() as host from clusterAllReplicas('default', 'system', 'one') GROUP BY host";
-        try (PreparedStatement pstmt = con.prepareStatement(getHostNamesQueryString);
+        try (PreparedStatement pstmt = con.prepareStatement(queryString);
                 ResultSet rs = pstmt.executeQuery()) {
-            while (rs.next()) {
-                hostnameSet.add(rs.getString("host"));
+            if (!rs.next()) {
+                log.warn(String.format(
+                        "evaluation of query produced empty result set : %s",
+                        queryString));
+                return false;
+            }
+            long result = rs.getLong(outputField);
+            if (result != expectedResult) {
+                log.warn(String.format(
+                        "waiting to reach expected result for query '%s' : expected %d saw %d",
+                        queryString,
+                        expectedResult,
+                        result
+                        ));
+                return false;
             }
         } finally {
             JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
         }
-        if (hostnameSet.isEmpty()) {
-            throw new DaoException(String.format(
-                    "unable to find set of active replica hosts using query : %s",
-                    getHostNamesQueryString));
-        }
-        return hostnameSet;
+        return true;
     }
 
+//ROB : todo : consolidate the next two methods
     // queryString must be a SQL query which returns results which includes a field "host" with the hostname() of the replica responding. "SELECT hostname() as host..."
     private boolean allReplicasReportExpectedResult(String queryString, String outputField, long expectedResult) throws SQLException, DaoException {
         boolean allReplicasAreAsExpected = false;
@@ -318,42 +525,75 @@ public class ClickHouseBulkDeleter {
         return allReplicasAreAsExpected;
     }
 
-    private boolean allReplicasReportStagingTableExists() throws SQLException, DaoException {
-        String getTableExistsString = String.format(
-                "SELECT hostname() as host, count() as table_exists FROM clusterAllReplicas('default', 'system', 'tables') where database = current_database() and name = '%s' GROUP BY host",
-                stagingTable);
-        return allReplicasReportExpectedResult(getTableExistsString, "table_exists", 1);
-    }
-
-    private boolean allReplicasReportExpectedStagingTableRecordCount() throws SQLException, DaoException {
-        String getRecordCountsString = String.format(
-                "SELECT hostname() as host, count() as record_count FROM clusterAllReplicas('default', current_database(), %s) GROUP BY host",
-                stagingTable);
-        return allReplicasReportExpectedResult(getRecordCountsString, "record_count", pendingIds.size());
-    }
-
-    private long deleteRecordsReferencedInStagingTable() throws SQLException {
-        long records_deleted;
-        String statementString = String.format(
-                "DELETE FROM %s WHERE %s IN (SELECT id FROM %s)",
-                targetTable, idColumn, stagingTable);
+    // queryString must be a SQL query which returns results which includes a field "host" with the hostname() of the replica responding, and field outputField
+    private boolean allReplicasReportSameValue(String queryString, String outputField) throws SQLException, DaoException {
+        boolean allReplicasAreAsExpected = false;
+        Set<String> allReplicaHostNames = getReplicaHostnames();
         Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
-        try (PreparedStatement stmt = con.prepareStatement(statementString)) {
-            records_deleted = stmt.executeUpdate();
+        try (PreparedStatement pstmt = con.prepareStatement(queryString);
+                ResultSet rs = pstmt.executeQuery()) {
+            boolean anUnexpectedResultWasSeen = false;
+            Set<String> reportedReplicaHostNames = new HashSet<>();
+            String valueToBeMatched = null;
+            while (rs.next()) {
+                String replicaHostname = rs.getString("host");
+                reportedReplicaHostNames.add(replicaHostname);
+                String resultOnReplica = rs.getString(outputField);
+                if (valueToBeMatched == null) {
+                    valueToBeMatched = resultOnReplica;
+                }
+                if (!valueToBeMatched.equals(resultOnReplica)) {
+                    log.warn(String.format(
+                            "waiting to reach consistent result for query '%s' : saw differing results '%s' and '%s'",
+                            queryString,
+                            valueToBeMatched,
+                            resultOnReplica));
+                    anUnexpectedResultWasSeen = true;
+                    break;
+                }
+            }
+            if (!reportedReplicaHostNames.containsAll(allReplicaHostNames)) {
+                // .containsAll() was used instead of .equals() because if additional replicas became active while the query was running,
+                // that is still acceptable so long as the new replicas all report the expected result. we might worry about additional non-responding replicas...
+                log.warn(String.format(
+                        "while querying all replicas using query '%s' : either the replica set was reduced during the query execution or one or more replicas failed to be evaluated. waiting will continue. All replicas : %s ; Reported replicas : %s",
+                        queryString,
+                        String.join(", ", allReplicaHostNames),
+                        String.join(", ", reportedReplicaHostNames)));
+            } else {
+                if (!anUnexpectedResultWasSeen) {
+                    allReplicasAreAsExpected = true;
+                }
+            }
         } finally {
             JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
         }
-        return records_deleted;
+        return allReplicasAreAsExpected;
     }
 
-    private boolean allReplicasCompletedDeletion() throws SQLException, DaoException {
-        String getUndeletedRecordCountsString = String.format(
-                "SELECT hostname() as host, count() as record_count FROM clusterAllReplicas('default', current_database(), %s) WHERE %s IN (SELECT id from %s) GROUP BY host",
-                targetTable, idColumn, stagingTable);
-        return allReplicasReportExpectedResult(getUndeletedRecordCountsString, "record_count", 0);
+// helper functions which query the database directly
+//
+    private Set<String> getReplicaHostnames() throws SQLException {
+        Set<String> hostnameSet = new HashSet<>();
+        Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
+        String getHostNamesQueryString = "SELECT hostname() as host from clusterAllReplicas('default', 'system', 'one') GROUP BY host";
+        try (PreparedStatement pstmt = con.prepareStatement(getHostNamesQueryString);
+                ResultSet rs = pstmt.executeQuery()) {
+            while (rs.next()) {
+                hostnameSet.add(rs.getString("host"));
+            }
+        } finally {
+            JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
+        }
+        if (hostnameSet.isEmpty()) {
+            throw new SQLException(String.format(
+                    "unable to find set of active replica hosts using query : %s",
+                    getHostNamesQueryString));
+        }
+        return hostnameSet;
     }
 
-    private byte[] buildTsvPayload() throws IOException {
+    private byte[] buildTsvPayload() throws DaoException {
         try (ByteArrayOutputStream buffer = new ByteArrayOutputStream()) {
             // header row
             buffer.write("id\n".getBytes(StandardCharsets.UTF_8));
@@ -362,6 +602,8 @@ public class ClickHouseBulkDeleter {
                 buffer.write((id.toString() + "\n").getBytes(StandardCharsets.UTF_8));
             }
             return buffer.toByteArray();
+        } catch (IOException e) {
+            throw new DaoException(e);
         }
     }
 }

--- a/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseBulkDeleter.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseBulkDeleter.java
@@ -59,33 +59,18 @@ import org.slf4j.LoggerFactory;
 public class ClickHouseBulkDeleter {
 
     private static final Map<String, ClickHouseBulkDeleter> BULK_DELETERS = new LinkedHashMap<>();
+    private static final Logger log = LoggerFactory.getLogger(ClickHouseBulkDeleter.class);
 
     private final String targetTable;
     private final String idColumn;
     private final String stagingTable;
     private final Set<Long> pendingIds = new HashSet<>();
 
-    private static final Logger log = LoggerFactory.getLogger(ClickHouseBulkDeleter.class);
-
-    private ClickHouseBulkDeleter(String targetTable, String idColumn) {
-        this.targetTable = targetTable;
-        this.idColumn = idColumn;
-        this.stagingTable = String.format("staging_delete_%s", targetTable);
-    }
+    // --- static methods ---
 
     public static ClickHouseBulkDeleter getBulkDeleter(String targetTable, String idColumn) {
         String key = String.format("%s:%s", targetTable, idColumn);
         return BULK_DELETERS.computeIfAbsent(key, k -> new ClickHouseBulkDeleter(targetTable, idColumn));
-    }
-
-    public void addId(long id) {
-        pendingIds.add(id);
-    }
-
-    public void addIds(Collection<? extends Number> ids) {
-        for (Number id : ids) {
-            pendingIds.add(id.longValue());
-        }
     }
 
     public static long flushAll() throws DaoException {
@@ -116,7 +101,7 @@ public class ClickHouseBulkDeleter {
         BULK_DELETERS.clear();
     }
 
-    private static void createAllStagingTables() throws SQLException {
+    private static void createAllStagingTables() throws SQLException, DaoException {
         for (ClickHouseBulkDeleter deleter : BULK_DELETERS.values()) {
             Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
             String createTableStatementString = String.format(
@@ -128,16 +113,13 @@ public class ClickHouseBulkDeleter {
                 JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
             }
         }
-        // wait for table existence to propagate to replicas (if they exist)
         for (ClickHouseBulkDeleter deleter : BULK_DELETERS.values()) {
-            Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
-            String alterTableStatementString = String.format(
-                    "ALTER TABLE %s MODIFY COMMENT 'Transient' SETTINGS mutations_sync = 3",
-                    deleter.stagingTable);
-            try (PreparedStatement stmt = con.prepareStatement(alterTableStatementString)) {
-                stmt.executeUpdate();
-            } finally {
-                JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
+            final int MAX_RETRY_SECONDS = 600;
+            if (! deleter.conditionIsTrueAfterTestWithRetry(deleter::allReplicasReportStagingTableExists, MAX_RETRY_SECONDS)) {
+                String exceptionMsgString = String.format(
+                        "Failed to see all replicas report existence of staging table %s after creation",
+                        deleter.stagingTable);
+                throw new DaoException(exceptionMsgString);
             }
         }
     }
@@ -152,74 +134,14 @@ public class ClickHouseBulkDeleter {
         //     inserted into the first table to be recognized / become visible in the other replica nodes
         //     running in a Clickhouse cluster (such as with clickhouse.cloud). This may avoid retry cycles.
         for (ClickHouseBulkDeleter deleter : BULK_DELETERS.values()) {
-            if (! deleter.allReplicasReachedRecordCount()) {
+            final int MAX_RETRY_SECONDS = 600;
+            if (! deleter.conditionIsTrueAfterTestWithRetry(deleter::allReplicasReportExpectedStagingTableRecordCount, MAX_RETRY_SECONDS)) {
                 String exceptionMsgString = String.format(
                         "Failed to see all replicas reflect delete list inserted into table %s",
                         deleter.stagingTable);
                 throw new DaoException(exceptionMsgString);
             }
         }
-    }
-
-    private void populateStagingTable() throws SQLException, IOException {
-        if (pendingIds.isEmpty()) {
-            return;
-        }
-        // Insert IDs into staging table via TSV stream
-        byte[] payload = buildTsvPayload();
-        String insertStatementString = String.format(
-                "INSERT INTO %s (id) FORMAT TSVWithNames",
-                stagingTable);
-        Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
-        try (PreparedStatement stmt = con.prepareStatement(insertStatementString)) {
-            stmt.setBinaryStream(1, new ByteArrayInputStream(payload));
-            stmt.executeUpdate();
-        } finally {
-            JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
-        }
-    }
-
-    private boolean allReplicasReachedRecordCount() throws SQLException {
-        int WAIT_CYCLE_MAX_COUNT = 60;
-        int WAIT_CYCLE_PERIOD_SECONDS = 10;
-        int WAIT_CYCLE_TOLERATE_EXCEPTION_LIMIT = 6;
-        int exceptions_ignored = 0;
-        for (int cycle = 0 ; cycle < WAIT_CYCLE_MAX_COUNT ; cycle = cycle + 1) {
-            String getRecordCountsString = String.format(
-                    "SELECT hostname() as host, COUNT() as record_count FROM clusterAllReplicas('default', current_database(), %s) GROUP BY host",
-                    stagingTable);
-            Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
-            try (PreparedStatement pstmt = con.prepareStatement(getRecordCountsString);
-                    ResultSet rs = pstmt.executeQuery()) {
-                boolean recordCountWasReached = true;
-                while (rs.next()) {
-                    long recordCountOnReplica = rs.getInt("record_count");
-                    if (recordCountOnReplica != pendingIds.size()) {
-                        log.warn(String.format(
-                                "waiting to reach record count in table %s : expected %d saw %d",
-                                stagingTable,
-                                pendingIds.size(),
-                                recordCountOnReplica));
-                        recordCountWasReached = false;
-                        break;
-                    }
-                }
-                if (recordCountWasReached) {
-                    return true;
-                }
-                Thread.sleep(1000 * WAIT_CYCLE_PERIOD_SECONDS);
-            } catch (SQLException e) {
-                if (exceptions_ignored >= WAIT_CYCLE_TOLERATE_EXCEPTION_LIMIT) {
-                    throw e;
-                }
-                exceptions_ignored = exceptions_ignored + 1;
-            } catch (InterruptedException ie) {
-                // ignore : ok to go on to next cycle immediately
-            } finally {
-                JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
-            }
-        }
-        return false;
     }
 
     private static long deleteRecordsReferencedInStagingTables() throws SQLException {
@@ -230,62 +152,11 @@ public class ClickHouseBulkDeleter {
         return totalDeleted;
     }
 
-    private long deleteRecordsReferencedInStagingTable() throws SQLException {
-        long records_deleted;
-        String statementString = String.format(
-                "DELETE FROM %s WHERE %s IN (SELECT id FROM %s)",
-                targetTable, idColumn, stagingTable);
-        Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
-        try (PreparedStatement stmt = con.prepareStatement(statementString)) {
-            records_deleted = stmt.executeUpdate();
-        } finally {
-            JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
-        }
-        return records_deleted;
-    }
-
-    private boolean allReplicasCompletedDeletion() throws SQLException {
-        int WAIT_CYCLE_MAX_COUNT = 60;
-        int WAIT_CYCLE_PERIOD_SECONDS = 10;
-        int WAIT_CYCLE_TOLERATE_EXCEPTION_LIMIT = 6;
-        int exceptions_ignored = 0;
-        for (int cycle = 0 ; cycle < WAIT_CYCLE_MAX_COUNT ; cycle = cycle + 1) {
-            String getUndeletedRecordCountsString = String.format(
-                    "SELECT hostname() as host, COUNT() as record_count FROM clusterAllReplicas('default', current_database(), %s) WHERE %s IN (SELECT id from %s) GROUP BY host",
-                    targetTable, idColumn, stagingTable);
-            Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
-            try (PreparedStatement pstmt = con.prepareStatement(getUndeletedRecordCountsString);
-                    ResultSet rs = pstmt.executeQuery()) {
-                boolean allRecordsWereDeleted = true;
-                while (rs.next()) {
-                    long undeletedRecordCountOnReplica = rs.getInt("record_count");
-                    if (undeletedRecordCountOnReplica != 0) {
-                        allRecordsWereDeleted = false;
-                        break;
-                    }
-                }
-                if (allRecordsWereDeleted) {
-                    return true;
-                }
-                Thread.sleep(1000 * WAIT_CYCLE_PERIOD_SECONDS);
-            } catch (SQLException e) {
-                if (exceptions_ignored >= WAIT_CYCLE_TOLERATE_EXCEPTION_LIMIT) {
-                    log.error("Over the limit of exceptions in allreplicasCompletedDeletion() .. re-throwing " + e.getMessage());
-                    throw e;
-                }
-                exceptions_ignored = exceptions_ignored + 1;
-            } catch (InterruptedException ie) {
-                // ignore : ok to go on to next cycle immediately
-            } finally {
-                JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
-            }
-        }
-        return false;
-    }
     private static void dropAnyExistingStagingTables(boolean deletionHasBeenExecuted) throws SQLException, DaoException {
         for (ClickHouseBulkDeleter deleter : BULK_DELETERS.values()) {
             // wait until all ids in the stagingTable table have been fully deleted from the target table
-            if (deletionHasBeenExecuted && ! deleter.allReplicasCompletedDeletion()) {
+            final int MAX_RETRY_SECONDS = 600;
+            if (deletionHasBeenExecuted && ! deleter.conditionIsTrueAfterTestWithRetry(deleter::allReplicasCompletedDeletion, MAX_RETRY_SECONDS)) {
                 String exceptionMessageString = String.format(
                         "Failed to complete the delete operation on all replicas for table %s",
                         deleter.stagingTable);
@@ -309,6 +180,177 @@ public class ClickHouseBulkDeleter {
                 JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
             }
         }
+    }
+
+    // --- instance methods ---
+
+    public void addId(long id) {
+        pendingIds.add(id);
+    }
+
+    public void addIds(Collection<? extends Number> ids) {
+        for (Number id : ids) {
+            pendingIds.add(id.longValue());
+        }
+    }
+
+    private ClickHouseBulkDeleter(String targetTable, String idColumn) {
+        this.targetTable = targetTable;
+        this.idColumn = idColumn;
+        this.stagingTable = String.format("staging_delete_%s", targetTable);
+    }
+
+    private void populateStagingTable() throws SQLException, IOException {
+        if (pendingIds.isEmpty()) {
+            return;
+        }
+        // Insert IDs into staging table via TSV stream
+        byte[] payload = buildTsvPayload();
+        String insertStatementString = String.format(
+                "INSERT INTO %s (id) FORMAT TSVWithNames",
+                stagingTable);
+        Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
+        try (PreparedStatement stmt = con.prepareStatement(insertStatementString)) {
+            stmt.setBinaryStream(1, new ByteArrayInputStream(payload));
+            stmt.executeUpdate();
+        } finally {
+            JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
+        }
+    }
+
+    @FunctionalInterface
+    private interface ConditionPredicate {
+        boolean conditionIsSatisfied() throws SQLException, DaoException;
+    }
+
+    private boolean conditionIsTrueAfterTestWithRetry(ConditionPredicate conPred, int maxTestingSeconds) throws SQLException, DaoException {
+        int WAIT_CYCLE_PERIOD_SECONDS = 10;
+        int WAIT_CYCLE_MAX_COUNT = maxTestingSeconds / WAIT_CYCLE_PERIOD_SECONDS;
+        int WAIT_CYCLE_TOLERATE_EXCEPTION_LIMIT = 6;
+        int exceptionsEncountered = 0;
+        boolean returnValue = false;
+        for (int cycle = 0 ; cycle < WAIT_CYCLE_MAX_COUNT ; cycle = cycle + 1) {
+            try {
+                if (conPred.conditionIsSatisfied()) {
+                    returnValue = true;
+                    break;
+                }
+            } catch (SQLException e) {
+                exceptionsEncountered = exceptionsEncountered + 1;
+                if (exceptionsEncountered > WAIT_CYCLE_TOLERATE_EXCEPTION_LIMIT) {
+                    throw e;
+                }
+            } finally {
+                if (returnValue == false && cycle < WAIT_CYCLE_MAX_COUNT - 1 && exceptionsEncountered <= WAIT_CYCLE_TOLERATE_EXCEPTION_LIMIT) {
+                    // sleep if we will be trying another iteration
+                    try {
+                        Thread.sleep(1000 * WAIT_CYCLE_PERIOD_SECONDS);
+                    } catch (InterruptedException ie) {
+                        // allow sleep interruption, and go on to next cycle immediately
+                        Thread.currentThread().interrupt(); // set interrupted status, in case we want to adjust for interrupted sleep
+                    }
+                }
+            }
+        }
+        return returnValue;
+    }
+
+    private Set<String> getReplicaHostnames() throws SQLException, DaoException {
+        Set<String> hostnameSet = new HashSet<>();
+        Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
+        String getHostNamesQueryString = "SELECT hostname() as host from clusterAllReplicas('default', 'system', 'one') GROUP BY host";
+        try (PreparedStatement pstmt = con.prepareStatement(getHostNamesQueryString);
+                ResultSet rs = pstmt.executeQuery()) {
+            while (rs.next()) {
+                hostnameSet.add(rs.getString("host"));
+            }
+        } finally {
+            JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
+        }
+        if (hostnameSet.isEmpty()) {
+            throw new DaoException(String.format(
+                    "unable to find set of active replica hosts using query : %s",
+                    getHostNamesQueryString));
+        }
+        return hostnameSet;
+    }
+
+    // queryString must be a SQL query which returns results which includes a field "host" with the hostname() of the replica responding. "SELECT hostname() as host..."
+    private boolean allReplicasReportExpectedResult(String queryString, String outputField, long expectedResult) throws SQLException, DaoException {
+        boolean allReplicasAreAsExpected = false;
+        Set<String> allReplicaHostNames = getReplicaHostnames();
+        Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
+        try (PreparedStatement pstmt = con.prepareStatement(queryString);
+                ResultSet rs = pstmt.executeQuery()) {
+            boolean anUnexpectedResultWasSeen = false;
+            Set<String> reportedReplicaHostNames = new HashSet<>();
+            while (rs.next()) {
+                String replicaHostname = rs.getString("host");
+                reportedReplicaHostNames.add(replicaHostname);
+                long resultOnReplica = rs.getLong(outputField);
+                if (resultOnReplica != expectedResult) {
+                    log.warn(String.format(
+                            "waiting to reach expected result for query '%s' : expected %d saw %d on replica %s",
+                            queryString,
+                            expectedResult,
+                            resultOnReplica,
+                            replicaHostname));
+                    anUnexpectedResultWasSeen = true;
+                    break;
+                }
+            }
+            if (!reportedReplicaHostNames.containsAll(allReplicaHostNames)) {
+                // .containsAll() was used instead of .equals() because if additional replicas became active while the query was running,
+                // that is still acceptable so long as the new replicas all report the expected result. we might worry about additional non-responding replicas...
+                log.warn(String.format(
+                        "while querying all replicas using query '%s' : either the replica set was reduced during the query execution or one or more replicas failed to be evaluated. waiting will continue. All replicas : %s ; Reported replicas : %s",
+                        queryString,
+                        String.join(", ", allReplicaHostNames),
+                        String.join(", ", reportedReplicaHostNames)));
+            } else {
+                if (!anUnexpectedResultWasSeen) {
+                    allReplicasAreAsExpected = true;
+                }
+            }
+        } finally {
+            JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
+        }
+        return allReplicasAreAsExpected;
+    }
+
+    private boolean allReplicasReportStagingTableExists() throws SQLException, DaoException {
+        String getTableExistsString = String.format(
+                "SELECT hostname() as host, count() as table_exists FROM clusterAllReplicas('default', 'system', 'tables') where database = current_database() and name = '%s' GROUP BY host",
+                stagingTable);
+        return allReplicasReportExpectedResult(getTableExistsString, "table_exists", 1);
+    }
+
+    private boolean allReplicasReportExpectedStagingTableRecordCount() throws SQLException, DaoException {
+        String getRecordCountsString = String.format(
+                "SELECT hostname() as host, count() as record_count FROM clusterAllReplicas('default', current_database(), %s) GROUP BY host",
+                stagingTable);
+        return allReplicasReportExpectedResult(getRecordCountsString, "record_count", pendingIds.size());
+    }
+
+    private long deleteRecordsReferencedInStagingTable() throws SQLException {
+        long records_deleted;
+        String statementString = String.format(
+                "DELETE FROM %s WHERE %s IN (SELECT id FROM %s)",
+                targetTable, idColumn, stagingTable);
+        Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
+        try (PreparedStatement stmt = con.prepareStatement(statementString)) {
+            records_deleted = stmt.executeUpdate();
+        } finally {
+            JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
+        }
+        return records_deleted;
+    }
+
+    private boolean allReplicasCompletedDeletion() throws SQLException, DaoException {
+        String getUndeletedRecordCountsString = String.format(
+                "SELECT hostname() as host, count() as record_count FROM clusterAllReplicas('default', current_database(), %s) WHERE %s IN (SELECT id from %s) GROUP BY host",
+                targetTable, idColumn, stagingTable);
+        return allReplicasReportExpectedResult(getUndeletedRecordCountsString, "record_count", 0);
     }
 
     private byte[] buildTsvPayload() throws IOException {

--- a/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseBulkDeleter.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseBulkDeleter.java
@@ -70,6 +70,16 @@ public class ClickHouseBulkDeleter {
     private final Set<Long> pendingIds = new HashSet<>();
     private boolean flushed; // once flushed, any particular deleter instance cannot not be flushed again
 
+    public enum AllReplicaTestType {
+        CONSISTENT,
+        EXPECTED_VALUE
+    }
+
+    public enum AllReplicaCriterionType {
+        LONG,
+        STRING
+    }
+
 // --- Interface ---
 
     public static ClickHouseBulkDeleter getBulkDeleter(String targetTable, String idColumn) {
@@ -129,7 +139,7 @@ public class ClickHouseBulkDeleter {
     private static boolean anyDeleterWasAlreadyFlushed(List<ClickHouseBulkDeleter> deleters) {
         return deleters.stream().anyMatch(d -> d.wasFlushed());
     }
- 
+
     // returns only the deleters which might delete anything (duplicates discarded)
     private static List<ClickHouseBulkDeleter> deletersWithPendingDeletes(List<ClickHouseBulkDeleter> deleters) {
         List<ClickHouseBulkDeleter> effectiveDeleters = new ArrayList<>();
@@ -383,35 +393,31 @@ public class ClickHouseBulkDeleter {
         String getTableExistsString = String.format(
                 "SELECT hostname() as host, count() as table_exists FROM clusterAllReplicas('default', 'system', 'tables') where database = current_database() and name = '%s' GROUP BY host",
                 stagingTable);
-        return allReplicasReportExpectedResult(getTableExistsString, "table_exists", 1);
+        return allReplicasReportExpectedResult(getTableExistsString, "table_exists", AllReplicaTestType.EXPECTED_VALUE, AllReplicaCriterionType.LONG, 1L);
     }
 
-// TODO : change this to simply look for the record count in system.tables (faster/more consistent)
     private boolean allReplicasReportExpectedStagingTableRecordCount() throws SQLException, DaoException {
         String getRecordCountsString = String.format(
-                "SELECT hostname() as host, count() as record_count FROM clusterAllReplicas('default', current_database(), %s) GROUP BY host",
+                "SELECT hostname() as host, total_rows as total_rows FROM clusterAllReplicas('default', 'system', 'tables') where database = current_database() and name = '%s'",
                 stagingTable);
-        return allReplicasReportExpectedResult(getRecordCountsString, "record_count", pendingIds.size());
+        return allReplicasReportExpectedResult(getRecordCountsString, "total_rows", AllReplicaTestType.EXPECTED_VALUE, AllReplicaCriterionType.LONG, new Long(pendingIds.size()));
     }
 
     private boolean deletionIsComplete() throws SQLException, DaoException {
         String getUndeletedRecordCountsString = String.format(
                 "SELECT count() as record_count FROM %s WHERE %s IN (SELECT id from %s)",
                 targetTable, idColumn, stagingTable);
-        return queryProducedExpectedResult(getUndeletedRecordCountsString, "record_count", 0);
+        return queryProducedExpectedResult(getUndeletedRecordCountsString, "record_count", 0L);
     }
 
     private boolean allReplicasReportSameMetadataForTargetTable() throws SQLException, DaoException {
         String selectClause = "SELECT hostname() as host, metadata_modification_time as field_value";
-        String fromClause = "FROM clusterAllReplicas('default', system, tables)";
+        String fromClause = "FROM clusterAllReplicas('default', 'system', 'tables')";
         String whereClause = "WHERE database = current_database() AND name = ";
         String getMetadataString = String.format(
                 "%s %s %s '%s'",
-                selectClause,
-                fromClause,
-                whereClause,
-                targetTable);
-        return allReplicasReportSameValue(getMetadataString, "field_value");
+                selectClause, fromClause, whereClause, targetTable);
+        return allReplicasReportExpectedResult(getMetadataString, "field_value", AllReplicaTestType.CONSISTENT, AllReplicaCriterionType.STRING, null);
     }
 
 // reusable logic to perform test/retry loops for database queries with criteria
@@ -481,98 +487,78 @@ public class ClickHouseBulkDeleter {
         return true;
     }
 
-//ROB : todo : consolidate the next two methods
     // queryString must be a SQL query which returns results which includes a field "host" with the hostname() of the replica responding. "SELECT hostname() as host..."
-    private boolean allReplicasReportExpectedResult(String queryString, String outputField, long expectedResult) throws SQLException, DaoException {
-        boolean allReplicasAreAsExpected = false;
+    // with testType AllReplicaTestType.CONSISTENT, the expectedValue argument is ignored (pass null)
+    private boolean allReplicasReportExpectedResult(String queryString, String outputField, AllReplicaTestType testType, AllReplicaCriterionType criterionType, Object expectedValue) throws SQLException, DaoException {
         Set<String> allReplicaHostNames = getReplicaHostnames();
-        Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
-        try (PreparedStatement pstmt = con.prepareStatement(queryString);
-                ResultSet rs = pstmt.executeQuery()) {
-            boolean anUnexpectedResultWasSeen = false;
-            Set<String> reportedReplicaHostNames = new HashSet<>();
-            while (rs.next()) {
-                String replicaHostname = rs.getString("host");
-                reportedReplicaHostNames.add(replicaHostname);
-                long resultOnReplica = rs.getLong(outputField);
-                if (resultOnReplica != expectedResult) {
-                    log.warn(String.format(
-                            "waiting to reach expected result for query '%s' : expected %d saw %d on replica %s",
-                            queryString,
-                            expectedResult,
-                            resultOnReplica,
-                            replicaHostname));
-                    anUnexpectedResultWasSeen = true;
-                    break;
-                }
-            }
-            if (!reportedReplicaHostNames.containsAll(allReplicaHostNames)) {
-                // .containsAll() was used instead of .equals() because if additional replicas became active while the query was running,
-                // that is still acceptable so long as the new replicas all report the expected result. we might worry about additional non-responding replicas...
-                log.warn(String.format(
-                        "while querying all replicas using query '%s' : either the replica set was reduced during the query execution or one or more replicas failed to be evaluated. waiting will continue. All replicas : %s ; Reported replicas : %s",
-                        queryString,
-                        String.join(", ", allReplicaHostNames),
-                        String.join(", ", reportedReplicaHostNames)));
-            } else {
-                if (!anUnexpectedResultWasSeen) {
-                    allReplicasAreAsExpected = true;
-                }
-            }
-        } finally {
-            JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
+        Map<String, Object> replicaValueMap = getReportedResultFromAllReplicas(queryString, criterionType, outputField);
+        if (replicaValueMap.isEmpty()) {
+            return false; // for this purpose, at least one replica must report a match
         }
-        return allReplicasAreAsExpected;
+        Collection<Object> values = replicaValueMap.values();
+        switch (testType) {
+            case AllReplicaTestType.CONSISTENT:
+                Object firstValue = values.iterator().next();
+                if (!values.stream().allMatch(value -> firstValue.equals(value))) {
+                    log.warn(String.format(
+                            "waiting to reach expected result for query '%s' : expected consistent values but saw: %s",
+                            queryString,
+                            replicaValueMap.toString()));
+                    return false;
+                }
+                break;
+            case AllReplicaTestType.EXPECTED_VALUE:
+                if (!values.stream().allMatch(value -> expectedValue.equals(value))) {
+                    log.warn(String.format(
+                            "waiting to reach expected result for query '%s' : expected %d as value but saw: %s",
+                            queryString,
+                            expectedValue,
+                            replicaValueMap.toString()));
+                    return false;
+                }
+                break;
+            default:
+                throw new DaoException("Unknown testType argument passed to allReplicasReportExpectedResult()");
+        }
+        if (!replicaValueMap.keySet().containsAll(allReplicaHostNames)) {
+            // .containsAll() was used instead of .equals() because if additional replicas became active while the query was running,
+            // that is still acceptable so long as the new replicas all report the expected result. we might worry about additional non-responding replicas...
+            log.warn(String.format(
+                    "while querying all replicas using query '%s' : either the replica set was reduced during the query execution or one or more replicas failed to be evaluated. waiting will continue. All replicas : %s ; Reported replicas : %s",
+                    queryString,
+                    String.join(", ", allReplicaHostNames),
+                    String.join(", ", replicaValueMap.keySet())));
+            return false;
+        }
+        return true;
     }
 
-    // queryString must be a SQL query which returns results which includes a field "host" with the hostname() of the replica responding, and field outputField
-    private boolean allReplicasReportSameValue(String queryString, String outputField) throws SQLException, DaoException {
-        boolean allReplicasAreAsExpected = false;
-        Set<String> allReplicaHostNames = getReplicaHostnames();
+    private Map<String, Object> getReportedResultFromAllReplicas(String queryString, AllReplicaCriterionType outputType, String outputField) throws SQLException, DaoException {
+        Map<String, Object> replicaValueMap = new LinkedHashMap<>();
         Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
         try (PreparedStatement pstmt = con.prepareStatement(queryString);
                 ResultSet rs = pstmt.executeQuery()) {
-            boolean anUnexpectedResultWasSeen = false;
-            Set<String> reportedReplicaHostNames = new HashSet<>();
-            String valueToBeMatched = null;
             while (rs.next()) {
                 String replicaHostname = rs.getString("host");
-                reportedReplicaHostNames.add(replicaHostname);
-                String resultOnReplica = rs.getString(outputField);
-                if (valueToBeMatched == null) {
-                    valueToBeMatched = resultOnReplica;
-                }
-                if (!valueToBeMatched.equals(resultOnReplica)) {
-                    log.warn(String.format(
-                            "waiting to reach consistent result for query '%s' : saw differing results '%s' and '%s'",
-                            queryString,
-                            valueToBeMatched,
-                            resultOnReplica));
-                    anUnexpectedResultWasSeen = true;
-                    break;
-                }
-            }
-            if (!reportedReplicaHostNames.containsAll(allReplicaHostNames)) {
-                // .containsAll() was used instead of .equals() because if additional replicas became active while the query was running,
-                // that is still acceptable so long as the new replicas all report the expected result. we might worry about additional non-responding replicas...
-                log.warn(String.format(
-                        "while querying all replicas using query '%s' : either the replica set was reduced during the query execution or one or more replicas failed to be evaluated. waiting will continue. All replicas : %s ; Reported replicas : %s",
-                        queryString,
-                        String.join(", ", allReplicaHostNames),
-                        String.join(", ", reportedReplicaHostNames)));
-            } else {
-                if (!anUnexpectedResultWasSeen) {
-                    allReplicasAreAsExpected = true;
+                switch (outputType) {
+                    case LONG:
+                        replicaValueMap.put(replicaHostname, rs.getLong(outputField));
+                        break;
+                    case STRING:
+                        replicaValueMap.put(replicaHostname, rs.getString(outputField));
+                        break;
+                    default:
+                        throw new DaoException("Unknown outputType argument passed to getReportedResultFromAllReplicas()");
                 }
             }
         } finally {
             JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
         }
-        return allReplicasAreAsExpected;
+        return replicaValueMap;
     }
 
 // helper functions which query the database directly
-//
+
     private Set<String> getReplicaHostnames() throws SQLException {
         Set<String> hostnameSet = new HashSet<>();
         Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);

--- a/src/main/java/org/mskcc/cbio/portal/dao/DaoCancerStudy.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/DaoCancerStudy.java
@@ -509,17 +509,17 @@ public final class DaoCancerStudy {
             DaoGenericAssay.checkAndDeleteGenericAssayMetaInStudy(internalCancerStudyId);
             
             String geneticProfileIdQuery = "SELECT genetic_profile_id FROM genetic_profile WHERE cancer_study_id=?";
-            List<Integer> geneticProfileIds = collectIds(geneticProfileIdQuery, internalCancerStudyId);
+            List<Long> geneticProfileIds = collectIds(geneticProfileIdQuery, internalCancerStudyId);
             String patientIdQuery = "SELECT internal_id FROM patient WHERE cancer_study_id=?";
-            List<Integer> patientIds = collectIds(patientIdQuery, internalCancerStudyId);
+            List<Long> patientIds = collectIds(patientIdQuery, internalCancerStudyId);
             String sampleIdQuery = "SELECT internal_id FROM sample WHERE patient_id IN (SELECT internal_id FROM patient WHERE cancer_study_id=?)";
-            List<Integer> sampleIds = collectIds(sampleIdQuery, internalCancerStudyId);
+            List<Long> sampleIds = collectIds(sampleIdQuery, internalCancerStudyId);
             String sampleListIdQuery = "SELECT list_id FROM sample_list WHERE cancer_study_id=?";
-            List<Integer> sampleListIds = collectIds(sampleListIdQuery, internalCancerStudyId);
+            List<Long> sampleListIds = collectIds(sampleListIdQuery, internalCancerStudyId);
             String clinicalEventIdQuery = "SELECT clinical_event_id FROM clinical_event WHERE patient_id IN (SELECT internal_id FROM patient WHERE cancer_study_id=?)";
-            List<Integer> clinicalEventIds = collectIds(clinicalEventIdQuery, internalCancerStudyId);
+            List<Long> clinicalEventIds = collectIds(clinicalEventIdQuery, internalCancerStudyId);
             String gisticIdQuery = "SELECT gistic_roi_id FROM gistic WHERE cancer_study_id=?";
-            List<Integer> gisticIds = collectIds(gisticIdQuery, internalCancerStudyId);
+            List<Long> gisticIds = collectIds(gisticIdQuery, internalCancerStudyId);
 
             ClickHouseBulkDeleter.getBulkDeleter("sample_cna_event", "genetic_profile_id").addIds(geneticProfileIds);
             ClickHouseBulkDeleter.getBulkDeleter("genetic_alteration", "genetic_profile_id").addIds(geneticProfileIds);
@@ -597,8 +597,8 @@ public final class DaoCancerStudy {
         }
     }
 
-    private static List<Integer> collectIds(String sql, int cancerStudyId) throws SQLException {
-        List<Integer> ids = new ArrayList<>();
+    private static List<Long> collectIds(String sql, int cancerStudyId) throws SQLException {
+        List<Long> ids = new ArrayList<>();
         Connection con = null;
         try {
             con = JdbcUtil.getDbConnection(DaoCancerStudy.class);
@@ -606,7 +606,7 @@ public final class DaoCancerStudy {
                 pstmt.setInt(1, cancerStudyId);
                 try (ResultSet rs = pstmt.executeQuery()) {
                     while (rs.next()) {
-                        ids.add(rs.getInt(1));
+                        ids.add(rs.getLong(1));
                     }
                 }
             }

--- a/src/main/java/org/mskcc/cbio/portal/dao/DaoCancerStudy.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/DaoCancerStudy.java
@@ -508,21 +508,18 @@ public final class DaoCancerStudy {
             // check whether should delete generic assay meta profile by profile
             DaoGenericAssay.checkAndDeleteGenericAssayMetaInStudy(internalCancerStudyId);
             
-            con = JdbcUtil.getDbConnection(DaoCancerStudy.class);
-            List<Integer> geneticProfileIds = collectIds(con,
-                "SELECT genetic_profile_id FROM genetic_profile WHERE cancer_study_id=?", internalCancerStudyId);
-            List<Integer> patientIds = collectIds(con,
-                "SELECT internal_id FROM patient WHERE cancer_study_id=?", internalCancerStudyId);
-            List<Integer> sampleIds = collectIds(con,
-                "SELECT internal_id FROM sample WHERE patient_id IN (SELECT internal_id FROM patient WHERE cancer_study_id=?)",
-                internalCancerStudyId);
-            List<Integer> sampleListIds = collectIds(con,
-                "SELECT list_id FROM sample_list WHERE cancer_study_id=?", internalCancerStudyId);
-            List<Integer> clinicalEventIds = collectIds(con,
-                "SELECT clinical_event_id FROM clinical_event WHERE patient_id IN (SELECT internal_id FROM patient WHERE cancer_study_id=?)",
-                internalCancerStudyId);
-            List<Integer> gisticIds = collectIds(con,
-                "SELECT gistic_roi_id FROM gistic WHERE cancer_study_id=?", internalCancerStudyId);
+            String geneticProfileIdQuery = "SELECT genetic_profile_id FROM genetic_profile WHERE cancer_study_id=?";
+            List<Integer> geneticProfileIds = collectIds(geneticProfileIdQuery, internalCancerStudyId);
+            String patientIdQuery = "SELECT internal_id FROM patient WHERE cancer_study_id=?";
+            List<Integer> patientIds = collectIds(patientIdQuery, internalCancerStudyId);
+            String sampleIdQuery = "SELECT internal_id FROM sample WHERE patient_id IN (SELECT internal_id FROM patient WHERE cancer_study_id=?)";
+            List<Integer> sampleIds = collectIds(sampleIdQuery, internalCancerStudyId);
+            String sampleListIdQuery = "SELECT list_id FROM sample_list WHERE cancer_study_id=?";
+            List<Integer> sampleListIds = collectIds(sampleListIdQuery, internalCancerStudyId);
+            String clinicalEventIdQuery = "SELECT clinical_event_id FROM clinical_event WHERE patient_id IN (SELECT internal_id FROM patient WHERE cancer_study_id=?)";
+            List<Integer> clinicalEventIds = collectIds(clinicalEventIdQuery, internalCancerStudyId);
+            String gisticIdQuery = "SELECT gistic_roi_id FROM gistic WHERE cancer_study_id=?";
+            List<Integer> gisticIds = collectIds(gisticIdQuery, internalCancerStudyId);
 
             ClickHouseBulkDeleter.getBulkDeleter("sample_cna_event", "genetic_profile_id").addIds(geneticProfileIds);
             ClickHouseBulkDeleter.getBulkDeleter("genetic_alteration", "genetic_profile_id").addIds(geneticProfileIds);
@@ -550,26 +547,24 @@ public final class DaoCancerStudy {
 
             ClickHouseBulkDeleter.flushAll();
 
-            deleteByStudyId(con, "DELETE FROM clinical_attribute_meta WHERE cancer_study_id=?", internalCancerStudyId);
-            deleteByStudyId(con, "DELETE FROM resource_definition WHERE cancer_study_id=?", internalCancerStudyId);
-            deleteByStudyId(con, "DELETE FROM resource_study WHERE internal_id=?", internalCancerStudyId);
-            deleteByStudyId(con, "DELETE FROM cancer_study_tags WHERE cancer_study_id=?", internalCancerStudyId);
-            deleteByStudyId(con, "DELETE FROM copy_number_seg WHERE cancer_study_id=?", internalCancerStudyId);
-            deleteByStudyId(con, "DELETE FROM copy_number_seg_file WHERE cancer_study_id=?", internalCancerStudyId);
-            deleteByStudyId(con, "DELETE FROM patient WHERE cancer_study_id=?", internalCancerStudyId);
-            deleteByStudyId(con, "DELETE FROM sample_list WHERE cancer_study_id=?", internalCancerStudyId);
-            deleteByStudyId(con, "DELETE FROM genetic_profile WHERE cancer_study_id=?", internalCancerStudyId);
-            deleteByStudyId(con, "DELETE FROM gistic WHERE cancer_study_id=?", internalCancerStudyId);
-            deleteByStudyId(con, "DELETE FROM mut_sig WHERE cancer_study_id=?", internalCancerStudyId);
-            deleteByStudyId(con, "DELETE FROM cancer_study WHERE cancer_study_id=?", internalCancerStudyId);
+            deleteByStudyId("DELETE FROM clinical_attribute_meta WHERE cancer_study_id=?", internalCancerStudyId);
+            deleteByStudyId("DELETE FROM resource_definition WHERE cancer_study_id=?", internalCancerStudyId);
+            deleteByStudyId("DELETE FROM resource_study WHERE internal_id=?", internalCancerStudyId);
+            deleteByStudyId("DELETE FROM cancer_study_tags WHERE cancer_study_id=?", internalCancerStudyId);
+            deleteByStudyId("DELETE FROM copy_number_seg WHERE cancer_study_id=?", internalCancerStudyId);
+            deleteByStudyId("DELETE FROM copy_number_seg_file WHERE cancer_study_id=?", internalCancerStudyId);
+            deleteByStudyId("DELETE FROM patient WHERE cancer_study_id=?", internalCancerStudyId);
+            deleteByStudyId("DELETE FROM sample_list WHERE cancer_study_id=?", internalCancerStudyId);
+            deleteByStudyId("DELETE FROM genetic_profile WHERE cancer_study_id=?", internalCancerStudyId);
+            deleteByStudyId("DELETE FROM gistic WHERE cancer_study_id=?", internalCancerStudyId);
+            deleteByStudyId("DELETE FROM mut_sig WHERE cancer_study_id=?", internalCancerStudyId);
+            deleteByStudyId("DELETE FROM cancer_study WHERE cancer_study_id=?", internalCancerStudyId);
 
             removeCancerStudyFromCache(internalCancerStudyId);
         } catch (DaoException e) {
             throw e;
         } catch (SQLException e) {
             throw new DaoException(e);
-        } finally {
-            JdbcUtil.closeAll(DaoCancerStudy.class, con, pstmt, rs);
         }
         purgeUnreferencedRecordsAfterDeletionOfStudy();
         reCacheAll();
@@ -602,27 +597,35 @@ public final class DaoCancerStudy {
         }
     }
 
-    private static List<Integer> collectIds(Connection con, String sql, int cancerStudyId) throws SQLException {
-        PreparedStatement pstmt = null;
-        ResultSet rs = null;
+    private static List<Integer> collectIds(String sql, int cancerStudyId) throws SQLException {
         List<Integer> ids = new ArrayList<>();
+        Connection con = null;
         try {
-            pstmt = con.prepareStatement(sql);
-            pstmt.setInt(1, cancerStudyId);
-            rs = pstmt.executeQuery();
-            while (rs.next()) {
-                ids.add(rs.getInt(1));
+            con = JdbcUtil.getDbConnection(DaoCancerStudy.class);
+            try (PreparedStatement pstmt = con.prepareStatement(sql)) {
+                pstmt.setInt(1, cancerStudyId);
+                try (ResultSet rs = pstmt.executeQuery()) {
+                    while (rs.next()) {
+                        ids.add(rs.getInt(1));
+                    }
+                }
             }
         } finally {
-            JdbcUtil.closeAll(DaoCancerStudy.class, null, pstmt, rs);
+            JdbcUtil.closeAll(DaoCancerStudy.class, con, null, null);
         }
         return ids;
     }
 
-    private static void deleteByStudyId(Connection con, String sql, int cancerStudyId) throws SQLException {
-        try (PreparedStatement pstmt = con.prepareStatement(sql)) {
-            pstmt.setInt(1, cancerStudyId);
-            pstmt.executeUpdate();
+    private static void deleteByStudyId(String sql, int cancerStudyId) throws SQLException {
+        Connection con = null;
+        try {
+            con = JdbcUtil.getDbConnection(DaoCancerStudy.class);
+            try (PreparedStatement pstmt = con.prepareStatement(sql)) {
+                pstmt.setInt(1, cancerStudyId);
+                pstmt.executeUpdate();
+            }
+        } finally {
+            JdbcUtil.closeAll(DaoCancerStudy.class, con, null, null);
         }
     }
 

--- a/src/main/java/org/mskcc/cbio/portal/dao/DaoPatient.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/DaoPatient.java
@@ -253,7 +253,7 @@ public class DaoPatient {
         Connection con = null;
         try {
             con = JdbcUtil.getDbConnection(DaoPatient.class);
-            List<Integer> clinicalEventIds = collectIds(con,
+            List<Long> clinicalEventIds = collectIds(con,
                     "SELECT clinical_event_id FROM clinical_event WHERE patient_id IN ", internalPatientIds);
             ClickHouseBulkDeleter.getBulkDeleter("clinical_event_data", "clinical_event_id").addIds(clinicalEventIds);
             ClickHouseBulkDeleter.getBulkDeleter("clinical_event", "clinical_event_id").addIds(clinicalEventIds);
@@ -287,16 +287,16 @@ public class DaoPatient {
         return internalPatientIds;
     }
 
-    private static List<Integer> collectIds(Connection con, String sqlPrefix, Collection<Integer> ids) throws DaoException, SQLException {
+    private static List<Long> collectIds(Connection con, String sqlPrefix, Collection<Integer> ids) throws DaoException, SQLException {
         if (ids == null || ids.isEmpty()) {
             return Collections.emptyList();
         }
         return ClickHouseBulkUploader.upload(ids, stagingTable -> {
-            List<Integer> collected = new ArrayList<>();
+            List<Long> collected = new ArrayList<>();
             try (PreparedStatement pstmt = con.prepareStatement(sqlPrefix + "(SELECT id FROM " + stagingTable + ")");
                  ResultSet rs = pstmt.executeQuery()) {
                 while (rs.next()) {
-                    collected.add(rs.getInt(1));
+                    collected.add(rs.getLong(1));
                 }
             }
             return collected;

--- a/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
+++ b/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2015 - 2018 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2015 - 2026 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -32,9 +32,13 @@
 
 package org.mskcc.cbio.portal.util;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
@@ -44,20 +48,16 @@ import org.slf4j.LoggerFactory;
  * Utility class for getting / setting global properties.
  */
 public class GlobalProperties {
-
     public static final String HOME_DIR = "PORTAL_HOME";
     private static final String PORTAL_PROPERTIES_FILE_NAME = "application.properties";
     private static final String POM_RESOURCE_PATH = "META-INF/maven/org.mskcc.cbio/core/pom.xml";
     private static final String DEFAULT_DB_VERSION = "0";
-    private static final Pattern DB_VERSION_PATTERN =
-        Pattern.compile("<db\\.version>\\s*([^<]+)\\s*</db\\.version>");
-
+    private static final Pattern DB_VERSION_PATTERN = Pattern.compile("<db\\.version>\\s*([^<]+)\\s*</db\\.version>");
     public static final String DB_VERSION = "db.version";
     public static final String SPECIES = "species";
     public static final String DEFAULT_SPECIES = "human";
     public static final String UCSC_BUILD = "ucsc.build";
     public static final String DEFAULT_UCSC_BUILD = "hg19";
-
     private static Logger LOG = LoggerFactory.getLogger(GlobalProperties.class);
     private static ConfigPropertyResolver portalProperties = new ConfigPropertyResolver();
     private static volatile String cachedDbVersion;
@@ -102,21 +102,17 @@ public class GlobalProperties {
         }
     }
 
-    private static Properties initializeProperties(String propertiesFileName)
-    {
+    private static Properties initializeProperties(String propertiesFileName) {
         return loadProperties(getResourceStream(propertiesFileName));
     }
 
-    private static InputStream getResourceStream(String propertiesFileName)
-    {
+    private static InputStream getResourceStream(String propertiesFileName) {
         String resourceFilename = null;
         InputStream resourceFIS = null;
-
         try {
             String home = System.getenv(HOME_DIR);
             if (home != null) {
-                 resourceFilename =
-                    home + File.separator + propertiesFileName;
+                 resourceFilename = home + File.separator + propertiesFileName;
                 if (LOG.isInfoEnabled()) {
                     LOG.info("Attempting to read properties file: " + resourceFilename);
                 }
@@ -125,101 +121,83 @@ public class GlobalProperties {
                     LOG.info("Successfully read properties file");
                 }
             }
-        }
-        catch (FileNotFoundException e) {
+        } catch (FileNotFoundException e) {
             if (LOG.isInfoEnabled()) {
                 LOG.info("Failed to read properties file: " + resourceFilename);
             }
         }
-
         if (resourceFIS == null) {
             if (LOG.isInfoEnabled()) {
                 LOG.info("Attempting to read properties file from classpath");
             }
-            resourceFIS = GlobalProperties.class.getClassLoader().
-                getResourceAsStream(propertiesFileName);
+            resourceFIS = GlobalProperties.class.getClassLoader().getResourceAsStream(propertiesFileName);
             if (LOG.isInfoEnabled()) {
                 LOG.info("Successfully read properties file");
             }
         }
-         
         return resourceFIS;
     }
 
-    private static Properties loadProperties(InputStream resourceInputStream)
-    {
+    private static Properties loadProperties(InputStream resourceInputStream) {
         Properties properties = new Properties();
-
         try {
             properties.load(resourceInputStream);
             resourceInputStream.close();
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
             if (LOG.isErrorEnabled()) {
                 LOG.error("Error loading properties file: " + e.getMessage());
             }
         }
-
         return properties;
     }
 
-    private static InputStream getPomResourceStream()
-    {
-        InputStream pomStream =
-            GlobalProperties.class.getClassLoader().getResourceAsStream(POM_RESOURCE_PATH);
+    private static InputStream getPomResourceStream() {
+        InputStream pomStream = GlobalProperties.class.getClassLoader().getResourceAsStream(POM_RESOURCE_PATH);
         if (pomStream != null) {
             return pomStream;
         }
-
         return null;
     }
 
-    private static String readDbVersionFromPom()
-    {
+    private static String readDbVersionFromPom() {
         try (InputStream pomStream = getPomResourceStream()) {
             if (pomStream == null) {
                 if (LOG.isWarnEnabled()) {
                     LOG.warn("Unable to locate pom.xml for db.version lookup. " +
-                        "Checked classpath resource " + POM_RESOURCE_PATH);
+                            "Checked classpath resource " + POM_RESOURCE_PATH);
                 }
                 return null;
             }
-
             String pomContents = new String(pomStream.readAllBytes(), StandardCharsets.UTF_8);
             Matcher matcher = DB_VERSION_PATTERN.matcher(pomContents);
             if (matcher.find()) {
                 return matcher.group(1).trim();
             }
-
             if (LOG.isWarnEnabled()) {
                 LOG.warn("db.version was not found in pom.xml.");
             }
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
             if (LOG.isErrorEnabled()) {
                 LOG.error("Error reading pom.xml for db.version: " + e.getMessage());
             }
         }
-
         return null;
     }
 
-	public static String getProperty(String property)
-	{
-		return (portalProperties.containsKey(property)) ? portalProperties.getProperty(property) : null;
-	}
+    public static String getProperty(String property) {
+        return (portalProperties.containsKey(property)) ? portalProperties.getProperty(property) : null;
+    }
 
-    public static String getSpecies(){
-    	String species = portalProperties.getProperty(SPECIES);
-    	return species == null ? DEFAULT_SPECIES : species;
-    	}
+    public static String getSpecies() {
+        String species = portalProperties.getProperty(SPECIES);
+        return species == null ? DEFAULT_SPECIES : species;
+    }
 
     public static String getDbVersion() {
         String override = System.getProperty(DB_VERSION);
         if (override != null) {
             return override;
         }
-
         if (cachedDbVersion == null) {
             synchronized (GlobalProperties.class) {
                 if (cachedDbVersion == null) {
@@ -228,12 +206,27 @@ public class GlobalProperties {
                 }
             }
         }
-
         return cachedDbVersion;
     }
 
     public static String getReferenceGenomeName() {
         return portalProperties.getProperty(UCSC_BUILD, DEFAULT_UCSC_BUILD);
+    }
+
+    public static Integer parseIntegerProperty(String key, Integer defaultValue) {
+        String valueString = getProperty(key);
+        if (valueString == null) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(valueString);
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+    public static Integer parseIntegerProperty(String key) {
+        return parseIntegerProperty(key, null);
     }
 
 }


### PR DESCRIPTION
- rather than processing per table, process per phase (create/populate/delete/drop)
- introduce wait loops to verify that all replicas (in clusters) "see" the data in staging tables

## Problem description

In the production databases (running in a multi-replica cluster deployed through clickhouse.cloud), we noticed accumulations of "orphaned" records where a study was deleted, but associated linked records in other tables (such as the samples table) failed to be deleted. This leads to (for example) sample records which refer to a non-existent patient record in field `patient_id`.

After analysis, a race condition was suspected based on this theory of behavior in ClickHouseBulkDeleter:
- the list of internal identifiers which should be deleted are uploaded into a temporary holding table
- a sql statement which retrieves the list of internal identifiers from the table is then immediately run to delete the referenced records
- hypothesis : the first operation takes time to complete processing and for the metadata associated with the holding table to be updated to refer the the data parts which are in the process of being created ... during that processing time, the second operation begins and says "delete all records with an internal identifier present in the holding table. This operation "sees" an empty holding table and deletes nothing. This is more likely to occur when the holding table has a great number of internal identifiers being inserted. It may also be due to a multi-replica Clickhouse service (like in Clickhouse.cloud) needing to propagate the metadata updates to other processing nodes (where the second operation may have already started)

## Solution

- give more time for the holding tables to be completed by:
    - writing all holding table contents first (when multiple tables are being deleted from) before using any of the holding table contents. By doing this, by the time the final holding table write operation is started, the first table (written a while ago) will have had time to be finalized and content registered.
    - testing each holding table for proper recordcount across all processing nodes (clickhouse has a "run command on all nodes and report all results" function) and entering a short pause/retry loop until the proper counts are seen