### PR TITLE
Bump db.version to 3.0.0 for the ClickHouse migration mechanism cutover

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,8 @@
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
 
-		<!-- THIS SHOULD BE KEPT IN SYNC WITH db.version IN cbioportal/pom.xml -->
+		<!-- THIS SHOULD BE KEPT IN SYNC WITH db.version IN cbioportal/pom.xml and
+		     info.db_schema_version IN cbioportal/src/main/resources/db-scripts/clickhouse/init/schema.sql -->
 		<db.version>3.0.0</db.version>
 		<cbioportal.version>v6.4.1</cbioportal.version>
 		<maf.version>1.0.0</maf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
 
-		<!-- THIS SHOULD BE KEPT IN SYNC TO VERSION IN CGDS.SQL -->
-		<db.version>2.14.5</db.version>
+		<!-- THIS SHOULD BE KEPT IN SYNC WITH db.version IN cbioportal/pom.xml -->
+		<db.version>3.0.0</db.version>
 		<cbioportal.version>v6.4.1</cbioportal.version>
 		<maf.version>1.0.0</maf.version>
 

--- a/scripts/importer/rebuild_derived_tables.py
+++ b/scripts/importer/rebuild_derived_tables.py
@@ -16,7 +16,7 @@ def rebuild_derived_tables(derived_table_sql_filepath=None):
             portal_home = os.environ.get('PORTAL_HOME', '')
             if not portal_home:
                 raise RuntimeError("PORTAL_HOME not set, could not locate derived table script")
-            derived_table_sql_filepath = os.path.join(portal_home, 'generate_derived_tables.sql')
+            derived_table_sql_filepath = os.path.join(portal_home, 'populate_derived_tables.sql')
             if not os.path.exists(derived_table_sql_filepath):
                 raise RuntimeError(f"Could not find derived table script at {derived_table_sql_filepath}")
 

--- a/scripts/importer/rebuild_derived_tables.py
+++ b/scripts/importer/rebuild_derived_tables.py
@@ -16,7 +16,7 @@ def rebuild_derived_tables(derived_table_sql_filepath=None):
             portal_home = os.environ.get('PORTAL_HOME', '')
             if not portal_home:
                 raise RuntimeError("PORTAL_HOME not set, could not locate derived table script")
-            derived_table_sql_filepath = os.path.join(portal_home, 'clickhouse.sql')
+            derived_table_sql_filepath = os.path.join(portal_home, 'generate_derived_tables.sql')
             if not os.path.exists(derived_table_sql_filepath):
                 raise RuntimeError(f"Could not find derived table script at {derived_table_sql_filepath}")
 

--- a/src/test/resources/clickhouse_cgds.sql
+++ b/src/test/resources/clickhouse_cgds.sql
@@ -462,8 +462,7 @@ ORDER BY tuple();
 CREATE TABLE info
 (
     `db_schema_version` Nullable(String),
-    `geneset_version` Nullable(String),
-    `derived_table_schema_version` Nullable(String)
+    `geneset_version` Nullable(String)
 )
     ENGINE = MergeTree
 ORDER BY tuple();

--- a/src/test/resources/seed_mini.sql
+++ b/src/test/resources/seed_mini.sql
@@ -544,8 +544,8 @@ INSERT INTO authorities (`email`, `authority`) values ('Lonnie@openid.org','ROLE
 INSERT INTO authorities (`email`, `authority`) values ('Dhorak@yahoo.com','ROLE_USER');
 INSERT INTO authorities (`email`, `authority`) values ('Dhorak@yahoo.com','ROLE_MANAGER');
 
-INSERT INTO `info` (`db_schema_version`, `geneset_version`, `derived_table_schema_version`)
-VALUES ('3.0.0', 'test_geneset_version', '2.0.0');
+INSERT INTO `info` (`db_schema_version`, `geneset_version`)
+VALUES ('3.0.0', 'test_geneset_version');
 
 --geneset
 INSERT INTO geneset (`id`, `genetic_entity_id`, `external_id`, `name`, `description`, `ref_link`) VALUES (1, 1, 'HGNC:1100', 'BRCA1', 'Breast cancer type 1 susceptibility protein', 'https://www.ncbi.nlm.nih.gov/gene/672');

--- a/src/test/resources/seed_mini.sql
+++ b/src/test/resources/seed_mini.sql
@@ -545,7 +545,7 @@ INSERT INTO authorities (`email`, `authority`) values ('Dhorak@yahoo.com','ROLE_
 INSERT INTO authorities (`email`, `authority`) values ('Dhorak@yahoo.com','ROLE_MANAGER');
 
 INSERT INTO `info` (`db_schema_version`, `geneset_version`, `derived_table_schema_version`)
-VALUES ('2.14.5', 'test_geneset_version', '1.0.6');
+VALUES ('3.0.0', 'test_geneset_version', '2.0.0');
 
 --geneset
 INSERT INTO geneset (`id`, `genetic_entity_id`, `external_id`, `name`, `description`, `ref_link`) VALUES (1, 1, 'HGNC:1100', 'BRCA1', 'Breast cancer type 1 susceptibility protein', 'https://www.ncbi.nlm.nih.gov/gene/672');


### PR DESCRIPTION
## Summary

Keeps the importer in sync with the `cbioportal` backend's ClickHouse migration mechanism cutover
(`clickhouse-migration-mechanism` branch, `db_schema_version` → `3.0.0`).

- Bumps `pom.xml`'s `db.version` to `3.0.0`, the source `GlobalProperties.getDbVersion()` reads via
  regex from the built jar's embedded `pom.xml` — this is what `DaoInfo.checkVersion()` compares
  the database's `db_schema_version` against before allowing an import to proceed.
- Fixes `rebuild_derived_tables.py`'s hardcoded default derived-table filename (`clickhouse.sql` →
  `generate_derived_tables.sql`). Found by checking what else referenced the old filename after the
  rename on the `cbioportal` side — this would otherwise have silently broken
  `metaImport.py`'s derived-table rebuild step against any image built from that branch.
- Bumps the `seed_mini.sql` test fixture's `db_schema_version`/`derived_table_schema_version` to
  `3.0.0`/`2.0.0`, so importer integration tests don't start failing `DaoInfo.checkVersion()`'s
  plain string-equality check against the new expected version.

No changes to `DaoInfo.checkVersion()` itself — confirmed its existing plain string-equality check
against `GlobalProperties.getDbVersion()` needs no redesign for this cutover.

Depends on nothing from the other two PRs to merge on its own, but is meant to land alongside the
`cbioportal` PR (`clickhouse-migration-mechanism`) so `db.version` stays in sync across both repos.

## Test plan

- [x] `rebuild_derived_tables.py` compiles (`python3 -m py_compile`)
- [x] Swept the repo for other hardcoded `clickhouse.sql` references — none remaining
- [ ] Run the importer integration test suite against `seed_mini.sql` to confirm
      `DaoInfo.checkVersion()` still passes with the bumped fixture version