### PR TITLE
Notify cmo-pipelines when containerized is pushed

### DIFF
--- a/.github/workflows/notify-cmo-pipelines.yml
+++ b/.github/workflows/notify-cmo-pipelines.yml
@@ -1,5 +1,5 @@
-# When cbioportal-core's containerized branch is pushed, notify cmo-pipelines
-# so its workflows can rebuild the importer / core images.
+# When cbioportal-core's main branch is pushed, notify cmo-pipelines so its
+# workflows can rebuild the importer / core images.
 #
 # cmo-pipelines subscribes to repository_dispatch events of type
 # cbioportal-core-push in:
@@ -14,6 +14,7 @@ name: Notify cmo-pipelines
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   dispatch:

--- a/.github/workflows/notify-cmo-pipelines.yml
+++ b/.github/workflows/notify-cmo-pipelines.yml
@@ -1,0 +1,32 @@
+# When cbioportal-core's containerized branch is pushed, notify cmo-pipelines
+# so its workflows can rebuild the importer / core images.
+#
+# cmo-pipelines subscribes to repository_dispatch events of type
+# cbioportal-core-push in:
+#   - .github/workflows/build-importer-image.yml (builds docker/Dockerfile)
+#   - .github/workflows/build-core-image.yml      (rebuilds docker/core.Dockerfile)
+#
+# NOTE: GITHUB_TOKEN is scoped to THIS repo and cannot dispatch events to
+# another repository, so this uses a PAT stored as a repository secret
+# (CMO_PIPELINES_DISPATCH_TOKEN) with access to the cmo-pipelines repo.
+name: Notify cmo-pipelines
+
+on:
+  push:
+    branches: [containerized]
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch cbioportal-core-push to cmo-pipelines
+        env:
+          GH_TOKEN: ${{ secrets.CMO_PIPELINES_DISPATCH_TOKEN }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            /repos/knowledgesystems/cmo-pipelines/dispatches \
+            -f event_type=cbioportal-core-push \
+            -f "client_payload[ref]=${GITHUB_SHA}" \
+            -f "client_payload[branch]=${GITHUB_REF_NAME}"

--- a/.github/workflows/notify-cmo-pipelines.yml
+++ b/.github/workflows/notify-cmo-pipelines.yml
@@ -13,7 +13,7 @@ name: Notify cmo-pipelines
 
 on:
   push:
-    branches: [containerized]
+    branches: [main]
 
 jobs:
   dispatch:

--- a/.github/workflows/notify-cmo-pipelines.yml
+++ b/.github/workflows/notify-cmo-pipelines.yml
@@ -15,6 +15,11 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      core_branch:
+        description: 'cbioportal-core branch to build (default: current branch)'
+        required: false
+        type: string
 
 jobs:
   dispatch:
@@ -24,10 +29,19 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.CMO_PIPELINES_DISPATCH_TOKEN }}
         run: |
+          branch="${{ inputs.core_branch || github.ref_name }}"
+          # For push events, use the exact SHA; for workflow_dispatch on a
+          # named branch, resolve its HEAD so cmo-pipelines gets a pinned ref.
+          if [ -n "${{ inputs.core_branch }}" ]; then
+            ref=$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.git" "${branch}" | cut -f1)
+          else
+            ref="${GITHUB_SHA}"
+          fi
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \
             /repos/knowledgesystems/cmo-pipelines/dispatches \
             -f event_type=cbioportal-core-push \
-            -f "client_payload[ref]=${GITHUB_SHA}" \
-            -f "client_payload[branch]=${GITHUB_REF_NAME}"
+            -f "client_payload[ref]=${ref}" \
+            -f "client_payload[branch]=${branch}" \
+            -f "client_payload[core_branch]=${branch}"


### PR DESCRIPTION
Adds a GitHub Actions workflow that sends a `cbioportal-core-push` repository_dispatch event to `knowledgesystems/cmo-pipelines` whenever the `containerized` branch is pushed. This is the missing trigger for the cmo-pipelines image-build workflows (build-importer-image.yml / build-core-image.yml), which subscribe to that event type.

**Requires setup:** the workflow uses a PAT stored as the repository secret `CMO_PIPELINES_DISPATCH_TOKEN` (the default GITHUB_TOKEN cannot dispatch to another repo). Add it to this repo's secrets with access to cmo-pipelines before merging.