### PR TITLE
Fix temp-file race between concurrent clickhouse_import_support scripts

### DIFF
--- a/scripts/clickhouse_import_support/clickhouse_client_command_line_functions.sh
+++ b/scripts/clickhouse_import_support/clickhouse_client_command_line_functions.sh
@@ -6,12 +6,14 @@ unset sql_data_array
 configured_clickhouse_config_file_path=""
 sql_data_field_value=""
 declare -a sql_data_array
-clickhouse_client_database_exists_filepath="$(pwd)/ccclf_database_exists.txt"
-clickhouse_client_database_table_list_filepath="$(pwd)/ccclf_database_table_list.txt"
+# temp filepaths include the process id : concurrent processes sourcing this file from the
+# same working directory must not collide on (or clean up) each other's temp files
+clickhouse_client_database_exists_filepath="$(pwd)/ccclf_database_exists_$$.txt"
+clickhouse_client_database_table_list_filepath="$(pwd)/ccclf_database_table_list_$$.txt"
 
 function write_clickhouse_config_file() {
     local selected_database=$1
-    configured_clickhouse_config_file_path="$(pwd)/clickhouse_client_config_$(date "+%Y-%m-%d-%H-%M-%S").yaml"
+    configured_clickhouse_config_file_path="$(pwd)/clickhouse_client_config_$$.yaml"
     if ! rm -f "$configured_clickhouse_config_file_path" || ! touch "$configured_clickhouse_config_file_path" ; then
         echo "Error : unable to create clickhouse_client_config file $configured_clickhouse_config_file_path" >&2
         return 1


### PR DESCRIPTION
## Problem

`write_clickhouse_config_file` names its temp config file with a second-resolution timestamp in `$(pwd)`:

```
clickhouse_client_config_$(date "+%Y-%m-%d-%H-%M-%S").yaml
```

Every script that sources `clickhouse_client_command_line_functions.sh` from the same working directory (e.g. `verify-management-state.sh` and the `get_database_currently_in_production.sh` child it spawns, both running with cwd = the SSH user's home dir) generates the same filename when they land in the same second. One process's creation (`rm -f` + `touch`) or shutdown cleanup then deletes the file out from under the other, and clickhouse-client fails with:

```
Code: 107. DB::Exception: Configuration file /home/cbioportal_importer/clickhouse_client_config_2026-08-26-09-15-02.yaml doesn't exist and there is no embedded config. (FILE_DOESNT_EXIST)
```

The caller then misreads this as "database does not exist" and aborts. Observed failing `import_triage_dag` / `verify_management_state` on 2026-08-26 (the error timestamp matches the colliding filename's second exactly). A stray zero-byte `clickhouse_client_config_2026-07-22-*.yaml` in the same home dir is debris from an earlier instance of the same collision.

`ccclf_database_exists.txt` / `ccclf_database_table_list.txt` are fixed filenames in `$(pwd)` with the same cross-process collision, without even needing same-second timing.

## Fix

Name all three temp files by process id instead — concurrent processes cannot share a PID, so no process can collide with (or clean up) another's files. Creation, permissions (600), content checks, and shutdown cleanup are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)