### PR TITLE
Prevent stale ClickHouse JDBC connections from being reused by DBCP2

### DIFF
--- a/src/main/java/org/mskcc/cbio/portal/dao/JdbcDataSource.java
+++ b/src/main/java/org/mskcc/cbio/portal/dao/JdbcDataSource.java
@@ -68,8 +68,14 @@ public class JdbcDataSource extends BasicDataSource {
         this.setMaxTotal(500);
         this.setMaxIdle(30);
         this.setMaxWaitMillis(10000);
+        // Evict idle connections after 30s of idleness, checking every 10s
         this.setMinEvictableIdleTimeMillis(30000);
+        this.setTimeBetweenEvictionRunsMillis(10000);
+        // Test connections before borrow and while idle to catch stale connections
         this.setTestOnBorrow(true);
+        this.setTestWhileIdle(true);
+        // Avoid connections living so long they go stale on the server side
+        this.setMaxConnLifetimeMillis(1800000); // 30 minutes
         this.setValidationQuery("SELECT 1");
     }
 


### PR DESCRIPTION
## Problem

The DBCP2 connection pool (`JdbcDataSource`) has been serving stale ClickHouse HTTP connections that the ClickHouse Cloud load balancer had already closed on its side. The typical failure trace:

```
BatchUpdateException: The target server failed to respond
  → com.clickhouse.jdbc.SqlExceptionUtils.batchUpdateError
  → com.clickhouse.jdbc.internal.SqlBasedPreparedStatement.executeAny
```

The root cause: the query never reached ClickHouse because it was sent into a dead HTTP keep-alive connection. This has been observed in production repeatedly (May 21, Jul 9, Jul 16, Jul 25, Aug 5 2026).

## Root cause

`setTimeBetweenEvictionRunsMillis` defaults to **-1** in DBCP2, meaning the idle-object evictor **never runs**. Without the evictor:

- `setMinEvictableIdleTimeMillis(30000)` (already set) is a **no-op** — it only takes effect when the evictor is active
- `setTestWhileIdle` (not set) can never activate
- Connections can sit idle in the pool indefinitely

ClickHouse Cloud sends `Keep-Alive: timeout=10` in HTTP responses, and its load balancer has a ~60-second idle timeout. After a query gap of that length (e.g., during local data processing), the LB closes the connection. When the pool reuses it without proactive validation, the query fails.

## Fix

1. **`setTimeBetweenEvictionRunsMillis(10000)`** — enable the idle-object evictor to run every 10 seconds, so idle connections are actually evicted
2. **`setTestWhileIdle(true)`** — proactively test connections while they sit idle, removing dead ones before a borrow attempt
3. **`setMaxConnLifetimeMillis(1800000)`** (30 minutes) — prevent connections from living so long that they inevitably go stale on the server side

`testOnBorrow(true)` + `validationQuery("SELECT 1")` were already configured and are retained as an additional safety net for any connections that do slip through.
