### PR TITLE
Use ClickHouseAutoIncrement rather than dao.getLargestId()

### DIFF
--- a/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseBulkDeleter.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/ClickHouseBulkDeleter.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2026 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2026 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -38,12 +38,19 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.mskcc.cbio.portal.util.GlobalProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Bulk deleter that buffers IDs in memory, streams them into a ClickHouse staging
@@ -55,106 +62,580 @@ import java.util.Map;
  */
 public class ClickHouseBulkDeleter {
 
-    private static final Map<String, ClickHouseBulkDeleter> BULK_DELETERS = new LinkedHashMap<>();
-
-    private final String targetTable;
+    private boolean flushed; // once flushed, any particular deleter instance cannot not be flushed again
+    private final Set<Long> pendingIds = new HashSet<>();
     private final String idColumn;
     private final String stagingTable;
-    private final List<Long> pendingIds = new ArrayList<>();
+    private final String targetTable;
 
-    private ClickHouseBulkDeleter(String targetTable, String idColumn) {
-        this.targetTable = targetTable;
-        this.idColumn = idColumn;
-        this.stagingTable = "staging_delete_" + targetTable;
+    private static final Logger log = LoggerFactory.getLogger(ClickHouseBulkDeleter.class);
+    private static final Map<String, ClickHouseBulkDeleter> BULK_DELETERS = new LinkedHashMap<>();
+
+    private static final Integer DEFAULT_CREATE_STAGING_TABLE_MAX_RETRY_SECONDS = 2 * 60;
+    private static final Integer DEFAULT_POPULATE_STAGING_TABLE_MAX_RETRY_SECONDS = 3 * 60;
+    private static final Integer DEFAULT_CONFIRM_DELETE_DATA_MAX_RETRY_SECONDS = 7 * 60;
+    private static final Integer DEFAULT_CONFIRM_DELETE_METADATA_MAX_RETRY_SECONDS = 2 * 60;
+    private static final Integer DEFAULT_RETRY_CYCLE_PERIOD_SECONDS = 10;
+    private static final Integer DEFAULT_RETRY_CYCLE_MAX_EXCEPTION_COUNT = 6;
+    private static final Integer CREATE_STAGING_TABLE_MAX_RETRY_SECONDS;
+    private static final Integer POPULATE_STAGING_TABLE_MAX_RETRY_SECONDS;
+    private static final Integer CONFIRM_DELETE_DATA_MAX_RETRY_SECONDS;
+    private static final Integer CONFIRM_DELETE_METADATA_MAX_RETRY_SECONDS;
+    private static final Integer RETRY_CYCLE_PERIOD_SECONDS;
+    private static final Integer RETRY_CYCLE_MAX_EXCEPTION_COUNT;
+
+    static {
+        CREATE_STAGING_TABLE_MAX_RETRY_SECONDS = GlobalProperties.parseIntegerProperty(
+                "bulkdeleter.create_staging_table.max_retry_seconds",
+                DEFAULT_CREATE_STAGING_TABLE_MAX_RETRY_SECONDS);
+        POPULATE_STAGING_TABLE_MAX_RETRY_SECONDS = GlobalProperties.parseIntegerProperty(
+                "bulkdeleter.populate_staging_table.max_retry_seconds",
+                DEFAULT_POPULATE_STAGING_TABLE_MAX_RETRY_SECONDS);
+        CONFIRM_DELETE_DATA_MAX_RETRY_SECONDS = GlobalProperties.parseIntegerProperty(
+                "bulkdeleter.confirm_delete_data.max_retry_seconds",
+                DEFAULT_CONFIRM_DELETE_DATA_MAX_RETRY_SECONDS);
+        CONFIRM_DELETE_METADATA_MAX_RETRY_SECONDS = GlobalProperties.parseIntegerProperty(
+                "bulkdeleter.confirm_delete_metadata.max_retry_seconds",
+                DEFAULT_CONFIRM_DELETE_METADATA_MAX_RETRY_SECONDS);
+        RETRY_CYCLE_PERIOD_SECONDS = GlobalProperties.parseIntegerProperty(
+                "bulkdeleter.retry_cycle_period_seconds",
+                DEFAULT_RETRY_CYCLE_PERIOD_SECONDS);
+        RETRY_CYCLE_MAX_EXCEPTION_COUNT = GlobalProperties.parseIntegerProperty(
+                "bulkdeleter.retry_cycle_max_exception_count",
+                DEFAULT_RETRY_CYCLE_MAX_EXCEPTION_COUNT);
     }
 
+    public enum AllReplicaTestType {
+        CONSISTENT,
+        EXPECTED_VALUE
+    }
+
+    public enum AllReplicaCriterionType {
+        LONG,
+        STRING
+    }
+
+// --- Interface ---
+
     public static ClickHouseBulkDeleter getBulkDeleter(String targetTable, String idColumn) {
-        String key = targetTable + ":" + idColumn;
+        if (ClickHouseBulkDeleter.stringContainsIllegalCharacter(targetTable)) {
+            throw new RuntimeException(String.format(
+                    "An illegal character was used in a Clickhouse table name argument : %s",
+                    targetTable));
+        }
+        if (ClickHouseBulkDeleter.stringContainsIllegalCharacter(idColumn)) {
+            throw new RuntimeException(String.format(
+                    "An illegal character was used in a Clickhouse field name argument : %s",
+                    idColumn));
+        }
+        String key = ClickHouseBulkDeleter.deleterKeyString(targetTable, idColumn);
         return BULK_DELETERS.computeIfAbsent(key, k -> new ClickHouseBulkDeleter(targetTable, idColumn));
     }
 
+    public static long flushAll() throws DaoException {
+        List<ClickHouseBulkDeleter> allDeleters = BULK_DELETERS.values().stream().collect(Collectors.toList());
+        long countOfDeletedRecords = ClickHouseBulkDeleter.flush(allDeleters); // deleters which have any potential deletes are removed from BULK_DELETERS here
+        // delete unused deleters : after flushAll is called, any retained references to ClickHouseBulkDeleter objects will become invalid
+        List<ClickHouseBulkDeleter> unusedDeleters = BULK_DELETERS.values().stream().collect(Collectors.toList());
+        teardownDeleters(unusedDeleters);
+        return countOfDeletedRecords;
+    }
+
+// --- Static helper functions
+
+    // might be made public in the future for partial flushes (would require testing)
+    private static long flush(List<ClickHouseBulkDeleter> deleters) throws DaoException {
+        long totalDeleted = 0;
+        if (anyDeleterWasAlreadyFlushed(deleters)) {
+            throw new RuntimeException("a ClickHouseBulkDeleter object had been flushed previously, and was attempted to be flushed a second time");
+        }
+        List<ClickHouseBulkDeleter> effectiveDeleters = deletersWithPendingDeletes(deleters);
+        try {
+            dropExistingStagingTables(effectiveDeleters, false); // drop any leftover tables from previous crash/failure
+            createStagingTables(effectiveDeleters);
+            populateStagingTables(effectiveDeleters);
+            totalDeleted = deleteRecordsReferencedInStagingTables(effectiveDeleters);
+        } finally {
+            dropExistingStagingTables(effectiveDeleters, true);
+            teardownDeleters(effectiveDeleters);
+        }
+        return totalDeleted;
+    }
+
+    private static boolean stringContainsIllegalCharacter(String s) {
+        // clickhouse field and table names can contain only letters, digits, or underscore (unless universally backquoted)
+        return s.matches(".*[^a-zA-Z0-9_].*");
+    }
+
+    private static String deleterKeyString(String targetTable, String idColumn) {
+        return String.format("%s:%s", targetTable, idColumn);
+    }
+
+    private static boolean anyDeleterWasAlreadyFlushed(List<ClickHouseBulkDeleter> deleters) {
+        return deleters.stream().anyMatch(d -> d.wasFlushed());
+    }
+
+    // returns only the deleters which might delete anything (duplicates discarded)
+    private static List<ClickHouseBulkDeleter> deletersWithPendingDeletes(List<ClickHouseBulkDeleter> deleters) {
+        List<ClickHouseBulkDeleter> effectiveDeleters = new ArrayList<>();
+        Set<String> keysSeen = new HashSet<>();
+        for (ClickHouseBulkDeleter d : deleters) {
+            if (d.hasPendingDeletes()) {
+                if (keysSeen.contains(d.getKey())) {
+                    continue; // skip duplicated keys
+                }
+                keysSeen.add(d.getKey());
+                effectiveDeleters.add(d);
+            }
+        }
+        return effectiveDeleters;
+    }
+
+    private static void teardownDeleters(List<ClickHouseBulkDeleter> deleters) {
+        for (ClickHouseBulkDeleter d : deleters) {
+            if (BULK_DELETERS.containsKey(d.getKey())) {
+                BULK_DELETERS.remove(d.getKey()); // object will not be re-used
+            } else {
+                String msg = String.format(
+                        "%s%s%s%s%s",
+                        "unable to deregister deleter which has just been flushed for targetTable ",
+                        d.targetTable,
+                        " and idColumn ",
+                        d.idColumn,
+                        ". Apparently an instance which was not in map BULK_DELETERS was used for record deletion");
+                log.warn(msg);
+            }
+            d.teardown();
+        }
+    }
+
+    private static void createStagingTables(List<ClickHouseBulkDeleter> deleters) throws DaoException {
+        for (ClickHouseBulkDeleter d : deleters) {
+            d.createStagingTable();
+        }
+        for (ClickHouseBulkDeleter d : deleters) {
+            d.confirmCreationOfStagingTable();
+        }
+    }
+
+    private static void populateStagingTables(List<ClickHouseBulkDeleter> deleters) throws DaoException {
+        for (ClickHouseBulkDeleter d : deleters) {
+            d.populateStagingTable();
+        }
+        // wait for inserts to be recognized by all replicas
+        // note: this is intentionally done in a second loop in the hope that while values are being inserted
+        //     into the second, third, ... tables, the time for processing those operations allows for the values
+        //     inserted into the first table to be recognized / become visible in the other replica nodes
+        //     running in a Clickhouse cluster (such as with clickhouse.cloud). This may avoid retry cycles.
+        for (ClickHouseBulkDeleter d : deleters) {
+            d.confirmPopulationOfStagingTable();
+        }
+    }
+
+    private static long deleteRecordsReferencedInStagingTables(List<ClickHouseBulkDeleter> deleters) throws DaoException {
+        long totalDeleted = 0;
+        for (ClickHouseBulkDeleter d : deleters) {
+            totalDeleted += d.deleteRecordsReferencedInStagingTable();
+        }
+        return totalDeleted;
+    }
+
+    private static void dropExistingStagingTables(List<ClickHouseBulkDeleter> deleters, boolean deletionHasBeenExecuted) throws DaoException {
+        for (ClickHouseBulkDeleter d : deleters) {
+            // wait until all ids in the stagingTable table have been fully deleted from the target table
+            if (deletionHasBeenExecuted) {
+                d.confirmDeletionIsComplete();
+            }
+            d.dropStagingTable(deletionHasBeenExecuted);
+        }
+    }
+
+// --- instance methods ---
+
     public void addId(long id) {
+        if (this.flushed) {
+            throw new RuntimeException("attempting to add identifiers to a ClickHouseBulkDeleter object which has already been flushed");
+        }
         pendingIds.add(id);
     }
 
     public void addIds(Collection<? extends Number> ids) {
+        if (this.flushed) {
+            throw new RuntimeException("attempting to add identifiers to a ClickHouseBulkDeleter object which has already been flushed");
+        }
         for (Number id : ids) {
             pendingIds.add(id.longValue());
         }
     }
 
-    public static int flushAll() throws DaoException {
-        int totalDeleted = 0;
-        for (ClickHouseBulkDeleter deleter : BULK_DELETERS.values()) {
-            totalDeleted += deleter.flushPendingIds();
-        }
-        BULK_DELETERS.clear();
-        return totalDeleted;
+    private ClickHouseBulkDeleter(String targetTable, String idColumn) {
+        this.targetTable = targetTable;
+        this.idColumn = idColumn;
+        this.stagingTable = String.format("staging_delete_for_table_%s_column_%s", targetTable, idColumn);
+        this.flushed = false;
     }
 
-    private int flushPendingIds() throws DaoException {
-        if (pendingIds.isEmpty()) {
-            return 0;
-        }
+    private boolean hasPendingDeletes() {
+        return !this.pendingIds.isEmpty();
+    }
 
-        Connection con = null;
+    private boolean wasFlushed() {
+        return flushed;
+    }
+
+    private void teardown() {
+        this.pendingIds.clear();
+        this.flushed = true; // prevent re-flushing
+    }
+
+    private String getKey() {
+        return ClickHouseBulkDeleter.deleterKeyString(this.targetTable, this.idColumn);
+    }
+
+// methods which are database alterations (on failure, these throw DaoException)
+
+    private void createStagingTable() throws DaoException {
         try {
-            con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
-
-            // Drop any leftover staging table from a previous crashed run
-            try (PreparedStatement stmt = con.prepareStatement(
-                    "DROP TABLE IF EXISTS " + stagingTable)) {
+            Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
+            String createTableStatementString = String.format(
+                    "CREATE TABLE %s (id Int64) ENGINE = MergeTree() ORDER BY id",
+                    this.stagingTable);
+            try (PreparedStatement stmt = con.prepareStatement(createTableStatementString)) {
                 stmt.executeUpdate();
+            } finally {
+                JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
             }
+        } catch (SQLException e) {
+            throw new DaoException(e);
+        }
+    }
 
-            // Create staging table
-            try (PreparedStatement stmt = con.prepareStatement(
-                    "CREATE TABLE " + stagingTable + " (id Int64) ENGINE = MergeTree() ORDER BY id")) {
-                stmt.executeUpdate();
-            }
-
-            // Insert IDs into staging table via TSV stream
-            byte[] payload = buildTsvPayload();
-            try (PreparedStatement stmt = con.prepareStatement(
-                    "INSERT INTO " + stagingTable + " (id) FORMAT TSVWithNames")) {
+    private void populateStagingTable() throws DaoException {
+        // Insert IDs into staging table via TSV stream
+        byte[] payload = buildTsvPayload();
+        String insertStatementString = String.format(
+                "INSERT INTO %s (id) FORMAT TSVWithNames",
+                stagingTable);
+        try {
+            Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
+            try (PreparedStatement stmt = con.prepareStatement(insertStatementString)) {
                 stmt.setBinaryStream(1, new ByteArrayInputStream(payload));
                 stmt.executeUpdate();
+            } finally {
+                JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
             }
-
-            // Execute delete via staging table
-            int deleted;
-            try (PreparedStatement stmt = con.prepareStatement(
-                    "DELETE FROM " + targetTable + " WHERE " + idColumn + " IN (SELECT id FROM " + stagingTable + ")")) {
-                deleted = stmt.executeUpdate();
-            }
-
-            return deleted;
-        } catch (SQLException | IOException e) {
+        } catch (SQLException e) {
             throw new DaoException(e);
-        } finally {
-            // Always drop staging table
-            try {
-                if (con != null) {
-                    try (PreparedStatement drop = con.prepareStatement(
-                            "DROP TABLE IF EXISTS " + stagingTable)) {
-                        drop.executeUpdate();
-                    }
-                }
-            } catch (SQLException ignored) {
-            }
-            JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
-            pendingIds.clear();
         }
     }
 
-    private byte[] buildTsvPayload() throws IOException {
-        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-        // header row
-        buffer.write("id\n".getBytes(StandardCharsets.UTF_8));
-        // data rows
-        for (Long id : pendingIds) {
-            buffer.write((id.toString() + "\n").getBytes(StandardCharsets.UTF_8));
+    private long deleteRecordsReferencedInStagingTable() throws DaoException {
+        long records_deleted;
+        String statementString = String.format(
+                "DELETE FROM %s WHERE %s IN (SELECT id FROM %s)",
+                targetTable, idColumn, stagingTable);
+        try {
+            Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
+            try (PreparedStatement stmt = con.prepareStatement(statementString)) {
+                records_deleted = stmt.executeUpdate();
+            } finally {
+                JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
+            }
+        } catch (SQLException e) {
+            throw new DaoException(e);
         }
-        return buffer.toByteArray();
+        return records_deleted;
     }
+
+    private void dropStagingTable(boolean tolerateFailure) throws DaoException {
+        try {
+            String dropStatementString = String.format(
+                    "DROP TABLE IF EXISTS %s",
+                    this.stagingTable);
+            Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
+            try (PreparedStatement stmt = con.prepareStatement(dropStatementString)) {
+                stmt.executeUpdate();
+            } catch (SQLException e) {
+                if (! tolerateFailure) {
+                    // it is fatal to fail to DROP any old staging tables during the first call
+                    // (during setup for deletion), because then the CREATE for staging will fail.
+                    // on the second call, so long as the deletion completed, it is allowabe to leave behind
+                    // residual staging tables -- they will (hopefully) DROP during the next update run
+                    throw new DaoException(e);
+                }
+            } finally {
+                JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
+            }
+        } catch (SQLException e) {
+            throw new DaoException(e);
+        }
+    }
+
+// methods which are complete confirmations of database alterations (on failure these throw DaoExcpetion)
+
+    private void confirmCreationOfStagingTable() throws DaoException {
+        if (! this.conditionIsTrueAfterQueryWithRetry(this::allReplicasReportStagingTableExists, CREATE_STAGING_TABLE_MAX_RETRY_SECONDS)) {
+            String exceptionMsgString = String.format(
+                    "Failed to see all replicas report existence of staging table %s after creation",
+                    this.stagingTable);
+            throw new DaoException(exceptionMsgString);
+        }
+    }
+
+    private void confirmPopulationOfStagingTable() throws DaoException {
+        if (! this.conditionIsTrueAfterQueryWithRetry(this::allReplicasReportExpectedStagingTableRecordCount, POPULATE_STAGING_TABLE_MAX_RETRY_SECONDS)) {
+            String exceptionMsgString = String.format(
+                    "Failed to see all replicas reflect delete list inserted into table %s",
+                    this.stagingTable);
+            throw new DaoException(exceptionMsgString);
+        }
+    }
+
+    private void confirmDeletionIsComplete() throws DaoException {
+        this.confirmDeletionIsCompleteInData();
+        this.confirmDeletionIsCompleteInMetadata();
+    }
+
+    private void confirmDeletionIsCompleteInData() throws DaoException {
+        if (!this.conditionIsTrueAfterQueryWithRetry(this::deletionIsComplete, DEFAULT_CONFIRM_DELETE_DATA_MAX_RETRY_SECONDS)) {
+            String exceptionMessageString = String.format(
+                    "Failed to complete the delete operation on all replicas for table %s after retrying for %d seconds",
+                    this.targetTable,
+                    DEFAULT_CONFIRM_DELETE_DATA_MAX_RETRY_SECONDS);
+            throw new DaoException(exceptionMessageString);
+        }
+        // TODO: if condition fails a few times, we might start checking whether any
+        // mutations are still in progress -- if not, stop waiting and fail early
+    }
+
+    private void confirmDeletionIsCompleteInMetadata() throws DaoException {
+        if (!this.conditionIsTrueAfterQueryWithRetry(this::allReplicasReportSameMetadataForTargetTable, CONFIRM_DELETE_METADATA_MAX_RETRY_SECONDS)) {
+            String exceptionMessageString = String.format(
+                    "Metadata for table %s could not be confirmed to have propagated across all cluster replica nodes after retrying for %d seconds",
+                    this.targetTable,
+                    CONFIRM_DELETE_METADATA_MAX_RETRY_SECONDS);
+            throw new DaoException(exceptionMessageString);
+        }
+    }
+
+// functional predicates for performing tests (these may return SQLException which allows retry, or DaoException for fatal failures)
+
+    private boolean allReplicasReportStagingTableExists() throws SQLException, DaoException {
+        String getTableExistsString = String.format(
+                "SELECT hostname() AS host, count() AS table_exists FROM clusterAllReplicas('default', 'system', 'tables') WHERE database = current_database() AND name = '%s' GROUP BY host",
+                stagingTable);
+        return allReplicasReportExpectedResult(getTableExistsString, "table_exists", AllReplicaTestType.EXPECTED_VALUE, AllReplicaCriterionType.LONG, 1L);
+    }
+
+    private boolean allReplicasReportExpectedStagingTableRecordCount() throws SQLException, DaoException {
+        String queryPart1 = "SELECT host, sum(record_count) AS total_rows FROM ((";
+        String queryPart2 = "SELECT hostname() AS host, rows AS record_count FROM clusterAllReplicas('default', 'system', 'parts')";
+        String queryPart3 = "WHERE database = current_database() AND table = ";
+        String queryPart4 = ") union all (";
+        // This union insures that at least one part with one record is included in the query result before aggregation. In this way, every host will be present in the results
+        String queryPart5 = "SELECT hostname() AS host, 0 AS record_count FROM clusterAllReplicas('default', 'system', 'one')";
+        String queryPart6 = ")) GROUP BY host";
+        String getRecordCountsString = String.format(
+                "%s%s %s '%s'%s%s%s",
+                queryPart1, queryPart2, queryPart3, stagingTable, queryPart4, queryPart5, queryPart6);
+        return allReplicasReportExpectedResult(getRecordCountsString, "total_rows", AllReplicaTestType.EXPECTED_VALUE, AllReplicaCriterionType.LONG, new Long(pendingIds.size()));
+    }
+
+    private boolean deletionIsComplete() throws SQLException, DaoException {
+        String getUndeletedRecordCountsString = String.format(
+                "SELECT count() AS record_count FROM %s WHERE %s IN (SELECT id FROM %s)",
+                targetTable, idColumn, stagingTable);
+        return queryProducedExpectedResult(getUndeletedRecordCountsString, "record_count", 0L);
+    }
+
+    private boolean allReplicasReportSameMetadataForTargetTable() throws SQLException, DaoException {
+        String queryPart1 = "SELECT host, sum(record_count) AS total_rows FROM ((";
+        String queryPart2 = "SELECT hostname() AS host, rows AS record_count FROM clusterAllReplicas('default', 'system', 'parts')";
+        String queryPart3 = "WHERE database = current_database() AND table = ";
+        String queryPart4 = ") union all (";
+        // This union insures that at least one part with one record is included in the query result before aggregation. In this way, every host will be present in the results
+        String queryPart5 = "SELECT hostname() AS host, 0 AS record_count FROM clusterAllReplicas('default', 'system', 'one')";
+        String queryPart6 = ")) GROUP BY host";
+        String getMetadataString = String.format(
+                "%s%s %s '%s'%s%s%s",
+                queryPart1, queryPart2, queryPart3, targetTable, queryPart4, queryPart5, queryPart6);
+        return allReplicasReportExpectedResult(getMetadataString, "total_rows", AllReplicaTestType.CONSISTENT, AllReplicaCriterionType.LONG, null);
+    }
+
+// reusable logic to perform test/retry loops for database queries with criteria
+
+    @FunctionalInterface
+    private interface ConditionPredicate {
+        boolean conditionIsSatisfied() throws SQLException, DaoException;
+    }
+
+    private boolean conditionIsTrueAfterQueryWithRetry(ConditionPredicate conPred, int maxTestingSeconds) throws DaoException {
+        int totalCycleCount = maxTestingSeconds / RETRY_CYCLE_PERIOD_SECONDS;
+        int exceptionsEncountered = 0;
+        boolean returnValue = false;
+        for (int cycle = 0 ; cycle < totalCycleCount ; cycle = cycle + 1) {
+            try {
+                if (conPred.conditionIsSatisfied()) {
+                    returnValue = true;
+                    break;
+                }
+            } catch (SQLException e) {
+                exceptionsEncountered = exceptionsEncountered + 1;
+                String msg = String.format(
+                        "SQL Exception encountered during try/retry loop on cycle number %d : %s",
+                        cycle, e.getMessage());
+                log.warn(msg);
+                if (exceptionsEncountered > DEFAULT_RETRY_CYCLE_MAX_EXCEPTION_COUNT) {
+                    throw new DaoException(e);
+                }
+            } finally {
+                if (returnValue == false && cycle < totalCycleCount - 1 && exceptionsEncountered <= DEFAULT_RETRY_CYCLE_MAX_EXCEPTION_COUNT) {
+                    // sleep if we will be trying another iteration
+                    try {
+                        Thread.sleep(1000 * RETRY_CYCLE_PERIOD_SECONDS);
+                    } catch (InterruptedException ie) {
+                        // allow sleep interruption, and go on to next cycle immediately
+                        Thread.currentThread().interrupt(); // set interrupted status, in case we want to adjust for interrupted sleep
+                    }
+                } else {
+                }
+            }
+        }
+        return returnValue;
+    }
+
+    // checks specified outputField in the results of running queryString and looks for expectedResult
+    // only the first result (in the result set) is examined
+    private boolean queryProducedExpectedResult(String queryString, String outputField, long expectedResult) throws SQLException {
+        Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
+        try (PreparedStatement pstmt = con.prepareStatement(queryString);
+                ResultSet rs = pstmt.executeQuery()) {
+            if (!rs.next()) {
+                log.warn(String.format(
+                        "evaluation of query produced empty result set : %s",
+                        queryString));
+                return false;
+            }
+            long result = rs.getLong(outputField);
+            if (result != expectedResult) {
+                log.warn(String.format(
+                        "waiting to reach expected result for query '%s' : expected %d saw %d",
+                        queryString,
+                        expectedResult,
+                        result
+                        ));
+                return false;
+            }
+        } finally {
+            JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
+        }
+        return true;
+    }
+
+    // queryString must be a SQL query which returns results which includes a field "host" with the hostname() of the replica responding. "SELECT hostname() AS host..."
+    // with testType AllReplicaTestType.CONSISTENT, the expectedValue argument is ignored (pass null)
+    private boolean allReplicasReportExpectedResult(String queryString, String outputField, AllReplicaTestType testType, AllReplicaCriterionType criterionType, Object expectedValue) throws SQLException, DaoException {
+        Set<String> allReplicaHostNames = getReplicaHostnames();
+        Map<String, Object> replicaValueMap = getReportedResultFromAllReplicas(queryString, criterionType, outputField);
+        if (replicaValueMap.isEmpty()) {
+            return false; // for this purpose, at least one replica must report a match
+        }
+        Collection<Object> values = replicaValueMap.values();
+        switch (testType) {
+            case AllReplicaTestType.CONSISTENT:
+                Object firstValue = values.iterator().next();
+                if (!values.stream().allMatch(value -> firstValue.equals(value))) {
+                    log.warn(String.format(
+                            "waiting to reach expected result for query '%s' : expected consistent values but saw: %s",
+                            queryString,
+                            replicaValueMap.toString()));
+                    return false;
+                }
+                break;
+            case AllReplicaTestType.EXPECTED_VALUE:
+                if (!values.stream().allMatch(value -> expectedValue.equals(value))) {
+                    log.warn(String.format(
+                            "waiting to reach expected result for query '%s' : expected %d as value but saw: %s",
+                            queryString,
+                            expectedValue,
+                            replicaValueMap.toString()));
+                    return false;
+                }
+                break;
+            default:
+                throw new DaoException("Unknown testType argument passed to allReplicasReportExpectedResult()");
+        }
+        if (!replicaValueMap.keySet().containsAll(allReplicaHostNames)) {
+            // .containsAll() was used instead of .equals() because if additional replicas became active while the query was running,
+            // that is still acceptable so long as the new replicas all report the expected result. we might worry about additional non-responding replicas...
+            log.warn(String.format(
+                    "while querying all replicas using query '%s' : either the replica set was reduced during the query execution or one or more replicas failed to be evaluated. waiting will continue. All replicas : %s ; Reported replicas : %s",
+                    queryString,
+                    String.join(", ", allReplicaHostNames),
+                    String.join(", ", replicaValueMap.keySet())));
+            return false;
+        }
+        return true;
+    }
+
+    private Map<String, Object> getReportedResultFromAllReplicas(String queryString, AllReplicaCriterionType outputType, String outputField) throws SQLException, DaoException {
+        Map<String, Object> replicaValueMap = new LinkedHashMap<>();
+        Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
+        try (PreparedStatement pstmt = con.prepareStatement(queryString);
+                ResultSet rs = pstmt.executeQuery()) {
+            while (rs.next()) {
+                String replicaHostname = rs.getString("host");
+                switch (outputType) {
+                    case LONG:
+                        replicaValueMap.put(replicaHostname, rs.getLong(outputField));
+                        break;
+                    case STRING:
+                        replicaValueMap.put(replicaHostname, rs.getString(outputField));
+                        break;
+                    default:
+                        throw new DaoException("Unknown outputType argument passed to getReportedResultFromAllReplicas()");
+                }
+            }
+        } finally {
+            JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
+        }
+        return replicaValueMap;
+    }
+
+// helper functions which query the database directly
+
+    private Set<String> getReplicaHostnames() throws SQLException {
+        Set<String> hostnameSet = new HashSet<>();
+        Connection con = JdbcUtil.getDbConnection(ClickHouseBulkDeleter.class);
+        String getHostNamesQueryString = "SELECT hostname() AS host FROM clusterAllReplicas('default', 'system', 'one') GROUP BY host";
+        try (PreparedStatement pstmt = con.prepareStatement(getHostNamesQueryString);
+                ResultSet rs = pstmt.executeQuery()) {
+            while (rs.next()) {
+                hostnameSet.add(rs.getString("host"));
+            }
+        } finally {
+            JdbcUtil.closeAll(ClickHouseBulkDeleter.class, con, null, null);
+        }
+        if (hostnameSet.isEmpty()) {
+            throw new SQLException(String.format(
+                    "unable to find set of active replica hosts using query : %s",
+                    getHostNamesQueryString));
+        }
+        return hostnameSet;
+    }
+
+    private byte[] buildTsvPayload() throws DaoException {
+        try (ByteArrayOutputStream buffer = new ByteArrayOutputStream()) {
+            // header row
+            buffer.write("id\n".getBytes(StandardCharsets.UTF_8));
+            // data rows
+            for (Long id : pendingIds) {
+                buffer.write((id.toString() + "\n").getBytes(StandardCharsets.UTF_8));
+            }
+            return buffer.toByteArray();
+        } catch (IOException e) {
+            throw new DaoException(e);
+        }
+    }
+
 }

--- a/src/main/java/org/mskcc/cbio/portal/dao/DaoCancerStudy.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/DaoCancerStudy.java
@@ -508,21 +508,18 @@ public final class DaoCancerStudy {
             // check whether should delete generic assay meta profile by profile
             DaoGenericAssay.checkAndDeleteGenericAssayMetaInStudy(internalCancerStudyId);
             
-            con = JdbcUtil.getDbConnection(DaoCancerStudy.class);
-            List<Integer> geneticProfileIds = collectIds(con,
-                "SELECT genetic_profile_id FROM genetic_profile WHERE cancer_study_id=?", internalCancerStudyId);
-            List<Integer> patientIds = collectIds(con,
-                "SELECT internal_id FROM patient WHERE cancer_study_id=?", internalCancerStudyId);
-            List<Integer> sampleIds = collectIds(con,
-                "SELECT internal_id FROM sample WHERE patient_id IN (SELECT internal_id FROM patient WHERE cancer_study_id=?)",
-                internalCancerStudyId);
-            List<Integer> sampleListIds = collectIds(con,
-                "SELECT list_id FROM sample_list WHERE cancer_study_id=?", internalCancerStudyId);
-            List<Integer> clinicalEventIds = collectIds(con,
-                "SELECT clinical_event_id FROM clinical_event WHERE patient_id IN (SELECT internal_id FROM patient WHERE cancer_study_id=?)",
-                internalCancerStudyId);
-            List<Integer> gisticIds = collectIds(con,
-                "SELECT gistic_roi_id FROM gistic WHERE cancer_study_id=?", internalCancerStudyId);
+            String geneticProfileIdQuery = "SELECT genetic_profile_id FROM genetic_profile WHERE cancer_study_id=?";
+            List<Long> geneticProfileIds = collectIds(geneticProfileIdQuery, internalCancerStudyId);
+            String patientIdQuery = "SELECT internal_id FROM patient WHERE cancer_study_id=?";
+            List<Long> patientIds = collectIds(patientIdQuery, internalCancerStudyId);
+            String sampleIdQuery = "SELECT internal_id FROM sample WHERE patient_id IN (SELECT internal_id FROM patient WHERE cancer_study_id=?)";
+            List<Long> sampleIds = collectIds(sampleIdQuery, internalCancerStudyId);
+            String sampleListIdQuery = "SELECT list_id FROM sample_list WHERE cancer_study_id=?";
+            List<Long> sampleListIds = collectIds(sampleListIdQuery, internalCancerStudyId);
+            String clinicalEventIdQuery = "SELECT clinical_event_id FROM clinical_event WHERE patient_id IN (SELECT internal_id FROM patient WHERE cancer_study_id=?)";
+            List<Long> clinicalEventIds = collectIds(clinicalEventIdQuery, internalCancerStudyId);
+            String gisticIdQuery = "SELECT gistic_roi_id FROM gistic WHERE cancer_study_id=?";
+            List<Long> gisticIds = collectIds(gisticIdQuery, internalCancerStudyId);
 
             ClickHouseBulkDeleter.getBulkDeleter("sample_cna_event", "genetic_profile_id").addIds(geneticProfileIds);
             ClickHouseBulkDeleter.getBulkDeleter("genetic_alteration", "genetic_profile_id").addIds(geneticProfileIds);
@@ -550,26 +547,24 @@ public final class DaoCancerStudy {
 
             ClickHouseBulkDeleter.flushAll();
 
-            deleteByStudyId(con, "DELETE FROM clinical_attribute_meta WHERE cancer_study_id=?", internalCancerStudyId);
-            deleteByStudyId(con, "DELETE FROM resource_definition WHERE cancer_study_id=?", internalCancerStudyId);
-            deleteByStudyId(con, "DELETE FROM resource_study WHERE internal_id=?", internalCancerStudyId);
-            deleteByStudyId(con, "DELETE FROM cancer_study_tags WHERE cancer_study_id=?", internalCancerStudyId);
-            deleteByStudyId(con, "DELETE FROM copy_number_seg WHERE cancer_study_id=?", internalCancerStudyId);
-            deleteByStudyId(con, "DELETE FROM copy_number_seg_file WHERE cancer_study_id=?", internalCancerStudyId);
-            deleteByStudyId(con, "DELETE FROM patient WHERE cancer_study_id=?", internalCancerStudyId);
-            deleteByStudyId(con, "DELETE FROM sample_list WHERE cancer_study_id=?", internalCancerStudyId);
-            deleteByStudyId(con, "DELETE FROM genetic_profile WHERE cancer_study_id=?", internalCancerStudyId);
-            deleteByStudyId(con, "DELETE FROM gistic WHERE cancer_study_id=?", internalCancerStudyId);
-            deleteByStudyId(con, "DELETE FROM mut_sig WHERE cancer_study_id=?", internalCancerStudyId);
-            deleteByStudyId(con, "DELETE FROM cancer_study WHERE cancer_study_id=?", internalCancerStudyId);
+            deleteByStudyId("DELETE FROM clinical_attribute_meta WHERE cancer_study_id=?", internalCancerStudyId);
+            deleteByStudyId("DELETE FROM resource_definition WHERE cancer_study_id=?", internalCancerStudyId);
+            deleteByStudyId("DELETE FROM resource_study WHERE internal_id=?", internalCancerStudyId);
+            deleteByStudyId("DELETE FROM cancer_study_tags WHERE cancer_study_id=?", internalCancerStudyId);
+            deleteByStudyId("DELETE FROM copy_number_seg WHERE cancer_study_id=?", internalCancerStudyId);
+            deleteByStudyId("DELETE FROM copy_number_seg_file WHERE cancer_study_id=?", internalCancerStudyId);
+            deleteByStudyId("DELETE FROM patient WHERE cancer_study_id=?", internalCancerStudyId);
+            deleteByStudyId("DELETE FROM sample_list WHERE cancer_study_id=?", internalCancerStudyId);
+            deleteByStudyId("DELETE FROM genetic_profile WHERE cancer_study_id=?", internalCancerStudyId);
+            deleteByStudyId("DELETE FROM gistic WHERE cancer_study_id=?", internalCancerStudyId);
+            deleteByStudyId("DELETE FROM mut_sig WHERE cancer_study_id=?", internalCancerStudyId);
+            deleteByStudyId("DELETE FROM cancer_study WHERE cancer_study_id=?", internalCancerStudyId);
 
             removeCancerStudyFromCache(internalCancerStudyId);
         } catch (DaoException e) {
             throw e;
         } catch (SQLException e) {
             throw new DaoException(e);
-        } finally {
-            JdbcUtil.closeAll(DaoCancerStudy.class, con, pstmt, rs);
         }
         purgeUnreferencedRecordsAfterDeletionOfStudy();
         reCacheAll();
@@ -602,27 +597,35 @@ public final class DaoCancerStudy {
         }
     }
 
-    private static List<Integer> collectIds(Connection con, String sql, int cancerStudyId) throws SQLException {
-        PreparedStatement pstmt = null;
-        ResultSet rs = null;
-        List<Integer> ids = new ArrayList<>();
+    private static List<Long> collectIds(String sql, int cancerStudyId) throws SQLException {
+        List<Long> ids = new ArrayList<>();
+        Connection con = null;
         try {
-            pstmt = con.prepareStatement(sql);
-            pstmt.setInt(1, cancerStudyId);
-            rs = pstmt.executeQuery();
-            while (rs.next()) {
-                ids.add(rs.getInt(1));
+            con = JdbcUtil.getDbConnection(DaoCancerStudy.class);
+            try (PreparedStatement pstmt = con.prepareStatement(sql)) {
+                pstmt.setInt(1, cancerStudyId);
+                try (ResultSet rs = pstmt.executeQuery()) {
+                    while (rs.next()) {
+                        ids.add(rs.getLong(1));
+                    }
+                }
             }
         } finally {
-            JdbcUtil.closeAll(DaoCancerStudy.class, null, pstmt, rs);
+            JdbcUtil.closeAll(DaoCancerStudy.class, con, null, null);
         }
         return ids;
     }
 
-    private static void deleteByStudyId(Connection con, String sql, int cancerStudyId) throws SQLException {
-        try (PreparedStatement pstmt = con.prepareStatement(sql)) {
-            pstmt.setInt(1, cancerStudyId);
-            pstmt.executeUpdate();
+    private static void deleteByStudyId(String sql, int cancerStudyId) throws SQLException {
+        Connection con = null;
+        try {
+            con = JdbcUtil.getDbConnection(DaoCancerStudy.class);
+            try (PreparedStatement pstmt = con.prepareStatement(sql)) {
+                pstmt.setInt(1, cancerStudyId);
+                pstmt.executeUpdate();
+            }
+        } finally {
+            JdbcUtil.closeAll(DaoCancerStudy.class, con, null, null);
         }
     }
 

--- a/src/main/java/org/mskcc/cbio/portal/dao/DaoClinicalEvent.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/DaoClinicalEvent.java
@@ -140,23 +140,6 @@ public final class DaoClinicalEvent {
         return clinicalEvent;
     }
     
-    public static long getLargestClinicalEventId() throws DaoException {
-        Connection con = null;
-        PreparedStatement pstmt = null;
-        ResultSet rs = null;
-        try {
-            con = JdbcUtil.getDbConnection(DaoClinicalEvent.class);
-            pstmt = con.prepareStatement
-                    ("SELECT max(`clinical_event_id`) FROM `clinical_event`");
-            rs = pstmt.executeQuery();
-            return rs.next() ? rs.getLong(1) : 0;
-        } catch (SQLException e) {
-            throw new DaoException(e);
-        } finally {
-            JdbcUtil.closeAll(DaoClinicalEvent.class, con, pstmt, rs);
-        }
-    }
-    
     /**
      * 
      * @param cancerStudyId

--- a/src/main/java/org/mskcc/cbio/portal/dao/DaoClinicalEvent.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/DaoClinicalEvent.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2015, 2026 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -48,40 +48,38 @@ import org.mskcc.cbio.portal.model.ClinicalEvent;
  * @author gaoj
  */
 public final class DaoClinicalEvent {
+
+    private static final String CLINICAL_EVENT_SEQUENCE = "seq_clinical_event";
+
     private DaoClinicalEvent() {}
-    
-    public static int addClinicalEvent(ClinicalEvent clinicalEvent) {
+
+    public static void addClinicalEvent(ClinicalEvent clinicalEvent) throws DaoException {
         if (!ClickHouseBulkLoader.isBulkLoad()) {
             throw new IllegalStateException("Only bulk load mode is allowed for importing clinical events");
         }
-        
+        Long clinicalEventId = ClickHouseAutoIncrement.nextId(CLINICAL_EVENT_SEQUENCE);
         ClickHouseBulkLoader.getClickHouseBulkLoader("clinical_event").insertRecord(
-                Long.toString(clinicalEvent.getClinicalEventId()),
+                Long.toString(clinicalEventId),
                 Integer.toString(clinicalEvent.getPatientId()),
                 clinicalEvent.getStartDate().toString(),
                 clinicalEvent.getStopDate()==null?null:clinicalEvent.getStopDate().toString(),
-                clinicalEvent.getEventType()
-                );
-        return 1+addClinicalEventData(clinicalEvent);
+                clinicalEvent.getEventType());
+        addClinicalEventData(clinicalEvent, clinicalEventId);
     }
-    
-    private static int addClinicalEventData(ClinicalEvent clinicalEvent) {
-        long eventId = clinicalEvent.getClinicalEventId();
+
+    private static void addClinicalEventData(ClinicalEvent clinicalEvent, Long clinicalEventId) {
         for (Map.Entry<String,String> entry : clinicalEvent.getEventData().entrySet()) {
             ClickHouseBulkLoader.getClickHouseBulkLoader("clinical_event_data").insertRecord(
-                    Long.toString(eventId),
+                    Long.toString(clinicalEventId),
                     entry.getKey(),
-                    entry.getValue()
-                    );
+                    entry.getValue());
         }
-        return 1;
-        
     }
-    
+
     public static List<ClinicalEvent> getClinicalEvent(int patientId) throws DaoException {
         return getClinicalEvent(patientId, null);
     }
-    
+
     public static List<ClinicalEvent> getClinicalEvent(int patientId, String eventType) throws DaoException {
 
         Connection con = null;
@@ -109,7 +107,7 @@ public final class DaoClinicalEvent {
             }
 
             rs.close();
-           
+
            // get data then
            if (!clinicalEvents.isEmpty()) {
                 pstmt = con.prepareStatement("SELECT * FROM clinical_event_data WHERE clinical_event_id IN ("
@@ -129,7 +127,7 @@ public final class DaoClinicalEvent {
            JdbcUtil.closeAll(DaoClinicalEvent.class, con, pstmt, rs);
         }
     }
-    
+
     private static ClinicalEvent extractClinicalEvent(ResultSet rs) throws SQLException {
         ClinicalEvent clinicalEvent = new ClinicalEvent();
         clinicalEvent.setClinicalEventId(rs.getLong("clinical_event_id"));
@@ -139,13 +137,13 @@ public final class DaoClinicalEvent {
         clinicalEvent.setEventType(rs.getString("event_type"));
         return clinicalEvent;
     }
-    
+
     /**
-     * 
+     *
      * @param cancerStudyId
      * @param caseId
      * @return true if timeline data exist for the case
-     * @throws DaoException 
+     * @throws DaoException
      */
     public static boolean timeEventsExistForPatient(int patientId) throws DaoException {
         Connection con = null;
@@ -163,19 +161,19 @@ public final class DaoClinicalEvent {
             JdbcUtil.closeAll(DaoCopyNumberSegment.class, con, pstmt, rs);
         }
     }
-    
+
     public static void deleteByCancerStudyId(int cancerStudyId) throws DaoException {
         Connection con = null;
         PreparedStatement pstmt = null;
         ResultSet rs = null;
         try {
             con = JdbcUtil.getDbConnection(DaoClinicalEvent.class);
-            
+
             pstmt = con.prepareStatement("DELETE FROM clinical_event_data WHERE clinical_event_id IN "
                     + "(SELECT clinical_event_id FROM clinical_event WHERE patient_id in (SELECT internal_id FROM patient where cancer_study_id=?))");
             pstmt.setInt(1, cancerStudyId);
             pstmt.executeUpdate();
-            
+
             pstmt = con.prepareStatement("DELETE FROM clinical_event WHERE patient_id in (SELECT internal_id FROM patient where cancer_study_id=?)");
             pstmt.setInt(1, cancerStudyId);
             pstmt.executeUpdate();
@@ -207,7 +205,7 @@ public final class DaoClinicalEvent {
             JdbcUtil.closeAll(DaoClinicalEvent.class, con, pstmt, rs);
         }
     }
-    
+
     public static void deleteAllRecords() throws DaoException {
         Connection con = null;
         PreparedStatement pstmt = null;

--- a/src/main/java/org/mskcc/cbio/portal/dao/DaoCopyNumberSegment.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/DaoCopyNumberSegment.java
@@ -140,23 +140,6 @@ public final class DaoCopyNumberSegment {
         }
     }
     
-    public static long getLargestId() throws DaoException {
-        Connection con = null;
-        PreparedStatement pstmt = null;
-        ResultSet rs = null;
-        try {
-            con = JdbcUtil.getDbConnection(DaoMutation.class);
-            pstmt = con.prepareStatement
-                    ("SELECT max(`seg_id`) FROM `copy_number_seg`");
-            rs = pstmt.executeQuery();
-            return rs.next() ? rs.getLong(1) : 0;
-        } catch (SQLException e) {
-            throw new DaoException(e);
-        } finally {
-            JdbcUtil.closeAll(DaoMutation.class, con, pstmt, rs);
-        }
-    }
-    
     public static List<CopyNumberSegment> getSegmentForASample(
             int sampleId, int cancerStudyId) throws DaoException {
         return getSegmentForSamples(Collections.singleton(sampleId),cancerStudyId);

--- a/src/main/java/org/mskcc/cbio/portal/dao/DaoCopyNumberSegment.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/DaoCopyNumberSegment.java
@@ -34,6 +34,7 @@ package org.mskcc.cbio.portal.dao;
 
 import java.sql.*;
 import java.util.*;
+//import org.mskcc.cbio.portal.dao.ClickHouseAutoIncrement;
 import org.mskcc.cbio.portal.model.ClinicalAttribute;
 import org.mskcc.cbio.portal.model.CopyNumberSegment;
 
@@ -45,15 +46,16 @@ public final class DaoCopyNumberSegment {
 
     private static final double FRACTION_GENOME_ALTERED_CUTOFF = 0.2;
     private static final String FRACTION_GENOME_ALTERED_ATTR_ID = "FRACTION_GENOME_ALTERED";
+    private static final String COPY_NUMBER_SEG_SEQUENCE = "seq_copy_number_seg";
 
     private DaoCopyNumberSegment() {}
-    
+
     public static int addCopyNumberSegment(CopyNumberSegment seg) throws DaoException {
         if (!ClickHouseBulkLoader.isBulkLoad()) {
             throw new DaoException("You have to turn on ClickHouseBulkLoader in order to insert mutations");
         } else {
             ClickHouseBulkLoader.getClickHouseBulkLoader("copy_number_seg").insertRecord(
-                    Long.toString(seg.getSegId()),
+                    Long.toString(ClickHouseAutoIncrement.nextId(COPY_NUMBER_SEG_SEQUENCE)),
                     Integer.toString(seg.getCancerStudyId()),
                     Integer.toString(seg.getSampleId()),
                     seg.getChr(),
@@ -139,12 +141,12 @@ public final class DaoCopyNumberSegment {
             JdbcUtil.closeAll(DaoCopyNumberSegment.class, con, null, null);
         }
     }
-    
+
     public static List<CopyNumberSegment> getSegmentForASample(
             int sampleId, int cancerStudyId) throws DaoException {
         return getSegmentForSamples(Collections.singleton(sampleId),cancerStudyId);
     }
-    
+
     public static List<CopyNumberSegment> getSegmentForSamples(
             Collection<Integer> sampleIds, int cancerStudyId) throws DaoException {
         if (sampleIds == null || sampleIds.isEmpty()) {
@@ -179,14 +181,14 @@ public final class DaoCopyNumberSegment {
             }
         });
     }
-    
+
     public static double getCopyNumberActeredFraction(int sampleId,
             int cancerStudyId, double cutoff) throws DaoException {
         Double d = getCopyNumberActeredFraction(Collections.singleton(sampleId), cancerStudyId, cutoff)
                 .get(sampleId);
         return d==null ? Double.NaN : d;
     }
-    
+
     public static Map<Integer,Double> getCopyNumberActeredFraction(Collection<Integer> sampleIds,
             int cancerStudyId, double cutoff) throws DaoException {
         Map<Integer,Long> alteredLength = getCopyNumberAlteredLength(sampleIds, cancerStudyId, cutoff);
@@ -205,7 +207,7 @@ public final class DaoCopyNumberSegment {
         }
         return fraction;
     }
-    
+
     private static Map<Integer,Long> getCopyNumberAlteredLength(Collection<Integer> sampleIds,
             int cancerStudyId, double cutoff) throws DaoException {
         return ClickHouseBulkUploader.upload(sampleIds, stagingTable -> {
@@ -232,12 +234,12 @@ public final class DaoCopyNumberSegment {
             }
         });
     }
-    
+
     /**
-     * 
+     *
      * @param cancerStudyId
      * @return true if segment data exist for the cancer study
-     * @throws DaoException 
+     * @throws DaoException
      */
     public static boolean segmentDataExistForCancerStudy(int cancerStudyId) throws DaoException {
         Connection con = null;
@@ -255,13 +257,13 @@ public final class DaoCopyNumberSegment {
             JdbcUtil.closeAll(DaoCopyNumberSegment.class, con, pstmt, rs);
         }
     }
-    
+
     /**
-     * 
+     *
      * @param cancerStudyId
      * @param sampleId
      * @return true if segment data exist for the case
-     * @throws DaoException 
+     * @throws DaoException
      */
     public static boolean segmentDataExistForSample(int cancerStudyId, int sampleId) throws DaoException {
         Connection con = null;

--- a/src/main/java/org/mskcc/cbio/portal/dao/DaoMutation.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/DaoMutation.java
@@ -650,22 +650,6 @@ public final class DaoMutation {
         return events;
     }
 
-    public static long getLargestMutationEventId() throws DaoException {
-        Connection con = null;
-        PreparedStatement pstmt = null;
-        ResultSet rs = null;
-        try {
-            con = JdbcUtil.getDbConnection(DaoMutation.class);
-            pstmt = con.prepareStatement("SELECT max(`mutation_event_id`) FROM `mutation_event`");
-            rs = pstmt.executeQuery();
-            return rs.next() ? rs.getLong(1) : 0;
-        } catch (SQLException e) {
-            throw new DaoException(e);
-        } finally {
-            JdbcUtil.closeAll(DaoMutation.class, con, pstmt, rs);
-        }
-    }
-
     private static ExtendedMutation extractMutation(ResultSet rs) throws SQLException, DaoException {
         try {
             ExtendedMutation mutation = new ExtendedMutation(extractMutationEvent(rs));

--- a/src/main/java/org/mskcc/cbio/portal/dao/DaoMutation.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/DaoMutation.java
@@ -74,70 +74,77 @@ public final class DaoMutation {
     private static final String DELETE_ALTERATION_DRIVER_ANNOTATION = "DELETE from alteration_driver_annotation WHERE genetic_profile_id=? and sample_id=?";
     private static final String DELETE_MUTATION = "DELETE from mutation WHERE genetic_profile_id=? and sample_id=?";
 
-    public static int addMutation(ExtendedMutation mutation, boolean newMutationEvent) throws DaoException {
+    public static void addMutation(ExtendedMutation mutation) throws DaoException {
         if (!ClickHouseBulkLoader.isBulkLoad()) {
             throw new DaoException("You have to turn on ClickHouseBulkLoader in order to insert mutations");
-        } else {
-            int result = 1;
-            if (newMutationEvent) {
-                //add event first, as mutation has a Foreign key constraint to the event:
-                result = addMutationEvent(mutation.getEvent())+1;
-            }
-
-            if ((mutation.getDriverFilter() != null
+        }
+        // caller must have already added/committed the associated mutation event, or else an exception is thrown
+        if (mutation.getEvent() == null) {
+            throw new DaoException("attempt to add a mutation without an associated mutation event");
+        }
+        // the very first mutation event record stored will be assigned internal id '1' because of
+        // this function call in ClickHouseAutoIncrement : return counter.incrementAndGet();
+        // So value '0' would indicate an uncommitted/uninitialized mutation event subobject
+        if (mutation.getMutationEventId() <= 0) {
+            String chr = mutation.getChr();
+            Long pos = mutation.getStartPosition();
+            String proteinChange = mutation.getProteinChange();
+            throw new DaoException(String.format(
+                    "Attempt to add a mutation before the associated mutation event has been added. Chr:%s S.Pos:%d Prot.Change:%s",
+                    (chr == null ? "null" : chr),
+                    (pos == null ? "null" : Long.toString(pos)),
+                    (proteinChange == null ? "null" : proteinChange)));
+        }
+        if ((mutation.getDriverFilter() != null
                 && !mutation.getDriverFilter().isEmpty()
                 && !mutation.getDriverFilter().toLowerCase().equals("na"))
                 ||
                 (mutation.getDriverTiersFilter() != null
                 && !mutation.getDriverTiersFilter().isEmpty()
                 && !mutation.getDriverTiersFilter().toLowerCase().equals("na"))) {
-                ClickHouseBulkLoader.getClickHouseBulkLoader("alteration_driver_annotation").insertRecord(
+            ClickHouseBulkLoader.getClickHouseBulkLoader("alteration_driver_annotation").insertRecord(
                     Long.toString(mutation.getMutationEventId()),
                     Integer.toString(mutation.getGeneticProfileId()),
                     Integer.toString(mutation.getSampleId()),
                     mutation.getDriverFilter(),
                     mutation.getDriverFilterAnn(),
                     mutation.getDriverTiersFilter(),
-                    mutation.getDriverTiersFilterAnn()
-                );
-            }
-
-            ClickHouseBulkLoader.getClickHouseBulkLoader("mutation").insertRecord(
-                    Long.toString(mutation.getMutationEventId()),
-                    Integer.toString(mutation.getGeneticProfileId()),
-                    Integer.toString(mutation.getSampleId()),
-                    Long.toString(mutation.getGene().getEntrezGeneId()),
-                    mutation.getSequencingCenter(),
-                    mutation.getSequencer(),
-                    mutation.getMutationStatus(),
-                    mutation.getValidationStatus(),
-                    mutation.getTumorSeqAllele1(),
-                    mutation.getTumorSeqAllele2(),
-                    mutation.getMatchedNormSampleBarcode(),
-                    mutation.getMatchNormSeqAllele1(),
-                    mutation.getMatchNormSeqAllele2(),
-                    mutation.getTumorValidationAllele1(),
-                    mutation.getTumorValidationAllele2(),
-                    mutation.getMatchNormValidationAllele1(),
-                    mutation.getMatchNormValidationAllele2(),
-                    mutation.getVerificationStatus(),
-                    mutation.getSequencingPhase(),
-                    mutation.getSequenceSource(),
-                    mutation.getValidationMethod(),
-                    mutation.getScore(),
-                    mutation.getBamFile(),
-                    (mutation.getTumorAltCount() == null) ? null : Integer.toString(mutation.getTumorAltCount()),
-                    (mutation.getTumorRefCount() == null) ? null : Integer.toString(mutation.getTumorRefCount()),
-                    (mutation.getNormalAltCount() == null) ? null : Integer.toString(mutation.getNormalAltCount()),
-                    (mutation.getNormalRefCount() == null) ? null : Integer.toString(mutation.getNormalRefCount()),
-                    //AminoAcidChange column is not used
-                    null,
-                    mutation.getAnnotationJson());
-            return result;
+                    mutation.getDriverTiersFilterAnn());
         }
+        ClickHouseBulkLoader.getClickHouseBulkLoader("mutation").insertRecord(
+                Long.toString(mutation.getMutationEventId()),
+                Integer.toString(mutation.getGeneticProfileId()),
+                Integer.toString(mutation.getSampleId()),
+                Long.toString(mutation.getGene().getEntrezGeneId()),
+                mutation.getSequencingCenter(),
+                mutation.getSequencer(),
+                mutation.getMutationStatus(),
+                mutation.getValidationStatus(),
+                mutation.getTumorSeqAllele1(),
+                mutation.getTumorSeqAllele2(),
+                mutation.getMatchedNormSampleBarcode(),
+                mutation.getMatchNormSeqAllele1(),
+                mutation.getMatchNormSeqAllele2(),
+                mutation.getTumorValidationAllele1(),
+                mutation.getTumorValidationAllele2(),
+                mutation.getMatchNormValidationAllele1(),
+                mutation.getMatchNormValidationAllele2(),
+                mutation.getVerificationStatus(),
+                mutation.getSequencingPhase(),
+                mutation.getSequenceSource(),
+                mutation.getValidationMethod(),
+                mutation.getScore(),
+                mutation.getBamFile(),
+                (mutation.getTumorAltCount() == null) ? null : Integer.toString(mutation.getTumorAltCount()),
+                (mutation.getTumorRefCount() == null) ? null : Integer.toString(mutation.getTumorRefCount()),
+                (mutation.getNormalAltCount() == null) ? null : Integer.toString(mutation.getNormalAltCount()),
+                (mutation.getNormalRefCount() == null) ? null : Integer.toString(mutation.getNormalRefCount()),
+                //AminoAcidChange column is not used
+                null,
+                mutation.getAnnotationJson());
     }
 
-    public static int addMutationEvent(ExtendedMutation.MutationEvent event) throws DaoException {
+    public static void addMutationEvent(ExtendedMutation.MutationEvent event) throws DaoException {
         // use this code if bulk loading
         // write to the temp file maintained by the ClickHouseBulkLoader
         String keyword = MutationKeywordUtils.guessOncotatorMutationKeyword(event.getProteinChange(), event.getMutationType());
@@ -163,7 +170,6 @@ public final class DaoMutation {
                 Integer.toString(event.getProteinPosEnd()),
                 boolToStr(event.isCanonicalTranscript()),
                 keyword==null ? "\\N":(event.getGene().getHugoGeneSymbolAllCaps()+" "+keyword));
-        return 1;
     }
 
     public static void createMutationCountClinicalData(GeneticProfile geneticProfile) throws DaoException {

--- a/src/main/java/org/mskcc/cbio/portal/dao/DaoPatient.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/DaoPatient.java
@@ -253,7 +253,7 @@ public class DaoPatient {
         Connection con = null;
         try {
             con = JdbcUtil.getDbConnection(DaoPatient.class);
-            List<Integer> clinicalEventIds = collectIds(con,
+            List<Long> clinicalEventIds = collectIds(con,
                     "SELECT clinical_event_id FROM clinical_event WHERE patient_id IN ", internalPatientIds);
             ClickHouseBulkDeleter.getBulkDeleter("clinical_event_data", "clinical_event_id").addIds(clinicalEventIds);
             ClickHouseBulkDeleter.getBulkDeleter("clinical_event", "clinical_event_id").addIds(clinicalEventIds);
@@ -287,16 +287,16 @@ public class DaoPatient {
         return internalPatientIds;
     }
 
-    private static List<Integer> collectIds(Connection con, String sqlPrefix, Collection<Integer> ids) throws DaoException, SQLException {
+    private static List<Long> collectIds(Connection con, String sqlPrefix, Collection<Integer> ids) throws DaoException, SQLException {
         if (ids == null || ids.isEmpty()) {
             return Collections.emptyList();
         }
         return ClickHouseBulkUploader.upload(ids, stagingTable -> {
-            List<Integer> collected = new ArrayList<>();
+            List<Long> collected = new ArrayList<>();
             try (PreparedStatement pstmt = con.prepareStatement(sqlPrefix + "(SELECT id FROM " + stagingTable + ")");
                  ResultSet rs = pstmt.executeQuery()) {
                 while (rs.next()) {
-                    collected.add(rs.getInt(1));
+                    collected.add(rs.getLong(1));
                 }
             }
             return collected;

--- a/src/main/java/org/mskcc/cbio/portal/dao/DaoStructuralVariant.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/DaoStructuralVariant.java
@@ -179,22 +179,6 @@ public class DaoStructuralVariant {
         }
     }
 
-    public static long getLargestInternalId() throws DaoException {
-        Connection con = null;
-        PreparedStatement pstmt = null;
-        ResultSet rs = null;
-        try {
-            con = JdbcUtil.getDbConnection(DaoMutation.class);
-            pstmt = con.prepareStatement("SELECT max(`internal_id`) FROM `structural_variant`");
-            rs = pstmt.executeQuery();
-            return rs.next() ? rs.getLong(1) : 0;
-        } catch (SQLException e) {
-            throw new DaoException(e);
-        } finally {
-            JdbcUtil.closeAll(DaoMutation.class, con, pstmt, rs);
-        }
-    }
-
     /**
      * Return all structural variants in the database.
      * @return

--- a/src/main/java/org/mskcc/cbio/portal/dao/DaoStructuralVariant.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/DaoStructuralVariant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2022 The Hyve B.V.
+ * Copyright (c) 2017 - 2026 The Hyve B.V.
  * This code is licensed under the GNU Affero General Public License (AGPL),
  * version 3, or (at your option) any later version.
  */
@@ -28,6 +28,8 @@ import java.util.*;
 import org.mskcc.cbio.portal.model.StructuralVariant;
 
 public class DaoStructuralVariant {
+
+    private static final String STRUCTURAL_VARIANT_SEQUENCE = "seq_structural_variant";
 
     private DaoStructuralVariant() {
     }
@@ -85,8 +87,9 @@ public class DaoStructuralVariant {
         bl.setFieldNames(fieldNames);
 
         // write to the temp file maintained by the ClickHouseBulkLoader
+        Long assignedSvInternalIdentifier = ClickHouseAutoIncrement.nextId(STRUCTURAL_VARIANT_SEQUENCE);
         bl.insertRecord(
-            Long.toString(structuralVariant.getInternalId()),
+            Long.toString(assignedSvInternalIdentifier),
             Integer.toString(structuralVariant.getGeneticProfileId()),
             Integer.toString(structuralVariant.getSampleIdInternal()),
             structuralVariant.getSite1EntrezGeneId() == null ? null : Long.toString(structuralVariant.getSite1EntrezGeneId()),
@@ -136,7 +139,7 @@ public class DaoStructuralVariant {
             && !structuralVariant.getDriverTiersFilter().isEmpty()
             && !structuralVariant.getDriverTiersFilter().toLowerCase().equals("na"))) {
             ClickHouseBulkLoader.getClickHouseBulkLoader("alteration_driver_annotation").insertRecord(
-                Long.toString(structuralVariant.getInternalId()),
+                Long.toString(assignedSvInternalIdentifier),
                 Integer.toString(structuralVariant.getGeneticProfileId()),
                 Integer.toString(structuralVariant.getSampleIdInternal()),
                 structuralVariant.getDriverFilter(),

--- a/src/main/java/org/mskcc/cbio/portal/scripts/ImportCopyNumberSegmentData.java
+++ b/src/main/java/org/mskcc/cbio/portal/scripts/ImportCopyNumberSegmentData.java
@@ -36,6 +36,7 @@ import java.io.*;
 import java.math.BigDecimal;
 import java.util.*;
 import joptsimple.OptionSet;
+import org.mskcc.cbio.portal.dao.ClickHouseAutoIncrement;
 import org.mskcc.cbio.portal.dao.ClickHouseBulkLoader;
 import org.mskcc.cbio.portal.dao.ClickHouseOptimizer;
 import org.mskcc.cbio.portal.dao.DaoCancerStudy;
@@ -63,12 +64,13 @@ public class ImportCopyNumberSegmentData extends ConsoleRunnable {
     private boolean isIncrementalUpdateMode;
     private Set<Integer> processedSampleIds;
 
+    private static final String COPY_NUMBER_SEG_SEQUENCE = "seq_copy_number_seg";
+
     private void importData(File file, int cancerStudyId) throws IOException, DaoException {
         FileReader reader = new FileReader(file);
         BufferedReader buf = new BufferedReader(reader);
         try {
             String line = buf.readLine(); // skip header line
-            long segId = DaoCopyNumberSegment.getLargestId();
             processedSampleIds = new HashSet<>();
             while ((line=buf.readLine()) != null) {
                 ProgressMonitor.incrementCurValue();
@@ -107,7 +109,7 @@ public class ImportCopyNumberSegmentData extends ConsoleRunnable {
                     }
                 }
                 CopyNumberSegment cns = new CopyNumberSegment(cancerStudyId, s.getInternalId(), chrom, start, end, numProbes, segMean);
-                cns.setSegId(++segId);
+                cns.setSegId(ClickHouseAutoIncrement.nextId(COPY_NUMBER_SEG_SEQUENCE)); // TODO : relocate this to dao code layer
                 DaoCopyNumberSegment.addCopyNumberSegment(cns);
                 processedSampleIds.add(s.getInternalId());
             }

--- a/src/main/java/org/mskcc/cbio/portal/scripts/ImportCopyNumberSegmentData.java
+++ b/src/main/java/org/mskcc/cbio/portal/scripts/ImportCopyNumberSegmentData.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2015, 2026 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -64,8 +64,6 @@ public class ImportCopyNumberSegmentData extends ConsoleRunnable {
     private boolean isIncrementalUpdateMode;
     private Set<Integer> processedSampleIds;
 
-    private static final String COPY_NUMBER_SEG_SEQUENCE = "seq_copy_number_seg";
-
     private void importData(File file, int cancerStudyId) throws IOException, DaoException {
         FileReader reader = new FileReader(file);
         BufferedReader buf = new BufferedReader(reader);
@@ -75,7 +73,6 @@ public class ImportCopyNumberSegmentData extends ConsoleRunnable {
             while ((line=buf.readLine()) != null) {
                 ProgressMonitor.incrementCurValue();
                 ConsoleUtil.showProgress();
-                
                 String[] strs = line.split("\t");
                 if (strs.length<6) {
                     System.err.println("wrong format: "+line);
@@ -84,7 +81,6 @@ public class ImportCopyNumberSegmentData extends ConsoleRunnable {
                 String chrom = strs[1].trim();
                 //validate in same way as GistitReader:
                 ValidationUtils.validateChromosome(chrom);
-                
                 long start = Double.valueOf(strs[2]).longValue();
                 long end = Double.valueOf(strs[3]).longValue();
                 if (start >= end) {
@@ -92,7 +88,7 @@ public class ImportCopyNumberSegmentData extends ConsoleRunnable {
                     ProgressMonitor.logWarning("Start position of segment is not lower than end position. Skipping this entry.");
                     entriesSkipped++;
                     continue;
-                }            
+                }
                 int numProbes = new BigDecimal((strs[4])).intValue();
                 double segMean = Double.parseDouble(strs[5]);
 
@@ -109,7 +105,6 @@ public class ImportCopyNumberSegmentData extends ConsoleRunnable {
                     }
                 }
                 CopyNumberSegment cns = new CopyNumberSegment(cancerStudyId, s.getInternalId(), chrom, start, end, numProbes, segMean);
-                cns.setSegId(ClickHouseAutoIncrement.nextId(COPY_NUMBER_SEG_SEQUENCE)); // TODO : relocate this to dao code layer
                 DaoCopyNumberSegment.addCopyNumberSegment(cns);
                 processedSampleIds.add(s.getInternalId());
             }
@@ -121,11 +116,10 @@ public class ImportCopyNumberSegmentData extends ConsoleRunnable {
             buf.close();
         }
     }
-    
+
     public void run() {
         try {
             String description = "Import 'segment data' files";
-            
             OptionSet options = ConsoleUtil.parseStandardDataAndMetaOptions(args, description, true);
             if (options.has("loadMode") && !"bulkLoad".equalsIgnoreCase((String) options.valueOf("loadMode"))) {
                 throw new UnsupportedOperationException("This loader supports bulkLoad load mode only, but "
@@ -135,14 +129,10 @@ public class ImportCopyNumberSegmentData extends ConsoleRunnable {
             String dataFile = (String) options.valueOf("data");
             File descriptorFile = new File((String) options.valueOf("meta"));
             isIncrementalUpdateMode = options.has("overwrite-existing");
-        
             Properties properties = new Properties();
             properties.load(new FileInputStream(descriptorFile));
-            
             ProgressMonitor.setCurrentMessage("Reading data from:  " + dataFile);
-            
             CancerStudy cancerStudy = getCancerStudy(properties);
-            
             if (!isIncrementalUpdateMode && segmentDataExistsForCancerStudy(cancerStudy)) {
                  throw new IllegalArgumentException("Seg data for cancer study " + cancerStudy.getCancerStudyStableId() + " has already been imported: " + dataFile);
             }
@@ -180,10 +170,10 @@ public class ImportCopyNumberSegmentData extends ConsoleRunnable {
             referenceGenome = ReferenceGenome.HOMO_SAPIENS_DEFAULT_GENOME_NAME;
         }
         if (!referenceGenomeId.equalsIgnoreCase(referenceGenome)) {
-            ProgressMonitor.setCurrentMessage(" Genome Build Name does not match, expecting " 
+            ProgressMonitor.setCurrentMessage(" Genome Build Name does not match, expecting "
                     + cancerStudy.getReferenceGenome());
         }
-        copyNumSegFile.referenceGenomeId = getRefGenId(referenceGenomeId); 
+        copyNumSegFile.referenceGenomeId = getRefGenId(referenceGenomeId);
         copyNumSegFile.description = properties.getProperty("description").trim();
         copyNumSegFile.filename = properties.getProperty("data_filename").trim();
         CopyNumberSegmentFile storedCopyNumSegFile = DaoCopyNumberSegmentFile.getCopyNumberSegmentFile(cancerStudy.getInternalId());

--- a/src/main/java/org/mskcc/cbio/portal/scripts/ImportExtendedMutationData.java
+++ b/src/main/java/org/mskcc/cbio/portal/scripts/ImportExtendedMutationData.java
@@ -38,6 +38,7 @@ import java.util.regex.*;
 import org.apache.commons.lang3.StringUtils;
 import org.mskcc.cbio.maf.MafRecord;
 import org.mskcc.cbio.maf.MafUtil;
+import org.mskcc.cbio.portal.dao.ClickHouseAutoIncrement;
 import org.mskcc.cbio.portal.dao.ClickHouseBulkLoader;
 import org.mskcc.cbio.portal.dao.DaoAlleleSpecificCopyNumber;
 import org.mskcc.cbio.portal.dao.DaoCancerStudy;
@@ -95,6 +96,8 @@ public class ImportExtendedMutationData {
 
     private final boolean overwriteExisting;
 
+    private static final String MUTATION_EVENT_SEQUENCE = "seq_mutation_event";
+
     /**
      * construct an ImportExtendedMutationData.
      * Filter mutations according to the no argument MutationFilter().
@@ -133,9 +136,7 @@ public class ImportExtendedMutationData {
 
     public void importData() throws IOException, DaoException {
         ClickHouseBulkLoader.bulkLoadOn();
-
         HashSet <String> sequencedCaseSet = new HashSet<String>();
-
         Map<MutationEvent,MutationEvent> existingEvents = new HashMap<MutationEvent,MutationEvent>();
         ProgressMonitor.setCurrentMessage("Starting to load existing mutation events...");
         for(MutationEvent mutationEvent: DaoMutation.getAllMutationEvents()) {
@@ -143,12 +144,8 @@ public class ImportExtendedMutationData {
         }
         ProgressMonitor.setCurrentMessage("Loaded " + existingEvents.size() + " existing mutation events.");
         Set<MutationEvent> newEvents = new HashSet<MutationEvent>();
-
         Map<ExtendedMutation,ExtendedMutation> mutations = new HashMap<ExtendedMutation,ExtendedMutation>();
-        long mutationEventId = DaoMutation.getLargestMutationEventId();
-
         List<AlleleSpecificCopyNumber> ascnRecords = new ArrayList<AlleleSpecificCopyNumber>();
-
         DaoGeneOptimized daoGene = DaoGeneOptimized.getInstance();
 
         try (FileReader reader = new FileReader(mutationFile);
@@ -435,7 +432,7 @@ public class ImportExtendedMutationData {
                         if (event!=null) {
                             mutation.setEvent(event);
                         } else {
-                            mutation.setMutationEventId(++mutationEventId);
+                            mutation.setMutationEventId(ClickHouseAutoIncrement.nextId(MUTATION_EVENT_SEQUENCE)); // TODO : relocate this to dao code layer
                             existingEvents.put(mutation.getEvent(), mutation.getEvent());
                             newEvents.add(mutation.getEvent());
                         }

--- a/src/main/java/org/mskcc/cbio/portal/scripts/ImportExtendedMutationData.java
+++ b/src/main/java/org/mskcc/cbio/portal/scripts/ImportExtendedMutationData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2022 Memorial Sloan Kettering Cancer Center.
+ * Copyright (c) 2015 - 2026 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -32,9 +32,20 @@
 
 package org.mskcc.cbio.portal.scripts;
 
-import java.io.*;
-import java.util.*;
-import java.util.regex.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.Set;
+import java.util.TreeSet;
 import org.apache.commons.lang3.StringUtils;
 import org.mskcc.cbio.maf.MafRecord;
 import org.mskcc.cbio.maf.MafUtil;
@@ -54,9 +65,9 @@ import org.mskcc.cbio.portal.model.CancerStudy;
 import org.mskcc.cbio.portal.model.CanonicalGene;
 import org.mskcc.cbio.portal.model.ExtendedMutation;
 import org.mskcc.cbio.portal.model.ExtendedMutation.MutationEvent;
-import org.mskcc.cbio.portal.model.shared.GeneticAlterationType;
 import org.mskcc.cbio.portal.model.GeneticProfile;
 import org.mskcc.cbio.portal.model.Sample;
+import org.mskcc.cbio.portal.model.shared.GeneticAlterationType;
 import org.mskcc.cbio.portal.util.ConsoleUtil;
 import org.mskcc.cbio.portal.util.ExtendedMutationUtil;
 import org.mskcc.cbio.portal.util.GeneticProfileUtil;
@@ -85,18 +96,13 @@ public class ImportExtendedMutationData {
     private int samplesSkipped = 0;
     private Set<String> sampleSet = new HashSet<String>();
     private Set<Integer> internalSampleIds = new HashSet<Integer>();
-
     private Set<String> geneSet = new HashSet<String>();
     private Set<String> filteredMutations = new HashSet<String>();
     private Set<String> namespaces = new HashSet<String>();
     private Pattern SEQUENCE_SAMPLES_REGEX = Pattern.compile("^.*sequenced_samples:(.*)$");
     private final String ASCN_NAMESPACE = "ASCN";
-
     private final Integer genePanelId;
-
     private final boolean overwriteExisting;
-
-    private static final String MUTATION_EVENT_SEQUENCE = "seq_mutation_event";
 
     /**
      * construct an ImportExtendedMutationData.
@@ -112,7 +118,6 @@ public class ImportExtendedMutationData {
         this.swissprotIsAccession = false;
         this.genePanelId = (genePanel == null) ? null : GeneticProfileUtil.getGenePanelId(genePanel);
         this.filteredMutations = filteredMutations;
-
         // create default MutationFilter
         myMutationFilter = new MutationFilter( );
         this.namespaces = namespaces;
@@ -139,7 +144,7 @@ public class ImportExtendedMutationData {
         HashSet <String> sequencedCaseSet = new HashSet<String>();
         Map<MutationEvent,MutationEvent> existingEvents = new HashMap<MutationEvent,MutationEvent>();
         ProgressMonitor.setCurrentMessage("Starting to load existing mutation events...");
-        for(MutationEvent mutationEvent: DaoMutation.getAllMutationEvents()) {
+        for (MutationEvent mutationEvent: DaoMutation.getAllMutationEvents()) {
             existingEvents.put(mutationEvent, mutationEvent);
         }
         ProgressMonitor.setCurrentMessage("Loaded " + existingEvents.size() + " existing mutation events.");
@@ -147,30 +152,23 @@ public class ImportExtendedMutationData {
         Map<ExtendedMutation,ExtendedMutation> mutations = new HashMap<ExtendedMutation,ExtendedMutation>();
         List<AlleleSpecificCopyNumber> ascnRecords = new ArrayList<AlleleSpecificCopyNumber>();
         DaoGeneOptimized daoGene = DaoGeneOptimized.getInstance();
-
-        try (FileReader reader = new FileReader(mutationFile);
-             BufferedReader buf = new BufferedReader(reader)) {
-
+        try (
+                FileReader reader = new FileReader(mutationFile);
+                BufferedReader buf = new BufferedReader(reader)) { // begin try-with-resources
         // process MAF header and return line immediately following it
         String line = processMAFHeader(buf);
-
         MafUtil mafUtil = new MafUtil(line, namespaces);
-
         boolean fileHasOMAData = false;
-
         if (mafUtil.getMaFImpactIndex() >= 0) {
             // fail gracefully if a non-essential column is missing
             // e.g. if there is no MA_link.var column, we assume that the value is NA and insert it as such
             fileHasOMAData = true;
-            ProgressMonitor.setCurrentMessage(" --> OMA Scores Column Number:  "
-                                       + mafUtil.getMaFImpactIndex());
-        }
-        else {
+            ProgressMonitor.setCurrentMessage(" --> OMA Scores Column Number:  " + mafUtil.getMaFImpactIndex());
+        } else {
             fileHasOMAData = false;
         }
 
         GeneticProfile geneticProfile = DaoGeneticProfile.getGeneticProfileById(geneticProfileId);
-
         CancerStudy cancerStudy = DaoCancerStudy.getCancerStudyByInternalId(geneticProfile.getCancerStudyId());
         String referenceGenome = cancerStudy.getReferenceGenome();
         if (referenceGenome == null) {
@@ -178,16 +176,12 @@ public class ImportExtendedMutationData {
         }
         String genomeBuildName = DaoReferenceGenome.getReferenceGenomeByGenomeName(referenceGenome).getBuildName();
         Set<Integer> processedSamples = new HashSet<>();
-        while((line=buf.readLine()) != null)
-        {
+        while ((line = buf.readLine()) != null) {
             ProgressMonitor.incrementCurValue();
             ConsoleUtil.showProgress();
-
-            if(TsvUtil.isDataLine(line))
-            {
+            if (TsvUtil.isDataLine(line)) {
                 String[] parts = TsvUtil.splitTsvLine(line);
                 MafRecord record = mafUtil.parseRecord(line);
-
                 if (!record.getNcbiBuild().equalsIgnoreCase(genomeBuildName)) {
                     ProgressMonitor.logWarning("Genome Build Name does not match, expecting " + genomeBuildName);
                 }
@@ -203,70 +197,56 @@ public class ImportExtendedMutationData {
                         if (sampleSet.add(barCode))
                             samplesSkipped++;
                         continue;
-                    }
-                    else {
+                    } else {
                         throw new RuntimeException("Unknown sample id '" + StableIdUtil.getSampleId(barCode) + "' found in MAF file: " + this.mutationFile.getCanonicalPath());
                     }
-                } else if (overwriteExisting && !processedSamples.contains(sample.getInternalId())) {
-                    DaoMutation.deleteAllRecordsInGeneticProfileForSample(geneticProfileId, sample.getInternalId());
-                    processedSamples.add(sample.getInternalId());
+                } else {
+                    if (overwriteExisting && !processedSamples.contains(sample.getInternalId())) {
+                        DaoMutation.deleteAllRecordsInGeneticProfileForSample(geneticProfileId, sample.getInternalId());
+                        processedSamples.add(sample.getInternalId());
+                    }
                 }
-
                 String validationStatus = record.getValidationStatus();
-
-                if (validationStatus == null ||
-                    validationStatus.equalsIgnoreCase("Wildtype"))
-                {
+                if (validationStatus == null || validationStatus.equalsIgnoreCase("Wildtype")) {
                     ProgressMonitor.logWarning("Skipping entry with Validation_Status: Wildtype");
                     entriesSkipped++;
                     continue;
                 }
-
                 String chr = DaoGeneOptimized.normalizeChr(record.getChr().toUpperCase());
-                if (chr==null) {
+                if (chr == null) {
                     ProgressMonitor.logWarning("Skipping entry with chromosome value: " + record.getChr());
                     entriesSkipped++;
                     continue;
                 }
                 record.setChr(chr);
-
-                if (record.getStartPosition() < 0)
+                if (record.getStartPosition() < 0) {
                     record.setStartPosition(0);
-
-                if (record.getEndPosition() < 0)
-                    record.setEndPosition(0);
-
-                String mutationType,
-                    proteinChange,
-                    aaChange,
-                    codonChange,
-                    refseqMrnaId,
-                    uniprotAccession;
-
-                int proteinPosStart,
-                    proteinPosEnd;
-
-                // determine whether to use canonical or best effect transcript
-
-                // try canonical first
-                if (ExtendedMutationUtil.isAcceptableMutation(record.getVariantClassification()))
-                {
-                    mutationType = record.getVariantClassification();
                 }
-                // if not acceptable either, use the default value
-                else
-                {
+                if (record.getEndPosition() < 0) {
+                    record.setEndPosition(0);
+                }
+                String mutationType;
+                String proteinChange;
+                String aaChange;
+                String codonChange;
+                String refseqMrnaId;
+                String uniprotAccession;
+                int proteinPosStart;
+                int proteinPosEnd;
+                // determine whether to use canonical or best effect transcript
+                // try canonical first
+                if (ExtendedMutationUtil.isAcceptableMutation(record.getVariantClassification())) {
+                    mutationType = record.getVariantClassification();
+                } else {
+                    // if not acceptable either, use the default value
                     mutationType = ExtendedMutationUtil.getMutationType(record);
                 }
-
                 // skip RNA mutations
-                if (mutationType != null && mutationType.equalsIgnoreCase("rna"))
-                {
+                if (mutationType != null && mutationType.equalsIgnoreCase("rna")) {
                     ProgressMonitor.logWarning("Skipping entry with mutation type: RNA");
                     entriesSkipped++;
                     continue;
                 }
-
                 proteinChange = ExtendedMutationUtil.getProteinChange(parts, record);
                 //proteinChange = record.getProteinChange();
                 aaChange = record.getAminoAcidChange();
@@ -274,20 +254,14 @@ public class ImportExtendedMutationData {
                 refseqMrnaId = record.getRefSeq();
                 //always uniprot accession
                 uniprotAccession = record.getSwissprot();
-                
-                proteinPosStart = ExtendedMutationUtil.getProteinPosStart(
-                        record.getProteinPosition(), proteinChange);
-                proteinPosEnd = ExtendedMutationUtil.getProteinPosEnd(
-                        record.getProteinPosition(), proteinChange);
-
+                proteinPosStart = ExtendedMutationUtil.getProteinPosStart(record.getProteinPosition(), proteinChange);
+                proteinPosEnd = ExtendedMutationUtil.getProteinPosEnd(record.getProteinPosition(), proteinChange);
                 //  Assume we are dealing with Entrez Gene Ids (this is the best / most stable option)
                 String geneSymbol = record.getHugoGeneSymbol();
                 String entrezIdString = record.getGivenEntrezGeneId();
-
                 CanonicalGene gene = null;
                 // try to parse entrez if it is not empty nor 0:
-                if (!(entrezIdString.isEmpty() ||
-                      entrezIdString.equals("0"))) {
+                if (!(entrezIdString.isEmpty() || entrezIdString.equals("0"))) {
                     Long entrezGeneId;
                     try {
                         entrezGeneId = Long.parseLong(entrezIdString);
@@ -296,42 +270,32 @@ public class ImportExtendedMutationData {
                     }
                     //non numeric values or negative values should not be allowed:
                     if (entrezGeneId == null || entrezGeneId < 0) {
-                        ProgressMonitor.logWarning(
-                                "Ignoring line with invalid Entrez_Id " +
-                                entrezIdString);
+                        ProgressMonitor.logWarning( "Ignoring line with invalid Entrez_Id " + entrezIdString);
                         entriesSkipped++;
                         continue;
                     } else {
                         gene = daoGene.getGene(entrezGeneId);
                         if (gene == null) {
                             //skip if not in DB:
-                            ProgressMonitor.logWarning(
-                                    "Entrez gene ID " + entrezGeneId +
-                                    " not found. Record will be skipped.");
+                            ProgressMonitor.logWarning("Entrez gene ID " + entrezGeneId + " not found. Record will be skipped.");
                             entriesSkipped++;
                             continue;
                         }
                     }
                 }
-
                 // If Entrez Gene ID Fails, try Symbol.
-                if (gene == null &&
-                        !(geneSymbol.equals("") ||
-                          geneSymbol.equals("Unknown"))) {
+                if (gene == null && !(geneSymbol.equals("") || geneSymbol.equals("Unknown"))) {
                     gene = daoGene.getNonAmbiguousGene(geneSymbol, true);
                 }
-
                 // assume symbol=Unknown and entrez=0 (or missing Entrez column) to imply an
                 // intergenic, irrespective of what the column Variant_Classification says
-                if (geneSymbol.equals("Unknown") &&
-                        (entrezIdString.equals("0") || mafUtil.getEntrezGeneIdIndex() == -1)) {
+                if (geneSymbol.equals("Unknown") && (entrezIdString.equals("0") || mafUtil.getEntrezGeneIdIndex() == -1)) {
                     // give extra warning if mutationType is something different from IGR:
-                    if (mutationType != null &&
-                            !mutationType.equalsIgnoreCase("IGR")) {
+                    if (mutationType != null && !mutationType.equalsIgnoreCase("IGR")) {
                         ProgressMonitor.logWarning(
-                            "Treating mutation with gene symbol 'Unknown' " +
-                            (mafUtil.getEntrezGeneIdIndex() == -1 ? "" : "and Entrez gene id 0") + " as intergenic ('IGR') " +
-                            "instead of '" + mutationType + "'. Entry filtered/skipped.");
+                                "Treating mutation with gene symbol 'Unknown' " +
+                                (mafUtil.getEntrezGeneIdIndex() == -1 ? "" : "and Entrez gene id 0") + " as intergenic ('IGR') " +
+                                "instead of '" + mutationType + "'. Entry filtered/skipped.");
                     }
                     // treat as IGR:
                     myMutationFilter.decisions++;
@@ -340,7 +304,6 @@ public class ImportExtendedMutationData {
                     entriesSkipped++;
                     continue;
                 }
-
                 // skip the record if a gene was expected but not identified
                 if (gene == null) {
                     ProgressMonitor.logWarning(
@@ -352,7 +315,6 @@ public class ImportExtendedMutationData {
                     continue;
                 } else {
                     ExtendedMutation mutation = new ExtendedMutation();
-
                     mutation.setGeneticProfileId(geneticProfileId);
                     mutation.setSampleId(sample.getInternalId());
                     mutation.setGene(gene);
@@ -373,9 +335,9 @@ public class ImportExtendedMutationData {
                     // log whether tumor seq allele is empty (failed to resolve tumor seq allele because of invalid data values)
                     if (mutation.getTumorSeqAllele().isEmpty()) {
                         ProgressMonitor.logWarning("Tumor allele could not be resolved for sample '" + sample.getStableId() +
-                            "' (chr,start,end,ref,tum1,tum2) = (" + record.getChr() + "," + record.getStartPosition() + "," +
-                            record.getEndPosition() + "," + record.getReferenceAllele() + "," + record.getTumorSeqAllele1() +
-                            "," + record.getTumorSeqAllele2() + ")");
+                                "' (chr,start,end,ref,tum1,tum2) = (" + record.getChr() + "," + record.getStartPosition() + "," +
+                                record.getEndPosition() + "," + record.getReferenceAllele() + "," + record.getTumorSeqAllele1() +
+                                "," + record.getTumorSeqAllele2() + ")");
                     }
                     mutation.setDbSnpRs(record.getDbSNP_RS());
                     mutation.setDbSnpValStatus(record.getDbSnpValStatus());
@@ -423,22 +385,18 @@ public class ImportExtendedMutationData {
                     mutation.setAnnotationJson(
                         mafUtil.getNamespaceColumnParser().writeValueAsString(record.getNamespacesMap())
                     );
-
                     sequencedCaseSet.add(sample.getStableId());
-
                     //  Filter out Mutations
-                    if( myMutationFilter.acceptMutation( mutation, this.filteredMutations )) {
+                    if (myMutationFilter.acceptMutation(mutation, this.filteredMutations)) {
                         MutationEvent event = existingEvents.get(mutation.getEvent());
-                        if (event!=null) {
+                        if (event != null) {
                             mutation.setEvent(event);
                         } else {
-                            mutation.setMutationEventId(ClickHouseAutoIncrement.nextId(MUTATION_EVENT_SEQUENCE)); // TODO : relocate this to dao code layer
                             existingEvents.put(mutation.getEvent(), mutation.getEvent());
                             newEvents.add(mutation.getEvent());
                         }
-
                         ExtendedMutation exist = mutations.get(mutation);
-                        if (exist!=null) {
+                        if (exist != null) {
                             ExtendedMutation merged = mergeMutationData(exist, mutation);
                             mutations.put(merged, merged);
                         } else {
@@ -449,36 +407,31 @@ public class ImportExtendedMutationData {
                             ascn.updateAscnUniqueKeyDetails(mutation);
                             ascnRecords.add(ascn);
                         }
-
                         //keep track:
                         sampleSet.add(sample.getStableId());
                         internalSampleIds.add(sample.getInternalId());
-                        geneSet.add(mutation.getEntrezGeneId()+"");
-                    }
-                    else {
+                        geneSet.add(mutation.getEntrezGeneId() + "");
+                    } else {
                         entriesSkipped++;
                     }
                 }
             }
         }
         DaoSampleProfile.upsertSampleToProfileMapping(internalSampleIds, geneticProfileId, genePanelId);
-
         for (MutationEvent event : newEvents) {
             try {
-                DaoMutation.addMutationEvent(event);
+                DaoMutation.addMutationEvent(event); // This also sets the mutation event internal id
             } catch (DaoException ex) {
                 throw ex;
             }
         }
-
         for (ExtendedMutation mutation : mutations.values()) {
             try {
-                DaoMutation.addMutation(mutation,false);
+                DaoMutation.addMutation(mutation);
             } catch (DaoException ex) {
                 throw ex;
             }
         }
-
         for (AlleleSpecificCopyNumber ascn : ascnRecords) {
             try {
                 DaoAlleleSpecificCopyNumber.addAlleleSpecificCopyNumber(ascn);
@@ -486,8 +439,7 @@ public class ImportExtendedMutationData {
                 throw ex;
             }
         }
-
-        if( ClickHouseBulkLoader.isBulkLoad()) {
+        if (ClickHouseBulkLoader.isBulkLoad()) {
             ClickHouseBulkLoader.flushAll();
         }
         // run sanity check on `mutation_event` to determine whether duplicate
@@ -495,12 +447,11 @@ public class ImportExtendedMutationData {
         if (DaoMutation.hasDuplicateMutationEvents()) {
             throw new DaoException("Duplicate mutation events were detected during this import. Aborting...");
         }
-
         /*
-         * At MSKCC there are some MUTATION_UNCALLED
-         * profiles that shouldn't be included when determining the number of
-         * mutations for a sample
-         */
+        * At MSKCC there are some MUTATION_UNCALLED
+        * profiles that shouldn't be included when determining the number of
+        * mutations for a sample
+        */
         if (geneticProfile.getGeneticAlterationType().equals(GeneticAlterationType.MUTATION_EXTENDED)) {
             DaoMutation.createMutationCountClinicalData(geneticProfile);
         }
@@ -508,11 +459,9 @@ public class ImportExtendedMutationData {
         // fine to calculate for any genetic profile
         ProgressMonitor.setCurrentMessage("Calculating mutation counts by keyword...");
         DaoMutation.calculateMutationCountByKeyword(geneticProfileId);
-
-        if( ClickHouseBulkLoader.isBulkLoad()) {
+        if (ClickHouseBulkLoader.isBulkLoad()) {
             ClickHouseBulkLoader.flushAll();
         }
-
         if (entriesSkipped > 0) {
             ProgressMonitor.setCurrentMessage(" --> total number of data entries skipped (see table below):  " + entriesSkipped);
         }
@@ -521,66 +470,63 @@ public class ImportExtendedMutationData {
             ProgressMonitor.setCurrentMessage(" --> total number of samples skipped (normal samples): " + samplesSkipped);
         }
         ProgressMonitor.setCurrentMessage(" --> total number of genes for which one or more mutation events were stored:  " + geneSet.size());
-
         ProgressMonitor.setCurrentMessage("Filtering table:\n-----------------");
         ProgressMonitor.setCurrentMessage(myMutationFilter.getStatistics() );
         } // end try-with-resources
     }
 
     /**
-         * merge the current mutation
-         * @return
-         */
-        private ExtendedMutation mergeMutationData(ExtendedMutation mut1, ExtendedMutation mut2) {
-            ExtendedMutation ret = mut1;
-            if (!mut1.getMatchedNormSampleBarcode().equalsIgnoreCase(mut2.getMatchedNormSampleBarcode())) {
-                if (mut2.getMatchedNormSampleBarcode().matches("TCGA-..-....-10.*")) {
-                    // select blood normal if available
+     * merge the current mutation
+     * @return
+     */
+    private ExtendedMutation mergeMutationData(ExtendedMutation mut1, ExtendedMutation mut2) {
+        ExtendedMutation ret = mut1;
+        if (!mut1.getMatchedNormSampleBarcode().equalsIgnoreCase(mut2.getMatchedNormSampleBarcode())) {
+            if (mut2.getMatchedNormSampleBarcode().matches("TCGA-..-....-10.*")) {
+                // select blood normal if available
+                ret = mut2;
+            }
+        } else if (!mut1.getValidationStatus().equalsIgnoreCase(mut2.getValidationStatus())) {
+            if (mut2.getValidationStatus().equalsIgnoreCase("Valid") ||
+                    mut2.getValidationStatus().equalsIgnoreCase("VALIDATED")) {
+                // select validated mutations
+                ret = mut2;
+            }
+        } else if (!mut1.getMutationStatus().equalsIgnoreCase(mut2.getMutationStatus())) {
+            if (mut2.getMutationStatus().equalsIgnoreCase("Germline")) {
+                // select germline over somatic
+                ret = mut2;
+            } else if (mut2.getMutationStatus().equalsIgnoreCase("SOMATIC")) {
+                if (!mut1.getMutationStatus().equalsIgnoreCase("Germline")) {
+                    // select somatic over others
                     ret = mut2;
-                }
-            } else if (!mut1.getValidationStatus().equalsIgnoreCase(mut2.getValidationStatus())) {
-                if (mut2.getValidationStatus().equalsIgnoreCase("Valid") ||
-                        mut2.getValidationStatus().equalsIgnoreCase("VALIDATED")) {
-                    // select validated mutations
-                    ret = mut2;
-                }
-            } else if (!mut1.getMutationStatus().equalsIgnoreCase(mut2.getMutationStatus())) {
-                if (mut2.getMutationStatus().equalsIgnoreCase("Germline")) {
-                    // select germline over somatic
-                    ret = mut2;
-                } else if (mut2.getMutationStatus().equalsIgnoreCase("SOMATIC")) {
-                    if (!mut1.getMutationStatus().equalsIgnoreCase("Germline")) {
-                        // select somatic over others
-                        ret = mut2;
-                    }
                 }
             }
-
-            // merge centers
-            Set<String> centers = new TreeSet<String>(Arrays.asList(mut1.getSequencingCenter().split(";")));
-            if (centers.addAll(Arrays.asList(mut2.getSequencingCenter().split(";")))) {
-                if (centers.size()>1) {
-                    centers.remove("NA");
-                }
-                ret.setSequencingCenter(StringUtils.join(centers, ";"));
-            }
-
-            return ret;
         }
+        // merge centers
+        Set<String> centers = new TreeSet<String>(Arrays.asList(mut1.getSequencingCenter().split(";")));
+        if (centers.addAll(Arrays.asList(mut2.getSequencingCenter().split(";")))) {
+            if (centers.size()>1) {
+                centers.remove("NA");
+            }
+            ret.setSequencingCenter(StringUtils.join(centers, ";"));
+        }
+        return ret;
+    }
 
     private String transformOMAScore( String omaScore) {
-        if( omaScore == null || omaScore.length() ==0) {
+        if (omaScore == null || omaScore.length() == 0) {
             return omaScore;
         }
-        if( omaScore.equalsIgnoreCase("H") || omaScore.equalsIgnoreCase("high")) {
+        if (omaScore.equalsIgnoreCase("H") || omaScore.equalsIgnoreCase("high")) {
             return "H";
-        } else if( omaScore.equalsIgnoreCase("M") || omaScore.equalsIgnoreCase("medium")) {
+        } else if (omaScore.equalsIgnoreCase("M") || omaScore.equalsIgnoreCase("medium")) {
             return "M";
-        } else if( omaScore.equalsIgnoreCase("L") || omaScore.equalsIgnoreCase("low")) {
+        } else if (omaScore.equalsIgnoreCase("L") || omaScore.equalsIgnoreCase("low")) {
             return "L";
-        } else if( omaScore.equalsIgnoreCase("N") || omaScore.equalsIgnoreCase("neutral")) {
+        } else if (omaScore.equalsIgnoreCase("N") || omaScore.equalsIgnoreCase("neutral")) {
             return "N";
-        } else if( omaScore.equalsIgnoreCase("[sent]")) {
+        } else if (omaScore.equalsIgnoreCase("[sent]")) {
             return "NA";
         } else {
             return omaScore;
@@ -606,8 +552,9 @@ public class ImportExtendedMutationData {
     private Set<Integer> getSequencedInternalSampleId(String sequencedSamplesIDList, GeneticProfile geneticProfile) {
         Set<Integer> toReturn = new HashSet<>();
         for (String stableSampleID : sequencedSamplesIDList.trim().split("\\s")) {
-            Sample sample = DaoSample.getSampleByCancerStudyAndSampleId(geneticProfile.getCancerStudyId(),
-                                                                        StableIdUtil.getSampleId(stableSampleID));
+            Sample sample = DaoSample.getSampleByCancerStudyAndSampleId(
+                    geneticProfile.getCancerStudyId(),
+                    StableIdUtil.getSampleId(stableSampleID));
             // if data files are run through validator, this condition should be minimal
             if (sample == null) {
                 missingSample(stableSampleID);

--- a/src/main/java/org/mskcc/cbio/portal/scripts/ImportStructuralVariantData.java
+++ b/src/main/java/org/mskcc/cbio/portal/scripts/ImportStructuralVariantData.java
@@ -26,6 +26,7 @@ package org.mskcc.cbio.portal.scripts;
 import java.io.*;
 import java.util.*;
 import org.mskcc.cbio.maf.TabDelimitedFileUtil;
+import org.mskcc.cbio.portal.dao.ClickHouseAutoIncrement;
 import org.mskcc.cbio.portal.dao.ClickHouseBulkLoader;
 import org.mskcc.cbio.portal.dao.DaoException;
 import org.mskcc.cbio.portal.dao.DaoGeneOptimized;
@@ -59,6 +60,8 @@ public class ImportStructuralVariantData {
 
     private final boolean isIncrementalUpdateMode;
 
+    private static final String STRUCTURAL_VARIANT_SEQUENCE = "seq_structural_variant";
+
     public ImportStructuralVariantData(
         File structuralVariantFile, 
         int geneticProfileId, 
@@ -85,7 +88,6 @@ public class ImportStructuralVariantData {
         // Genetic profile is read in first
         GeneticProfile geneticProfile = DaoGeneticProfile.getGeneticProfileById(geneticProfileId);
         Set<Integer> sampleIds = new HashSet<>();
-        long id = DaoStructuralVariant.getLargestInternalId();
         Set<String> uniqueSVs = new HashSet<>();
         while ((line = buf.readLine()) != null) {
             ProgressMonitor.incrementCurValue();
@@ -94,7 +96,7 @@ public class ImportStructuralVariantData {
                 recordCount++;
                 String parts[] = TsvUtil.splitTsvLine(line);
                 StructuralVariant structuralVariant = structuralVariantUtil.parseStructuralVariantRecord(parts);
-                structuralVariant.setInternalId(++id);
+                structuralVariant.setInternalId(ClickHouseAutoIncrement.nextId(STRUCTURAL_VARIANT_SEQUENCE)); // TODO : relocate this to dao code layer
                 structuralVariant.setGeneticProfileId(geneticProfileId);
                 if (!structuralVariantUtil.hasRequiredStructuralVariantFields(structuralVariant)) {
                     ProgressMonitor.logWarning(

--- a/src/main/java/org/mskcc/cbio/portal/scripts/ImportStructuralVariantData.java
+++ b/src/main/java/org/mskcc/cbio/portal/scripts/ImportStructuralVariantData.java
@@ -60,12 +60,10 @@ public class ImportStructuralVariantData {
 
     private final boolean isIncrementalUpdateMode;
 
-    private static final String STRUCTURAL_VARIANT_SEQUENCE = "seq_structural_variant";
-
     public ImportStructuralVariantData(
-        File structuralVariantFile, 
-        int geneticProfileId, 
-        String genePanel, 
+        File structuralVariantFile,
+        int geneticProfileId,
+        String genePanel,
         Set<String> namespaces,
         boolean isIncrementalUpdateMode
     ) throws DaoException {
@@ -96,7 +94,6 @@ public class ImportStructuralVariantData {
                 recordCount++;
                 String parts[] = TsvUtil.splitTsvLine(line);
                 StructuralVariant structuralVariant = structuralVariantUtil.parseStructuralVariantRecord(parts);
-                structuralVariant.setInternalId(ClickHouseAutoIncrement.nextId(STRUCTURAL_VARIANT_SEQUENCE)); // TODO : relocate this to dao code layer
                 structuralVariant.setGeneticProfileId(geneticProfileId);
                 if (!structuralVariantUtil.hasRequiredStructuralVariantFields(structuralVariant)) {
                     ProgressMonitor.logWarning(

--- a/src/main/java/org/mskcc/cbio/portal/scripts/ImportTimelineData.java
+++ b/src/main/java/org/mskcc/cbio/portal/scripts/ImportTimelineData.java
@@ -35,6 +35,7 @@ package org.mskcc.cbio.portal.scripts;
 import java.io.*;
 import java.util.*;
 import joptsimple.OptionSet;
+import org.mskcc.cbio.portal.dao.ClickHouseAutoIncrement;
 import org.mskcc.cbio.portal.dao.ClickHouseBulkLoader;
 import org.mskcc.cbio.portal.dao.DaoClinicalEvent;
 import org.mskcc.cbio.portal.dao.DaoException;
@@ -50,6 +51,8 @@ import org.mskcc.cbio.portal.util.ProgressMonitor;
  * @author jgao, inodb
  */
 public class ImportTimelineData extends ConsoleRunnable {
+
+    private static final String CLINICAL_EVENT_SEQUENCE = "seq_clinical_event";
 
 	private static void importData(String dataFile, int cancerStudyId, boolean overwriteExisting) throws IOException, DaoException {
 		ClickHouseBulkLoader.bulkLoadOn();
@@ -75,9 +78,7 @@ public class ImportTimelineData extends ConsoleRunnable {
 					+ "PATIENT_ID\tSTART_DATE\tSTOP_DATE\tEVENT_TYPE");
 			}
 
-			long clinicalEventId = DaoClinicalEvent.getLargestClinicalEventId();
 			Set<Integer> processedPatientIds = new HashSet<>();
-
 			while ((line = buff.readLine()) != null) {
 				line = line.trim();
 	
@@ -97,7 +98,7 @@ public class ImportTimelineData extends ConsoleRunnable {
 					DaoClinicalEvent.deleteByPatientId(patient.getInternalId());
 				}
 				ClinicalEvent event = new ClinicalEvent();
-				event.setClinicalEventId(++clinicalEventId);
+				event.setClinicalEventId(ClickHouseAutoIncrement.nextId(CLINICAL_EVENT_SEQUENCE)); // TODO : relocate this to dao code layer
 				event.setPatientId(patient.getInternalId());
 				event.setStartDate(Long.valueOf(fields[1]));
 				if (indexCategorySpecificField != 3 && !fields[2].isEmpty()) {

--- a/src/main/java/org/mskcc/cbio/portal/scripts/ImportTimelineData.java
+++ b/src/main/java/org/mskcc/cbio/portal/scripts/ImportTimelineData.java
@@ -47,102 +47,90 @@ import org.mskcc.cbio.portal.util.ProgressMonitor;
 
 /**
  * Imports timeline data for display in patient view
- * 
+ *
  * @author jgao, inodb
  */
 public class ImportTimelineData extends ConsoleRunnable {
 
-    private static final String CLINICAL_EVENT_SEQUENCE = "seq_clinical_event";
+    private static void importData(String dataFile, int cancerStudyId, boolean overwriteExisting) throws IOException, DaoException {
+        ClickHouseBulkLoader.bulkLoadOn();
 
-	private static void importData(String dataFile, int cancerStudyId, boolean overwriteExisting) throws IOException, DaoException {
-		ClickHouseBulkLoader.bulkLoadOn();
-
-		ProgressMonitor.setCurrentMessage("Reading file " + dataFile);
-		FileReader reader = new FileReader(dataFile);
-		BufferedReader buff = new BufferedReader(reader);
-		try {
-			String line = buff.readLine();
-	
-			// Check event category agnostic headers
-			String[] headers = line.split("\t");
-			int indexCategorySpecificField = -1;
-			if (headers[0].equals("PATIENT_ID") && headers[1].equals("START_DATE")) {
-				if ("STOP_DATE".equals(headers[2]) && "EVENT_TYPE".equals(headers[3])) {
-					indexCategorySpecificField = 4;
-				} else if (headers[2].equals("EVENT_TYPE")) {
-					indexCategorySpecificField = 3;
-				}
-			}
-			if (indexCategorySpecificField == -1) {
-				throw new RuntimeException("The first line must start with\n'PATIENT_ID\tSTART_DATE\tEVENT_TYPE'\nor\n"
-					+ "PATIENT_ID\tSTART_DATE\tSTOP_DATE\tEVENT_TYPE");
-			}
-
-			Set<Integer> processedPatientIds = new HashSet<>();
-			while ((line = buff.readLine()) != null) {
-				line = line.trim();
-	
-				String[] fields = line.split("\t");
-				if (fields.length > headers.length) {
-					//TODO - should better throw an exception here...
-					ProgressMonitor.logWarning("more attributes than header: " + line + ". Skipping entry.");
-					continue;
-				}
-				String patientId = fields[0];
-				Patient patient = DaoPatient.getPatientByCancerStudyAndPatientId(cancerStudyId, patientId);
-				if (patient == null) {
-					ProgressMonitor.logWarning("Patient " + patientId + " not found in study " + cancerStudyId + ". Skipping entry.");
-					continue;
-				}
-				if (overwriteExisting && processedPatientIds.add(patient.getInternalId())) {
-					DaoClinicalEvent.deleteByPatientId(patient.getInternalId());
-				}
-				ClinicalEvent event = new ClinicalEvent();
-				event.setClinicalEventId(ClickHouseAutoIncrement.nextId(CLINICAL_EVENT_SEQUENCE)); // TODO : relocate this to dao code layer
-				event.setPatientId(patient.getInternalId());
-				event.setStartDate(Long.valueOf(fields[1]));
-				if (indexCategorySpecificField != 3 && !fields[2].isEmpty()) {
-					event.setStopDate(Long.valueOf(fields[2]));
-				}
-				event.setEventType(fields[indexCategorySpecificField - 1]);
-				Map<String, String> eventData = new HashMap<String, String>();
-				for (int i = indexCategorySpecificField; i < fields.length; i++) {
-					if (!fields[i].isEmpty()) {
-						eventData.put(headers[i], fields[i]);
-					}
-				}
-				event.setEventData(eventData);
-	
-				DaoClinicalEvent.addClinicalEvent(event);
-			}
-	
-			ClickHouseBulkLoader.flushAll();
-		}
-		finally {
-			buff.close();
-		}
-	}
+        ProgressMonitor.setCurrentMessage("Reading file " + dataFile);
+        FileReader reader = new FileReader(dataFile);
+        BufferedReader buff = new BufferedReader(reader);
+        try {
+            String line = buff.readLine();
+            // Check event category agnostic headers
+            String[] headers = line.split("\t");
+            int indexCategorySpecificField = -1;
+            if (headers[0].equals("PATIENT_ID") && headers[1].equals("START_DATE")) {
+                if ("STOP_DATE".equals(headers[2]) && "EVENT_TYPE".equals(headers[3])) {
+                    indexCategorySpecificField = 4;
+                } else if (headers[2].equals("EVENT_TYPE")) {
+                    indexCategorySpecificField = 3;
+                }
+            }
+            if (indexCategorySpecificField == -1) {
+                throw new RuntimeException("The first line must start with\n'PATIENT_ID\tSTART_DATE\tEVENT_TYPE'\nor\n"
+                    + "PATIENT_ID\tSTART_DATE\tSTOP_DATE\tEVENT_TYPE");
+            }
+            Set<Integer> processedPatientIds = new HashSet<>();
+            while ((line = buff.readLine()) != null) {
+                line = line.trim();
+                String[] fields = line.split("\t");
+                if (fields.length > headers.length) {
+                    //TODO - should better throw an exception here...
+                    ProgressMonitor.logWarning("more attributes than header: " + line + ". Skipping entry.");
+                    continue;
+                }
+                String patientId = fields[0];
+                Patient patient = DaoPatient.getPatientByCancerStudyAndPatientId(cancerStudyId, patientId);
+                if (patient == null) {
+                    ProgressMonitor.logWarning("Patient " + patientId + " not found in study " + cancerStudyId + ". Skipping entry.");
+                    continue;
+                }
+                if (overwriteExisting && processedPatientIds.add(patient.getInternalId())) {
+                    DaoClinicalEvent.deleteByPatientId(patient.getInternalId());
+                }
+                ClinicalEvent event = new ClinicalEvent();
+                event.setPatientId(patient.getInternalId());
+                event.setStartDate(Long.valueOf(fields[1]));
+                if (indexCategorySpecificField != 3 && !fields[2].isEmpty()) {
+                    event.setStopDate(Long.valueOf(fields[2]));
+                }
+                event.setEventType(fields[indexCategorySpecificField - 1]);
+                Map<String, String> eventData = new HashMap<String, String>();
+                for (int i = indexCategorySpecificField; i < fields.length; i++) {
+                    if (!fields[i].isEmpty()) {
+                        eventData.put(headers[i], fields[i]);
+                    }
+                }
+                event.setEventData(eventData);
+                DaoClinicalEvent.addClinicalEvent(event);
+            }
+            ClickHouseBulkLoader.flushAll();
+        } finally {
+            buff.close();
+        }
+    }
 
     public void run() {
         try {
-		    String description = "Import 'timeline' data";
+            String description = "Import 'timeline' data";
 
-		    OptionSet options = ConsoleUtil.parseStandardDataAndMetaOptions(args, description, true);
-			if (options.has("loadMode") && !"bulkLoad".equalsIgnoreCase((String) options.valueOf("loadMode"))) {
-				throw new UnsupportedOperationException("This loader supports bulkLoad load mode only, but "
-						+ options.valueOf("loadMode")
-						+ " has been supplied.");
-			}
-			String dataFile = (String) options.valueOf("data");
-		    File descriptorFile = new File((String) options.valueOf("meta"));
-			boolean overwriteExisting = options.has("overwrite-existing");
-            
-			Properties properties = new TrimmedProperties();
-			properties.load(new FileInputStream(descriptorFile));
-            
-			int cancerStudyInternalId = ValidationUtils.getInternalStudyId(properties.getProperty("cancer_study_identifier"));
-            
-			importData(dataFile, cancerStudyInternalId, overwriteExisting);
+            OptionSet options = ConsoleUtil.parseStandardDataAndMetaOptions(args, description, true);
+            if (options.has("loadMode") && !"bulkLoad".equalsIgnoreCase((String) options.valueOf("loadMode"))) {
+                throw new UnsupportedOperationException("This loader supports bulkLoad load mode only, but "
+                        + options.valueOf("loadMode")
+                        + " has been supplied.");
+            }
+            String dataFile = (String) options.valueOf("data");
+            File descriptorFile = new File((String) options.valueOf("meta"));
+            boolean overwriteExisting = options.has("overwrite-existing");
+            Properties properties = new TrimmedProperties();
+            properties.load(new FileInputStream(descriptorFile));
+            int cancerStudyInternalId = ValidationUtils.getInternalStudyId(properties.getProperty("cancer_study_identifier"));
+            importData(dataFile, cancerStudyInternalId, overwriteExisting);
         } catch (RuntimeException e) {
             throw e;
         } catch (IOException|DaoException e) {

--- a/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
+++ b/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2015 - 2018 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2015 - 2026 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
  * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
- * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * is on an "as is" basis, and Memorial Sloan Kettering Cancer Center has no
  * obligations to provide maintenance, support, updates, enhancements or
- * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * modifications. In no event shall Memorial Sloan Kettering Cancer Center be
  * liable to any party for direct, indirect, special, incidental or
  * consequential damages, including lost profits, arising out of the use of this
- * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * software and its documentation, even if Memorial Sloan Kettering Cancer
  * Center has been advised of the possibility of such damage.
  */
 
@@ -32,9 +32,13 @@
 
 package org.mskcc.cbio.portal.util;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
@@ -44,20 +48,16 @@ import org.slf4j.LoggerFactory;
  * Utility class for getting / setting global properties.
  */
 public class GlobalProperties {
-
     public static final String HOME_DIR = "PORTAL_HOME";
     private static final String PORTAL_PROPERTIES_FILE_NAME = "application.properties";
     private static final String POM_RESOURCE_PATH = "META-INF/maven/org.mskcc.cbio/core/pom.xml";
     private static final String DEFAULT_DB_VERSION = "0";
-    private static final Pattern DB_VERSION_PATTERN =
-        Pattern.compile("<db\\.version>\\s*([^<]+)\\s*</db\\.version>");
-
+    private static final Pattern DB_VERSION_PATTERN = Pattern.compile("<db\\.version>\\s*([^<]+)\\s*</db\\.version>");
     public static final String DB_VERSION = "db.version";
     public static final String SPECIES = "species";
     public static final String DEFAULT_SPECIES = "human";
     public static final String UCSC_BUILD = "ucsc.build";
     public static final String DEFAULT_UCSC_BUILD = "hg19";
-
     private static Logger LOG = LoggerFactory.getLogger(GlobalProperties.class);
     private static ConfigPropertyResolver portalProperties = new ConfigPropertyResolver();
     private static volatile String cachedDbVersion;
@@ -102,21 +102,17 @@ public class GlobalProperties {
         }
     }
 
-    private static Properties initializeProperties(String propertiesFileName)
-    {
+    private static Properties initializeProperties(String propertiesFileName) {
         return loadProperties(getResourceStream(propertiesFileName));
     }
 
-    private static InputStream getResourceStream(String propertiesFileName)
-    {
+    private static InputStream getResourceStream(String propertiesFileName) {
         String resourceFilename = null;
         InputStream resourceFIS = null;
-
         try {
             String home = System.getenv(HOME_DIR);
             if (home != null) {
-                 resourceFilename =
-                    home + File.separator + propertiesFileName;
+                 resourceFilename = home + File.separator + propertiesFileName;
                 if (LOG.isInfoEnabled()) {
                     LOG.info("Attempting to read properties file: " + resourceFilename);
                 }
@@ -125,101 +121,83 @@ public class GlobalProperties {
                     LOG.info("Successfully read properties file");
                 }
             }
-        }
-        catch (FileNotFoundException e) {
+        } catch (FileNotFoundException e) {
             if (LOG.isInfoEnabled()) {
                 LOG.info("Failed to read properties file: " + resourceFilename);
             }
         }
-
         if (resourceFIS == null) {
             if (LOG.isInfoEnabled()) {
                 LOG.info("Attempting to read properties file from classpath");
             }
-            resourceFIS = GlobalProperties.class.getClassLoader().
-                getResourceAsStream(propertiesFileName);
+            resourceFIS = GlobalProperties.class.getClassLoader().getResourceAsStream(propertiesFileName);
             if (LOG.isInfoEnabled()) {
                 LOG.info("Successfully read properties file");
             }
         }
-         
         return resourceFIS;
     }
 
-    private static Properties loadProperties(InputStream resourceInputStream)
-    {
+    private static Properties loadProperties(InputStream resourceInputStream) {
         Properties properties = new Properties();
-
         try {
             properties.load(resourceInputStream);
             resourceInputStream.close();
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
             if (LOG.isErrorEnabled()) {
                 LOG.error("Error loading properties file: " + e.getMessage());
             }
         }
-
         return properties;
     }
 
-    private static InputStream getPomResourceStream()
-    {
-        InputStream pomStream =
-            GlobalProperties.class.getClassLoader().getResourceAsStream(POM_RESOURCE_PATH);
+    private static InputStream getPomResourceStream() {
+        InputStream pomStream = GlobalProperties.class.getClassLoader().getResourceAsStream(POM_RESOURCE_PATH);
         if (pomStream != null) {
             return pomStream;
         }
-
         return null;
     }
 
-    private static String readDbVersionFromPom()
-    {
+    private static String readDbVersionFromPom() {
         try (InputStream pomStream = getPomResourceStream()) {
             if (pomStream == null) {
                 if (LOG.isWarnEnabled()) {
                     LOG.warn("Unable to locate pom.xml for db.version lookup. " +
-                        "Checked classpath resource " + POM_RESOURCE_PATH);
+                            "Checked classpath resource " + POM_RESOURCE_PATH);
                 }
                 return null;
             }
-
             String pomContents = new String(pomStream.readAllBytes(), StandardCharsets.UTF_8);
             Matcher matcher = DB_VERSION_PATTERN.matcher(pomContents);
             if (matcher.find()) {
                 return matcher.group(1).trim();
             }
-
             if (LOG.isWarnEnabled()) {
                 LOG.warn("db.version was not found in pom.xml.");
             }
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
             if (LOG.isErrorEnabled()) {
                 LOG.error("Error reading pom.xml for db.version: " + e.getMessage());
             }
         }
-
         return null;
     }
 
-	public static String getProperty(String property)
-	{
-		return (portalProperties.containsKey(property)) ? portalProperties.getProperty(property) : null;
-	}
+    public static String getProperty(String property) {
+        return (portalProperties.containsKey(property)) ? portalProperties.getProperty(property) : null;
+    }
 
-    public static String getSpecies(){
-    	String species = portalProperties.getProperty(SPECIES);
-    	return species == null ? DEFAULT_SPECIES : species;
-    	}
+    public static String getSpecies() {
+        String species = portalProperties.getProperty(SPECIES);
+        return species == null ? DEFAULT_SPECIES : species;
+    }
 
     public static String getDbVersion() {
         String override = System.getProperty(DB_VERSION);
         if (override != null) {
             return override;
         }
-
         if (cachedDbVersion == null) {
             synchronized (GlobalProperties.class) {
                 if (cachedDbVersion == null) {
@@ -228,12 +206,27 @@ public class GlobalProperties {
                 }
             }
         }
-
         return cachedDbVersion;
     }
 
     public static String getReferenceGenomeName() {
         return portalProperties.getProperty(UCSC_BUILD, DEFAULT_UCSC_BUILD);
+    }
+
+    public static Integer parseIntegerProperty(String key, Integer defaultValue) {
+        String valueString = getProperty(key);
+        if (valueString == null) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(valueString);
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+    public static Integer parseIntegerProperty(String key) {
+        return parseIntegerProperty(key, null);
     }
 
 }

--- a/src/test/java/org/mskcc/cbio/portal/integrationTest/dao/TestDaoMutation.java
+++ b/src/test/java/org/mskcc/cbio/portal/integrationTest/dao/TestDaoMutation.java
@@ -137,7 +137,8 @@ public class TestDaoMutation extends IntegrationTestBase {
         mutation.setCanonicalTranscript(true);
         mutation.setAnnotationJson(makeMockAnnotationJsonString());
 
-        DaoMutation.addMutation(mutation,true);
+        DaoMutation.addMutationEvent(mutation.getEvent());
+        DaoMutation.addMutation(mutation);
 
         // if bulkLoading, execute LOAD FILE
         if( ClickHouseBulkLoader.isBulkLoad()){

--- a/src/test/java/org/mskcc/cbio/portal/integrationTest/incremental/TestIncrementalCopyNumberSegmentDataImport.java
+++ b/src/test/java/org/mskcc/cbio/portal/integrationTest/incremental/TestIncrementalCopyNumberSegmentDataImport.java
@@ -54,7 +54,7 @@ public class TestIncrementalCopyNumberSegmentDataImport extends IntegrationTestB
     /**
      * Test incremental upload of CNA SEG data
      */
-	@Test
+    @Test
     public void testIncrementalUpload() throws DaoException {
         String segSampleId = "TCGA-A1-A0SE-01";
         Sample segDataSample = DaoSample.getSampleByCancerStudyAndSampleId(cancerStudy.getInternalId(), segSampleId);
@@ -76,7 +76,6 @@ public class TestIncrementalCopyNumberSegmentDataImport extends IntegrationTestB
                 95674710,
                 100,
                 0.01);
-        copyNumberSegment.setSegId(1L);
         DaoCopyNumberSegment.addCopyNumberSegment(copyNumberSegment);
         ClickHouseBulkLoader.flushAll();
 


### PR DESCRIPTION
Several import classes were using their own business logic to increment internal ids based on the highest available integer value in the current database table.

This PR converts that business logic over to using the ClickHouseAutoIncrement class, and will also relocate the assignment of internal identifiers into the dao layer rather than the scripts layer.